### PR TITLE
Support DSKGet command

### DIFF
--- a/lib/grizzly/command_class/network_management_basic.ex
+++ b/lib/grizzly/command_class/network_management_basic.ex
@@ -3,6 +3,13 @@ defmodule Grizzly.CommandClass.NetworkManagementBasic do
   @type learn_mode_status :: :done | :failed | :failed_security
   @type learn_mode :: :enable | :disable | :enable_routed
   @type learn_mode_byte :: 0x00 | 0x01 | 0x02
+  @type add_mode :: :learn | :add
+  @type add_mode_byte :: 0x00 | 0x01
+
+  @type dsk_get_report :: %{
+          add_mode: add_mode(),
+          dsk: binary()
+        }
 
   @spec encode_learn_mode(learn_mode) :: {:ok, learn_mode_byte} | {:error, :invalid_arg, any()}
   def encode_learn_mode(mode) do
@@ -14,6 +21,30 @@ defmodule Grizzly.CommandClass.NetworkManagementBasic do
       # ZW_SET_LEARN_MODE_NWI - accept routed inclusion
       :enable_routed -> {:ok, 0x02}
       other -> {:error, :invalid_arg, other}
+    end
+  end
+
+  @doc """
+  Encode the add mode `:learn` or `:add` into a byte
+  """
+  @spec encode_add_mode(add_mode()) :: {:ok, add_mode_byte()} | {:error, :invalid_arg, any()}
+  def encode_add_mode(:learn), do: {:ok, 0x00}
+  def encode_add_mode(:add), do: {:ok, 0x01}
+  def encode_add_mode(other), do: {:error, :invalid_arg, other}
+
+  @doc """
+  Take the byte of the add mode and decode it into `:learn` or `:add`.
+  """
+  @spec add_mode_from_byte(byte()) :: add_mode()
+  def add_mode_from_byte(byte) do
+    <<_::size(7), add_mode_bit::size(1)>> = <<byte>>
+
+    case add_mode_bit do
+      0 ->
+        :learn
+
+      1 ->
+        :add
     end
   end
 
@@ -35,5 +66,23 @@ defmodule Grizzly.CommandClass.NetworkManagementBasic do
 
   def decode_learn_mode_set_status(0x09, _new_node_id) do
     %{status: :security_failed, new_node_id: 0}
+  end
+
+  @doc """
+  Decode the bytestring that is returned from Z-Wave that has the DSK
+  report
+  """
+  @spec decode_dsk_report(binary()) :: dsk_get_report()
+  def decode_dsk_report(<<add_mode, dsk::binary-size(16)>>) do
+    %{
+      add_mode: add_mode_from_byte(add_mode),
+      dsk: dsk_to_string(dsk)
+    }
+  end
+
+  defp dsk_to_string(binary) do
+    for(<<b::16 <- binary>>, do: b)
+    |> Enum.map(fn b -> String.slice("00000" <> "#{b}", -5, 5) end)
+    |> Enum.join("-")
   end
 end

--- a/lib/grizzly/command_class/network_management_basic/dsk_get.ex
+++ b/lib/grizzly/command_class/network_management_basic/dsk_get.ex
@@ -1,0 +1,108 @@
+defmodule Grizzly.CommandClass.NetworkManagementBasic.DSKGet do
+  @moduledoc """
+  Command module for working with the NetworkManagementBasic command class DSK_GET command
+
+  Command Options:
+
+    * `:add_mode` - the controller has two different DSKs for S2, one for
+       learn (`:learn`) mode and one for normal inclusion (this is called `:add`)
+    * `:seq_number` - the sequence number used for the Z/IP packet
+    * `:retries` - the number of attempts to send the command (default 2)
+  """
+  @behaviour Grizzly.Command
+
+  alias Grizzly.Packet
+  alias Grizzly.CommandClass.NetworkManagementBasic
+  alias Grizzly.Command.{EncodeError, Encoding}
+
+  @type t :: %__MODULE__{
+          seq_number: Grizzly.seq_number(),
+          retries: non_neg_integer(),
+          add_mode: NetworkManagementBasic.add_mode()
+        }
+
+  @type opt :: {:seq_number, Grizzly.seq_number()} | {:retries, non_neg_integer()}
+
+  defstruct seq_number: nil,
+            retries: 2,
+            add_mode: :add
+
+  @spec init([opt]) :: {:ok, t}
+  def init(opts) do
+    {:ok, struct(__MODULE__, opts)}
+  end
+
+  @spec encode(t()) :: {:ok, binary()} | {:error, EncodeError.t()}
+  def encode(%__MODULE__{seq_number: seq_number} = command) do
+    with {:ok, encoded} <-
+           Encoding.encode_and_validate_args(command, %{
+             add_mode: {:encode_with, NetworkManagementBasic, :encode_add_mode}
+           }) do
+      binary = Packet.header(seq_number) <> <<0x4D, 0x08, seq_number, encoded.add_mode()>>
+      {:ok, binary}
+    end
+  end
+
+  @spec handle_response(t, Packet.t()) ::
+          {:continue, t}
+          | {:done, {:error, :nack_response}}
+          | {:done, NetworkManagementBasic.dsk_get_report()}
+          | {:retry, t}
+  def handle_response(
+        %__MODULE__{seq_number: seq_number} = command,
+        %Packet{
+          seq_number: seq_number,
+          types: [:ack_response]
+        }
+      ) do
+    {:continue, command}
+  end
+
+  def handle_response(
+        %__MODULE__{seq_number: seq_number, retries: 0},
+        %Packet{
+          seq_number: seq_number,
+          types: [:nack_response]
+        }
+      ) do
+    {:done, {:error, :nack_response}}
+  end
+
+  def handle_response(
+        %__MODULE__{seq_number: seq_number, retries: n} = command,
+        %Packet{
+          seq_number: seq_number,
+          types: [:nack_response]
+        }
+      ) do
+    {:retry, %{command | retries: n - 1}}
+  end
+
+  def handle_response(
+        %__MODULE__{seq_number: seq_number} = command,
+        %Packet{
+          seq_number: seq_number,
+          types: [:nack_response, :nack_waiting]
+        } = packet
+      ) do
+    if Packet.sleeping_delay?(packet) do
+      {:queued, command}
+    else
+      {:continue, command}
+    end
+  end
+
+  def handle_response(
+        _command,
+        %Packet{
+          body: %{
+            command: :dsk_report,
+            report: report
+          }
+        }
+      ) do
+    {:done, {:ok, report}}
+  end
+
+  def handle_response(command, _), do: {:continue, command}
+end

