### PR TITLE
Add command encode error

### DIFF
--- a/lib/grizzly/command/encode_error.ex
+++ b/lib/grizzly/command/encode_error.ex
@@ -1,0 +1,26 @@
+defmodule Grizzly.Command.EncodeError do
+  @moduledoc """
+  Exception for when encoding a Command goes wrong
+  """
+  defexception [:message]
+
+  @type error_type ::
+          {:invalid_argument_value, arg_name :: any(), arg_value :: any(), module()}
+
+  @type t :: %__MODULE__{message: String.t()}
+
+  @doc """
+  Make a new `%EncodeError{}` from the error type
+  """
+  @spec new(error_type()) :: t()
+  def new({:invalid_argument_value, argument_name, argument_value, command_module}) do
+    %__MODULE__{
+      message: """
+        Invalid argument value #{inspect(argument_value)} for #{inspect(argument_name)}
+
+        See https://hexdocs.pm/grizzly/#{inspect(command_module)}.html for more
+        documentation
+      """
+    }
+  end
+end

--- a/lib/grizzly/command_class/switch_binary.ex
+++ b/lib/grizzly/command_class/switch_binary.ex
@@ -2,7 +2,9 @@ defmodule Grizzly.CommandClass.SwitchBinary do
   @type switch_state :: :on | :off
   @type switch_state_byte :: 0x00 | 0xFF
 
-  @spec encode_switch_state(switch_state) :: switch_state_byte
-  def encode_switch_state(:on), do: 0xFF
-  def encode_switch_state(:off), do: 0x00
+  @spec encode_switch_state(switch_state) ::
+          {:ok, switch_state_byte} | {:error, :invalid_arg, any()}
+  def encode_switch_state(:on), do: {:ok, 0xFF}
+  def encode_switch_state(:off), do: {:ok, 0x00}
+  def encode_switch_state(arg), do: {:error, :invalid_arg, arg}
 end

--- a/test/grizzly/command_class/switch_binary_test.exs
+++ b/test/grizzly/command_class/switch_binary_test.exs
@@ -5,11 +5,27 @@ defmodule Grizzly.CommandClass.SwitchBinary.Test do
 
   describe "encoding switch state" do
     test "on" do
-      assert 0xFF == SwitchBinary.encode_switch_state(:on)
+      assert {:ok, 0xFF} == SwitchBinary.encode_switch_state(:on)
     end
 
     test "off" do
-      assert 0x00 == SwitchBinary.encode_switch_state(:off)
+      assert {:ok, 0x00} == SwitchBinary.encode_switch_state(:off)
+    end
+
+    test "nil" do
+      assert {:error, :invalid_arg, nil} == SwitchBinary.encode_switch_state(nil)
+    end
+
+    test "number 1" do
+      assert {:error, :invalid_arg, 1} == SwitchBinary.encode_switch_state(1)
+    end
+
+    test "string grizzly" do
+      assert {:error, :invalid_arg, "grizzly"} == SwitchBinary.encode_switch_state("grizzly")
+    end
+
+    test "atom grizzly" do
+      assert {:error, :invalid_arg, :grizzly} == SwitchBinary.encode_switch_state(:grizzly)
     end
   end
 end

--- a/test/grizzly_test.exs
+++ b/test/grizzly_test.exs
@@ -9,6 +9,7 @@ defmodule Grizzly.Test do
   alias Grizzly.CommandClass.ZipNd.InvNodeSolicitation
   alias Grizzly.CommandClass.ManufacturerSpecific.Get, as: ManufacturerSpecificGet
   alias Grizzly.Network.State, as: NetworkState
+  alias Grizzly.Command.EncodeError
 
   setup do
     config = Grizzly.config()
@@ -42,6 +43,13 @@ defmodule Grizzly.Test do
     test "send the manufacturer specific command", %{conn: conn} do
       {:ok, %{manufacturer_id: 335, product_id: 21558, product_type_id: 21570}} =
         Grizzly.send_command(conn, ManufacturerSpecificGet, seq_number: 0x01)
+    end
+  end
+
+  describe "sending bad stuff to grizzly" do
+    test "send values to switch binary set", %{conn: conn} do
+      {:error, %EncodeError{}} =
+        Grizzly.send_command(conn, SwitchBinarySet, seq_number: 0x08, value: :grizzly)
     end
   end
 end


### PR DESCRIPTION
Provides the `Grizzly.Command.EncodeError` and an example of using it with the `SwitchBinary.Set` command.

Right now if there are bad values passed to a command for encoding then `send_command` crashes and Grizzly can get in an odd state, so the motivateion behind this is to help provide relaibilty and allow the user to decide if they should crash or handle this type of error in a particular way. 

Moving forward I would like to update all existing commands to use this, but can probably do that in PRs grouped by command class to make reviewing and testing maintainable.

This will be a breaking change once released so it would be nice to roll all the updates in one release to avoid too many breaking releases. 

refs: #31 