### PR TITLE
Remove pidof docs and functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,20 +126,6 @@ config :grizzly,
 If you are using a base nerves system please see the documentation for your particular
 system at the [Nerves Project](https://github.com/nerves-project) github page.
 
-To run some scripts that `zipgateway` uses we need the `pidof` command line utility. 
-Not all Nerves base systems provide this utility so you can use the [busybox](https://hex.pm/packages/busybox)
-package to avoid having to build a custom nerves system. After adding the `busybox` package
-to your `mix.exs` file, you can configure `Grizzly` to use the busybox path for the `pidof`
-utility:
-
-```elixir
-config :grizzly,
-  pidof_bin: "/srv/erlang/lib/busybox-0.1.2/priv/bin/pidof"
-```
-
-Be sure to check the version of the `busybox` package you are using matches
-the version in the path.
-
 If you want to run tests without running the `zipgateway` binary provided by Silicon Labs you
 can configure `run_zipgateway_bin` to be `false`:
 

--- a/lib/grizzly/application.ex
+++ b/lib/grizzly/application.ex
@@ -39,7 +39,7 @@ defmodule Grizzly.Application do
          [
            "/usr/sbin/zipgateway",
            ["-c", Path.join(priv_dir, "zipgateway.cfg"), "-s", serial_port],
-           [cd: priv_dir, log_output: :debug, env: [{"PIDOF", get_pidof_command()}]]
+           [cd: priv_dir, log_output: :debug]
          ]}
       ] ++ children_list
     else
@@ -77,10 +77,6 @@ defmodule Grizzly.Application do
       true -> :ok
       false -> :no_run_zipgateway_bin
     end
-  end
-
-  defp get_pidof_command() do
-    Application.get_env(:grizzly, :pidof_bin, "pidof")
   end
 
   defp get_grizzly_config() do


### PR DESCRIPTION
Remove the need to configure `pidof` via `busybox` and remove the
support in `Grizzly` to use the configured `pidof` since we don't
rely on `pidof` anymore.