--- a/lib/grizzly/packet/body_parser.ex
+++ b/lib/grizzly/packet/body_parser.ex
@@ -173,6 +173,15 @@ defmodule Grizzly.Packet.BodyParser do
     }
   end
 
+  def parse(<<0x4D, 0x09, seq_no, report::binary>>) do
+    %{
+      command_class: NetworkManagementBasic,
+      command: :dsk_report,
+      seq_no: seq_no,
+      report: NetworkManagementBasic.decode_dsk_report(report)
+    }
+  end
+
   def parse(<<0x52, 0x02, seq_no, status, _controller_id, node_list::binary>>) do
     %{
       command_class: :network_management_proxy,

--- a/mix.exs
+++ b/mix.exs
@@ -124,6 +124,7 @@ defmodule Grizzly.MixProject do
           Grizzly.CommandClass.MultiChannelAssociation.Set,
           Grizzly.CommandClass.MultiChannelAssociation.SupportedGroupingsGet,
           Grizzly.CommandClass.NetworkManagementBasic.DefaultSet,
+          Grizzly.CommandClass.NetworkManagementBasic.DSKGet,
           Grizzly.CommandClass.NetworkManagementBasic.LearnModeSet,
           Grizzly.CommandClass.NetworkManagementInclusion.NodeAdd,
           Grizzly.CommandClass.NetworkManagementInclusion.NodeAddDSKSet,

--- a/test/grizzly/command_class/network_management_basic/dsk_get_test.exs
+++ b/test/grizzly/command_class/network_management_basic/dsk_get_test.exs
@@ -1,0 +1,86 @@
+defmodule Grizzly.CommandClass.NetworkManagementBasic.DSKGetTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.Packet
+  alias Grizzly.CommandClass.NetworkManagementBasic
+  alias Grizzly.CommandClass.NetworkManagementBasic.DSKGet
+
+  describe "implements Grizzly.Command correctly" do
+    test "initializes to command" do
+      assert {:ok, %DSKGet{}} == DSKGet.init([])
+    end
+
+    test "encodes correctly" do
+      {:ok, command} = DSKGet.init(seq_number: 10, add_mode: :learn)
+
+      binary = <<35, 2, 128, 208, 10, 0, 0, 3, 2, 0, 0x4D, 0x08, 10, 0x00>>
+
+      assert {:ok, binary} == DSKGet.encode(command)
+    end
+
+    test "handles ack responses" do
+      {:ok, command} = DSKGet.init(seq_number: 0x05)
+      packet = Packet.new(seq_number: 0x05, types: [:ack_response])
+
+      assert {:continue, ^command} = DSKGet.handle_response(command, packet)
+    end
+
+    test "handles nack response" do
+      {:ok, command} = DSKGet.init(seq_number: 0x07, retries: 0)
+      packet = Packet.new(seq_number: 0x07, types: [:nack_response])
+
+      assert {:done, {:error, :nack_response}} == DSKGet.handle_response(command, packet)
+    end
+
+    test "handles retries" do
+      {:ok, command} = DSKGet.init(seq_number: 0x07)
+      packet = Packet.new(seq_number: 0x07, types: [:nack_response])
+
+      assert {:retry, %DSKGet{}} = DSKGet.handle_response(command, packet)
+    end
+
+    test "handles queued for wake up nodes" do
+      {:ok, command} = DSKGet.init(seq_number: 0x01, add_mode: :add)
+
+      packet =
+        Packet.new(seq_number: 0x01, types: [:nack_response, :nack_waiting])
+        |> Packet.put_expected_delay(5000)
+
+      assert {:queued, ^command} = DSKGet.handle_response(command, packet)
+    end
+
+    test "handles nack waiting when delay is 1 or less" do
+      {:ok, command} = DSKGet.init(seq_number: 0x01)
+
+      packet =
+        Packet.new(seq_number: 0x01, types: [:nack_response, :nack_waiting])
+        |> Packet.put_expected_delay(1)
+
+      assert {:continue, ^command} = DSKGet.handle_response(command, packet)
+    end
+
+    test "handles dsk report responses" do
+      dsk = "38212-43450-54414-56613-50407-01928-44861-21469"
+
+      report = %{
+        command_class: NetworkManagementBasic,
+        command: :dsk_report,
+        report: %{
+          dsk: dsk,
+          add_mode: :add
+        }
+      }
+
+      packet = Packet.new(body: report)
+      {:ok, command} = DSKGet.init(add_mode: :add)
+
+      assert {:done, {:ok, %{dsk: dsk, add_mode: :add}}} ==
+               DSKGet.handle_response(command, packet)
+    end
+
+    test "handles responses" do
+      {:ok, command} = DSKGet.init([])
+      assert {:continue, %DSKGet{}} = DSKGet.handle_response(command, %{command_class: :foo})
+    end
+  end
+end

--- a/test/grizzly/command_class/network_management_basic_test.exs
+++ b/test/grizzly/command_class/network_management_basic_test.exs
@@ -23,4 +23,42 @@ defmodule Grizzly.CommandClass.NetworkManagementBasic.Test do
       assert :busy == NetworkManagementBasic.decode_default_set_status(0x07)
     end
   end
+
+  describe "decoding DSK report" do
+    test "decode full report when add mode is learn" do
+      dsk = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16>>
+      report_binary = <<0x00>> <> dsk
+
+      expected_report = %{
+        add_mode: :learn,
+        dsk: "00258-00772-01286-01800-02314-02828-03342-03856"
+      }
+
+      assert expected_report == NetworkManagementBasic.decode_dsk_report(report_binary)
+    end
+
+    test "decode full report when add mode is add" do
+      dsk = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16>>
+      report_binary = <<0x01>> <> dsk
+
+      expected_report = %{
+        add_mode: :add,
+        dsk: "00258-00772-01286-01800-02314-02828-03342-03856"
+      }
+
+      assert expected_report == NetworkManagementBasic.decode_dsk_report(report_binary)
+    end
+
+    test "decode add mode learn from byte" do
+      byte = 0b1101_1100
+
+      assert :learn == NetworkManagementBasic.add_mode_from_byte(byte)
+    end
+
+    test "decode add mode add from byte" do
+      byte = 0b1101_1101
+
+      assert :add == NetworkManagementBasic.add_mode_from_byte(byte)
+    end
+  end
 end

--- a/test/grizzly/packet/body_parser_test.exs
+++ b/test/grizzly/packet/body_parser_test.exs
@@ -316,6 +316,38 @@ defmodule Grizzly.Packet.BodyParser.Test do
              }
     end
 
