### PR TITLE
Adjust zipgateway.tun script to avoid pidof

### DIFF
--- a/priv/zipgateway.tun
+++ b/priv/zipgateway.tun
@@ -15,12 +15,19 @@ case "$1" in
       rm -f $ROUTING_PID
     fi
 
-    sh -c "while true; do
-               $PIDOF zipgateway || break;
+    sh -c "for i in 1 2 3 4 5 6; do
+               if [ \$i -gt 5 ]; then
+                 echo \"Failed to start tunnel script\"
+                 kill -9 \$PPID
+                 exit -1
+               fi;
+
                ip -6 route del $HANPREFIX > /dev/null 2>&1
                ip -6 route add $HANPREFIX via $LANIP dev $TUNDEV > /dev/null 2>&1
+
                if [ \$? -eq 2 ]; then
-                   sleep 5;
+                   echo \"Failed adding tunnel routes. Attempt \$i\"
+                   sleep 2;
                    continue;
                else
                    break;


### PR DESCRIPTION
Things have changed slightly with new `zipgateway` 7.11 and what environment varia
bles are available when this script is called. So this adjusts the script slightly
 to avoid using `pidof` and allows only 5 attempts before restarting the parent pr
ocess.