### PR TITLE
Support NodeProvisioning SET and GET commands

### DIFF
--- a/lib/grizzly/command_class/network_management_basic.ex
+++ b/lib/grizzly/command_class/network_management_basic.ex
@@ -1,4 +1,6 @@
 defmodule Grizzly.CommandClass.NetworkManagementBasic do
+  alias Grizzly.DSK
+
   @type default_set_status :: :done | :busy
   @type learn_mode_status :: :done | :failed | :failed_security
   @type learn_mode :: :enable | :disable | :enable_routed
@@ -74,15 +76,11 @@ defmodule Grizzly.CommandClass.NetworkManagementBasic do
   """
   @spec decode_dsk_report(binary()) :: dsk_get_report()
   def decode_dsk_report(<<add_mode, dsk::binary-size(16)>>) do
+    {:ok, dsk} = DSK.binary_to_string(dsk)
+
     %{
       add_mode: add_mode_from_byte(add_mode),
-      dsk: dsk_to_string(dsk)
+      dsk: dsk
     }
-  end
-
-  defp dsk_to_string(binary) do
-    for(<<b::16 <- binary>>, do: b)
-    |> Enum.map(fn b -> String.slice("00000" <> "#{b}", -5, 5) end)
-    |> Enum.join("-")
   end
 end

--- a/lib/grizzly/command_class/node_provisioning/get.ex
+++ b/lib/grizzly/command_class/node_provisioning/get.ex
@@ -1,0 +1,90 @@
+defmodule Grizzly.CommandClass.NodeProvisioning.Get do
+  @moduledoc """
+  Command Options:
+
+    * `:dsk` - A DSK string to look up the device in the provisioning
+      list. See `Grizzly.DSK` for more information
+    * `:seq_number` - The sequence number of the Z/IP Packet
+    * `:retries` - The number of times to try to send the command (default 2) 
+  """
+  @behaviour Grizzly.Command
+
+  alias Grizzly.{Packet, DSK}
+  alias Grizzly.Command.{EncodeError, Encoding}
+
+  @type t :: %__MODULE__{
+          dsk: DSK.dsk_string(),
+          seq_number: Grizzly.seq_number(),
+          retries: non_neg_integer()
+        }
+
+  @type opt ::
+          {:dsk, DSK.dsk_string()}
+          | {:seq_number, Grizzly.seq_number()}
+          | {:retries, non_neg_integer()}
+
+  defstruct dsk: nil, seq_number: nil, retries: 2
+
+  @spec init([opt]) :: {:ok, t}
+  def init(opts) do
+    {:ok, struct(__MODULE__, opts)}
+  end
+
+  @spec encode(t) :: {:ok, binary} | {:error, EncodeError.t()}
+  def encode(%__MODULE__{dsk: _dsk, seq_number: seq_number} = command) do
+    with {:ok, encoded} <-
+           Encoding.encode_and_validate_args(command, %{
+             dsk: {:encode_with, DSK, :string_to_binary}
+           }) do
+      binary = Packet.header(seq_number) <> <<0x78, 0x05, seq_number, 0x10>> <> encoded.dsk
+
+      {:ok, binary}
+    end
+  end
+
+  @spec handle_response(t, Packet.t()) ::
+          {:continue, t}
+          | {:done, {:error, :nack_response | :not_found}}
+          | {:done, {:ok, String.t()}}
+  def handle_response(%__MODULE__{seq_number: seq_number} = command, %Packet{
+        seq_number: seq_number,
+        types: [:ack_response]
+      }) do
+    {:continue, command}
+  end
+
+  def handle_response(%__MODULE__{seq_number: seq_number, retries: 0}, %Packet{
+        seq_number: seq_number,
+        types: [:nack_response]
+      }) do
+    {:done, {:error, :nack_response}}
+  end
+
+  def handle_response(%__MODULE__{seq_number: seq_number, retries: n} = command, %Packet{
+        seq_number: seq_number,
+        types: [:nack_response]
+      }) do
+    {:retry, %{command | retries: n - 1}}
+  end
+
+  def handle_response(
+        _command,
+        %Packet{
+          body: %{
+            command_class: :node_provisioning,
+            command: :report,
+            dsk: dsk
+          }
+        }
+      ) do
+    case dsk do
+      :not_found ->
+        {:done, {:error, :not_found}}
+
+      _dsk ->
+        {:done, {:ok, dsk}}
+    end
+  end
+
+  def handle_response(command, _), do: {:continue, command}
+end

--- a/lib/grizzly/command_class/node_provisioning/set.ex
+++ b/lib/grizzly/command_class/node_provisioning/set.ex
@@ -1,0 +1,69 @@
+defmodule Grizzly.CommandClass.NodeProvisioning.Set do
+  @moduledoc """
+  Command Options:
+
+    * `:dsk` - A DSK string for the device see `Grizzly.DSK`
+      for more details
+    * `:seq_number` - The sequence number of the Z/IP Packet
+    * `:retries` - The number of times to try to send the command (default 2) 
+  """
+  @behaviour Grizzly.Command
+
+  alias Grizzly.{Packet, DSK}
+  alias Grizzly.Command.{EncodeError, Encoding}
+
+  @type t :: %__MODULE__{
+          dsk: DSK.dsk_string(),
+          seq_number: Grizzly.seq_number(),
+          retries: non_neg_integer()
+        }
+
+  @type opt ::
+          {:dsk, DSK.dsk_string()}
+          | {:seq_number, Grizzly.seq_number()}
+          | {:retries, non_neg_integer()}
+
+  defstruct dsk: nil, seq_number: nil, retries: 2
+
+  @spec init([opt]) :: {:ok, t}
+  def init(opts) do
+    {:ok, struct(__MODULE__, opts)}
+  end
+
+  @spec encode(t) :: {:ok, binary} | {:error, EncodeError.t()}
+  def encode(%__MODULE__{dsk: _dsk, seq_number: seq_number} = command) do
+    with {:ok, encoded} <-
+           Encoding.encode_and_validate_args(command, %{
+             dsk: {:encode_with, DSK, :string_to_binary}
+           }) do
+      binary = Packet.header(seq_number) <> <<0x78, 0x01, seq_number, 0x10>> <> encoded.dsk
+
+      {:ok, binary}
+    end
+  end
+
+  @spec handle_response(t, Packet.t()) ::
+          {:continue, t} | {:done, {:error, :nack_response}} | {:done, :ok}
+  def handle_response(%__MODULE__{seq_number: seq_number}, %Packet{
+        seq_number: seq_number,
+        types: [:ack_response]
+      }) do
+    {:done, :ok}
+  end
+
+  def handle_response(%__MODULE__{seq_number: seq_number, retries: 0}, %Packet{
+        seq_number: seq_number,
+        types: [:nack_response]
+      }) do
+    {:done, {:error, :nack_response}}
+  end
+
+  def handle_response(%__MODULE__{seq_number: seq_number, retries: n} = command, %Packet{
+        seq_number: seq_number,
+        types: [:nack_response]
+      }) do
+    {:retry, %{command | retries: n - 1}}
+  end
+
+  def handle_response(command, _), do: {:continue, command}
+end

--- a/lib/grizzly/dsk.ex
+++ b/lib/grizzly/dsk.ex
@@ -1,0 +1,70 @@
+defmodule Grizzly.DSK do
+  @moduledoc """
+  Module for working with the SmartStart and S2 DSKs 
+  """
+
+  @typedoc """
+  The DSK string is the string version of the DSK
+
+  The general format is `XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX-XXXXX`
+
+  That is 8 blocks of 16 bit integers separated by a dash.
+
+  An example of this would be `50285-18819-09924-30691-15973-33711-04005-03623`
+  """
+  @type dsk_string :: String.t()
+
+  @typedoc """
+  The DSK binary is the elixir binary string form of the DSK
+
+  The format is `<<b1, b2, b3, ... b16>>`
+
+  That is 16 bytes.
+
+  An example of this would be:
+
+  ```elixir
+  <<196, 109, 73, 131, 38, 196, 119, 227, 62, 101, 131, 175, 15, 165, 14, 39>>
+  ```
+  """
+  @type dsk_binary :: binary()
+
+  @doc """
+  Take a string representation of the DSK and change it into the
+  binary representation
+  """
+  @spec string_to_binary(dsk_string()) ::
+          {:ok, dsk_binary()} | {:error, :dsk_too_short | :dsk_too_long}
+  def string_to_binary(dsk_string) when byte_size(dsk_string) > 47, do: {:error, :dsk_too_long}
+  def string_to_binary(dsk_string) when byte_size(dsk_string) < 47, do: {:error, :dsk_too_short}
+
+  def string_to_binary(dsk_string) do
+    dsk_binary =
+      dsk_string
+      |> String.split("-")
+      |> Enum.map(&String.to_integer/1)
+      |> Enum.reduce(<<>>, fn dsk_number, binary ->
+        binary <> <<dsk_number::size(16)>>
+      end)
+
+    {:ok, dsk_binary}
+  end
+
+  @doc """
+  Take a binary representation of the DSK and change it into the
+  string representation
+  """
+  @spec binary_to_string(dsk_binary()) ::
+          {:ok, dsk_string()} | {:error, :dsk_too_short | :dsk_too_long}
+  def binary_to_string(dsk_binary) when byte_size(dsk_binary) > 16, do: {:error, :dsk_too_long}
+  def binary_to_string(dsk_binary) when byte_size(dsk_binary) < 16, do: {:error, :dsk_too_short}
+
+  def binary_to_string(dsk_binary) do
+    dsk_string =
+      for(<<b::16 <- dsk_binary>>, do: b)
+      |> Enum.map(fn b -> String.slice("00000" <> "#{b}", -5, 5) end)
+      |> Enum.join("-")
+
+    {:ok, dsk_string}
+  end
+end

--- a/lib/grizzly/packet/body_parser.ex
+++ b/lib/grizzly/packet/body_parser.ex
@@ -576,6 +576,24 @@ defmodule Grizzly.Packet.BodyParser do
     }
   end
 
+  def parse(<<0x78, 0x06, _seq, 0>>) do
+    %{
+      command_class: :node_provisioning,
+      command: :report,
+      dsk: :not_found
+    }
+  end
+
+  def parse(<<0x78, 0x06, _seq, _dsk_length, dsk::binary-size(16), _rest::binary>>) do
+    {:ok, dsk_string} = Grizzly.DSK.binary_to_string(dsk)
+
+    %{
+      command_class: :node_provisioning,
+      command: :report,
+      dsk: dsk_string
+    }
+  end
+
   def parse(
         <<0x69, 0x03, _reserved::size(3), proxy_support::size(1), service_support::size(1),
           mode::size(3), mail_box_capacity::integer-size(16), ip_address::binary-size(16),

--- a/mix.exs
+++ b/mix.exs
@@ -138,6 +138,8 @@ defmodule Grizzly.MixProject do
           Grizzly.CommandClass.NetworkManagementInstallationMaintenance.StatisticsGet,
           Grizzly.CommandClass.NetworkManagementProxy.NodeInfoCache,
           Grizzly.CommandClass.NetworkManagementProxy.NodeListGet,
+          Grizzly.CommandClass.NodeProvisioning.Get,
+          Grizzly.CommandClass.NodeProvisioning.Set,
           Grizzly.CommandClass.Powerlevel.Get,
           Grizzly.CommandClass.Powerlevel.Set,
           Grizzly.CommandClass.Powerlevel.TestNodeGet,

--- a/test/grizzly/command_class/node_provisioning/get_test.exs
+++ b/test/grizzly/command_class/node_provisioning/get_test.exs
@@ -1,0 +1,79 @@
+defmodule Grizzly.CommandClass.NodeProvisioning.GetTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.Packet
+  alias Grizzly.CommandClass.NodeProvisioning.Get
+
+  describe "implements the Grizzly.Command behaviour" do
+    test "initializes command" do
+      assert {:ok, %Get{}} = Get.init(seq_number: 0x09)
+    end
+
+    test "encodes correctly" do
+      binary_dsk = <<196, 109, 73, 131, 38, 196, 119, 227, 62, 101, 131, 175, 15, 165, 14, 39>>
+
+      {:ok, command} =
+        Get.init(seq_number: 0x08, dsk: "50285-18819-09924-30691-15973-33711-04005-03623")
+
+      binary = <<35, 2, 128, 208, 8, 0, 0, 3, 2, 0, 0x78, 0x05, 0x08, 0x10>> <> binary_dsk
+
+      assert {:ok, binary} == Get.encode(command)
+    end
+
+    test "does not encode too long dsk" do
+      {:ok, command} =
+        Get.init(seq_number: 0x08, dsk: "50285-18819-09924-30691-15973-33711-04005-03623-12345")
+
+      assert {:error, %Grizzly.Command.EncodeError{}} = Get.encode(command)
+    end
+
+    test "does not encode too short dsk" do
+      {:ok, command} =
+        Get.init(seq_number: 0x08, dsk: "09924-30691-15973-33711-04005-03623-12345")
+
+      assert {:error, %Grizzly.Command.EncodeError{}} = Get.encode(command)
+    end
+
+    test "handles ack response" do
+      {:ok, command} = Get.init(seq_number: 0x01)
+      packet = Packet.new(seq_number: 0x01, types: [:ack_response])
+
+      assert {:continue, ^command} = Get.handle_response(command, packet)
+    end
+
+    test "handles nack response" do
+      {:ok, command} = Get.init(seq_number: 0x01, retries: 0)
+      packet = Packet.new(seq_number: 0x01, types: [:nack_response])
+
+      assert {:done, {:error, :nack_response}} == Get.handle_response(command, packet)
+    end
+
+    test "handles retires" do
+      {:ok, command} = Get.init(seq_number: 0x01)
+      packet = Packet.new(seq_number: 0x01, types: [:nack_response])
+
+      assert {:retry, %Get{}} = Get.handle_response(command, packet)
+    end
+
+    test "handles node provisioning report" do
+      expected_dsk = "50285-18819-09924-30691-15973-33711-04005-03623"
+
+      report = %{
+        command_class: :node_provisioning,
+        command: :report,
+        dsk: expected_dsk
+      }
+
+      {:ok, command} = Get.init(seq_number: 0x01)
+      packet = Packet.new(body: report)
+
+      assert {:done, {:ok, expected_dsk}} == Get.handle_response(command, packet)
+    end
+
+    test "handles other responses" do
+      {:ok, command} = Get.init([])
+
+      assert {:continue, ^command} = Get.handle_response(command, %{value: 100})
+    end
+  end
+end

--- a/test/grizzly/command_class/node_provisioning/set_test.exs
+++ b/test/grizzly/command_class/node_provisioning/set_test.exs
@@ -1,0 +1,68 @@
+defmodule Grizzly.CommandClass.NodeProvisioning.SetTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.{Packet, DSK}
+  alias Grizzly.CommandClass.NodeProvisioning.Set
+  alias Grizzly.Command.EncodeError
+
+  setup do
+    dsk = "50285-18819-09924-30691-15973-33711-04005-03623"
+    {:ok, %{dsk: dsk}}
+  end
+
+  describe "implements the Grizzly command behaviour" do
+    test "initializes the command state", %{dsk: dsk} do
+      {:ok, command} = Set.init(dsk: dsk)
+
+      assert %Set{dsk: dsk} == command
+    end
+
+    test "encodes correctly", %{dsk: dsk} do
+      {:ok, binary_dsk} = DSK.string_to_binary(dsk)
+      {:ok, command} = Set.init(dsk: dsk, seq_number: 0x06)
+
+      binary = <<35, 2, 128, 208, 6, 0, 0, 3, 2, 0, 0x78, 0x01, 0x06, 0x10>> <> binary_dsk
+
+      assert {:ok, binary} == Set.encode(command)
+    end
+
+    test "errors when dsk is too long", %{dsk: dsk} do
+      {:ok, command} = Set.init(seq_number: 0x06, dsk: dsk <> "-12312")
+
+      assert {:error, %EncodeError{}} = Set.encode(command)
+    end
+
+    test "errors when dsk is too short" do
+      {:ok, command} = Set.init(seq_number: 0x06, dsk: "12345-12345")
+
+      assert {:error, %EncodeError{}} = Set.encode(command)
+    end
+
+    test "handles an ack response" do
+      {:ok, command} = Set.init(seq_number: 0x01)
+      packet = Packet.new(seq_number: 0x01, types: [:ack_response])
+
+      assert {:done, :ok} == Set.handle_response(command, packet)
+    end
+
+    test "handles a nack response" do
+      {:ok, command} = Set.init(seq_number: 0x01, retries: 0)
+      packet = Packet.new(seq_number: 0x01, types: [:nack_response])
+
+      assert {:done, {:error, :nack_response}} == Set.handle_response(command, packet)
+    end
+
+    test "handles retries" do
+      {:ok, command} = Set.init(seq_number: 0x01, retries: 2)
+      packet = Packet.new(seq_number: 0x01, types: [:nack_response])
+
+      assert {:retry, %Set{}} = Set.handle_response(command, packet)
+    end
+
+    test "handles responses" do
+      {:ok, command} = Set.init(seq_number: 0x01)
+
+      assert {:continue, _} = Set.handle_response(command, %{})
+    end
+  end
+end

--- a/test/grizzly/dsk_test.exs
+++ b/test/grizzly/dsk_test.exs
@@ -1,0 +1,41 @@
+defmodule Grizzly.DSK.Test do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.DSK
+
+  test "turn the binary dsk into a the string dsk" do
+    binary_dsk = <<196, 109, 73, 131, 38, 196, 119, 227, 62, 101, 131, 175, 15, 165, 14, 39>>
+    expected_string_dsk = "50285-18819-09924-30691-15973-33711-04005-03623"
+
+    assert {:ok, expected_string_dsk} == DSK.binary_to_string(binary_dsk)
+  end
+
+  test "returns error if the dsk is too short" do
+    assert {:error, :dsk_too_short} == DSK.string_to_binary("123")
+  end
+
+  test "returns error if the dsk is too long" do
+    string_dsk = "50285-18819-09924-30691-15973-33711-04005-03623-111111"
+    assert {:error, :dsk_too_long} == DSK.string_to_binary(string_dsk)
+  end
+
+  test "turn the string dsk into the binary dsk" do
+    string_dsk = "50285-18819-09924-30691-15973-33711-04005-03623"
+
+    expected_binary_dsk =
+      <<196, 109, 73, 131, 38, 196, 119, 227, 62, 101, 131, 175, 15, 165, 14, 39>>
+
+    assert {:ok, expected_binary_dsk} == DSK.string_to_binary(string_dsk)
+  end
+
+  test "returns error if the dsk binary is too short" do
+    assert {:error, :dsk_too_short} == DSK.binary_to_string(<<12, 23, 45>>)
+  end
+
+  test "returns error if the dsk binary is too long" do
+    too_long_dsk_binary =
+      <<196, 109, 73, 131, 38, 196, 119, 227, 62, 101, 131, 175, 15, 165, 14, 39, 12>>
+
+    assert {:error, :dsk_too_long} == DSK.binary_to_string(too_long_dsk_binary)
+  end
+end

--- a/test/grizzly/packet/body_parser_test.exs
+++ b/test/grizzly/packet/body_parser_test.exs
@@ -387,6 +387,32 @@ defmodule Grizzly.Packet.BodyParser.Test do
              }
     end
 
+    test "parses node provisioning report when dsk is return" do
+      binary = <<0x78, 0x06, 0x01, 0x0>>
+      parsed = BodyParser.parse(binary)
+
+      assert parsed == %{
+               command_class: :node_provisioning,
+               command: :report,
+               dsk: :not_found
+             }
+    end
+
+    test "parses node provisioning report with dsk" do
+      dsk_binary = <<196, 109, 73, 131, 38, 196, 119, 227, 62, 101, 131, 175, 15, 165, 14, 39>>
+      binary = <<0x78, 0x06, 0x01, 0x10>> <> dsk_binary
+
+      {:ok, dsk_string} = Grizzly.DSK.binary_to_string(dsk_binary)
+
+      parsed = BodyParser.parse(binary)
+
+      assert parsed == %{
+               command_class: :node_provisioning,
+               command: :report,
+               dsk: dsk_string
+             }
+    end
+
     test "parses controller learn mode set with status failed and new node id 0" do
       binary = <<0x4D, 0x02, 0x01, 0x07, 0x00, 0x00>>
       parsed = BodyParser.parse(binary)


### PR DESCRIPTION
These two commands give basic support to add DSKs to the node
provisioning list to allow for SmartStart devices. This gives
Grizzly basic SmartStart support.