+    test "parses the dsk report for add mode" do
+      dsk = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16>>
+      binary = <<0x4D, 0x09, 0x00, 0x01>> <> dsk
+      parsed = BodyParser.parse(binary)
+
+      assert parsed == %{
+               command_class: NetworkManagementBasic,
+               command: :dsk_report,
+               seq_no: 0x00,
+               report: %{
+                 dsk: "00258-00772-01286-01800-02314-02828-03342-03856",
+                 add_mode: :add
+               }
+             }
+    end
+
+    test "parses the dsk report for learn mode" do
+      dsk = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16>>
+      binary = <<0x4D, 0x09, 0x00, 0x00>> <> dsk
+      parsed = BodyParser.parse(binary)
+
+      assert parsed == %{
+               command_class: NetworkManagementBasic,
+               command: :dsk_report,
+               seq_no: 0x00,
+               report: %{
+                 dsk: "00258-00772-01286-01800-02314-02828-03342-03856",
+                 add_mode: :learn
+               }
+             }
+    end
+
     test "parses controller learn mode set with status done and new node id 10" do
       binary = <<0x4D, 0x02, 0x01, 0x06, 0x00, 0x0A, 0, 0, 0, 0, 0, 0, 0, 0>>
       parsed = BodyParser.parse(binary)


### PR DESCRIPTION
`DSKGet` get takes a `add_mode` argument because the controller can
return two different types of DSKs, one for when the device is in learn
mode and another for when the device is doing regular inclusion.