### PR TITLE
Move meta extesion modules to be under SmartStart namespace

### DIFF
--- a/lib/grizzly/smart_start/meta_extension/advanced_joining.ex
+++ b/lib/grizzly/smart_start/meta_extension/advanced_joining.ex
@@ -1,4 +1,4 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.AdvancedJoining do
+defmodule Grizzly.SmartStart.MetaExtension.AdvancedJoining do
   @moduledoc """
   This extension is used to advertise the Security keys to grant during S2
   bootstrapping to a SmartStart node in the provisioning list

--- a/lib/grizzly/smart_start/meta_extension/bootstrapping_mode.ex
+++ b/lib/grizzly/smart_start/meta_extension/bootstrapping_mode.ex
@@ -1,4 +1,4 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.BootstrappingMode do
+defmodule Grizzly.SmartStart.MetaExtension.BootstrappingMode do
   @moduledoc """
   This extension is used to advertise the bootstrapping mode to use when
   including the node advertised in the provisioning list

--- a/lib/grizzly/smart_start/meta_extension/location_information.ex
+++ b/lib/grizzly/smart_start/meta_extension/location_information.ex
@@ -1,4 +1,4 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.LocationInformation do
+defmodule Grizzly.SmartStart.MetaExtension.LocationInformation do
   @moduledoc """
   This extension is used to advertise the location assigned to the supporting node
 

--- a/lib/grizzly/smart_start/meta_extension/max_inclusion_request_interval.ex
+++ b/lib/grizzly/smart_start/meta_extension/max_inclusion_request_interval.ex
@@ -1,4 +1,4 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.MaxInclusionRequestInterval do
+defmodule Grizzly.SmartStart.MetaExtension.MaxInclusionRequestInterval do
   @moduledoc """
   This is used to advertise if a power constrained Smart Start node will issue
   inclusion request at a higher interval value than the default 512 seconds.

--- a/lib/grizzly/smart_start/meta_extension/name_information.ex
+++ b/lib/grizzly/smart_start/meta_extension/name_information.ex
@@ -1,4 +1,4 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.NameInformation do
+defmodule Grizzly.SmartStart.MetaExtension.NameInformation do
   @moduledoc """
   This extension is used to advertise the name assigned to the supporting node
 

--- a/lib/grizzly/smart_start/meta_extension/network_status.ex
+++ b/lib/grizzly/smart_start/meta_extension/network_status.ex
@@ -1,4 +1,4 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.NetworkStatus do
+defmodule Grizzly.SmartStart.MetaExtension.NetworkStatus do
   @moduledoc """
   This extension is used to advertise if the node is in the network and its
   assigned node id

--- a/lib/grizzly/smart_start/meta_extension/product_id.ex
+++ b/lib/grizzly/smart_start/meta_extension/product_id.ex
@@ -1,4 +1,4 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.ProductId do
+defmodule Grizzly.SmartStart.MetaExtension.ProductId do
   @moduledoc """
   This Information Type is used to advertise the product identifying data of a supporting node.
   """

--- a/lib/grizzly/smart_start/meta_extension/product_type.ex
+++ b/lib/grizzly/smart_start/meta_extension/product_type.ex
@@ -1,4 +1,4 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.ProductType do
+defmodule Grizzly.SmartStart.MetaExtension.ProductType do
   @moduledoc """
   This Information Type is used to advertise the product type data of a
   supporting node
@@ -56,11 +56,11 @@ defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.ProductType do
   If there is invalid device classes or installer icon type with will return
   `{:error, reason}` where reason is:
 
-  * `:invalid_generic_device_class` - the generic device class could not be 
+  * `:invalid_generic_device_class` - the generic device class could not be
      encoded into its byte representation
   * `:invalid_specific_device_class` - the specific device class could nto be
      encoded into its byte representation
-  * `:unknown_icon_type` - the installer icon type cannot be encoded into its 
+  * `:unknown_icon_type` - the installer icon type cannot be encoded into its
      byte representation
   """
   @spec to_binary(t()) ::

--- a/lib/grizzly/smart_start/meta_extension/smart_start_inclusion_setting.ex
+++ b/lib/grizzly/smart_start/meta_extension/smart_start_inclusion_setting.ex
@@ -1,4 +1,4 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.SmartStartInclusionSetting do
+defmodule Grizzly.SmartStart.MetaExtension.SmartStartInclusionSetting do
   @moduledoc """
   This extension is used to advertise the SmartStart inclusion setting of the
   provisioning list entry

--- a/lib/grizzly/smart_start/meta_extension/uuid16.ex
+++ b/lib/grizzly/smart_start/meta_extension/uuid16.ex
@@ -1,4 +1,4 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.UUID16 do
+defmodule Grizzly.SmartStart.MetaExtension.UUID16 do
   @moduledoc """
   This is used to advertise 16 bytes of manufactured-defined information that
   is unique for a given product.

--- a/test/grizzly/smart_start/meta_extesion/advanced_joining_test.exs
+++ b/test/grizzly/smart_start/meta_extesion/advanced_joining_test.exs
@@ -1,7 +1,7 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.AdvancedJoiningTest do
+defmodule Grizzly.SmartStart.MetaExtension.AdvancedJoiningTest do
   use ExUnit.Case, async: true
 
-  alias Grizzly.CommandClass.NodeProvisioning.MetaExtension.AdvancedJoining
+  alias Grizzly.SmartStart.MetaExtension.AdvancedJoining
 
   describe "creating a AdvancedJoining.t()" do
     test "when all is okay" do

--- a/test/grizzly/smart_start/meta_extesion/bootstrapping_mode_test.exs
+++ b/test/grizzly/smart_start/meta_extesion/bootstrapping_mode_test.exs
@@ -1,7 +1,7 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.BootstrappingModeTest do
+defmodule Grizzly.SmartStart.MetaExtension.BootstrappingModeTest do
   use ExUnit.Case, async: true
 
-  alias Grizzly.CommandClass.NodeProvisioning.MetaExtension.BootstrappingMode
+  alias Grizzly.SmartStart.MetaExtension.BootstrappingMode
 
   describe "create a BootstrappingMode.t()" do
     test "when mode is :security_2" do

--- a/test/grizzly/smart_start/meta_extesion/location_information_test.exs
+++ b/test/grizzly/smart_start/meta_extesion/location_information_test.exs
@@ -1,7 +1,7 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.LocationInformationTest do
+defmodule Grizzly.SmartStart.MetaExtension.LocationInformationTest do
   use ExUnit.Case, async: true
 
-  alias Grizzly.CommandClass.NodeProvisioning.MetaExtension.LocationInformation
+  alias Grizzly.SmartStart.MetaExtension.LocationInformation
 
   test "serialize when all okay" do
     location_info = %LocationInformation{location: "location12340"}

--- a/test/grizzly/smart_start/meta_extesion/max_inclusion_request_interval_test.exs
+++ b/test/grizzly/smart_start/meta_extesion/max_inclusion_request_interval_test.exs
@@ -1,6 +1,6 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.MaxInclusionRequestIntervalTest do
+defmodule Grizzly.SmartStart.MetaExtension.MaxInclusionRequestIntervalTest do
   use ExUnit.Case, async: true
-  alias Grizzly.CommandClass.NodeProvisioning.MetaExtension.MaxInclusionRequestInterval
+  alias Grizzly.SmartStart.MetaExtension.MaxInclusionRequestInterval
 
   describe "decode binary" do
     test "when all is okay" do

--- a/test/grizzly/smart_start/meta_extesion/name_information_test.exs
+++ b/test/grizzly/smart_start/meta_extesion/name_information_test.exs
@@ -1,7 +1,7 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.NameInformationTest do
+defmodule Grizzly.SmartStart.MetaExtension.NameInformationTest do
   use ExUnit.Case, async: true
 
-  alias Grizzly.CommandClass.NodeProvisioning.MetaExtension.NameInformation
+  alias Grizzly.SmartStart.MetaExtension.NameInformation
 
   test "serialize when all okay" do
     name_info = %NameInformation{name: "my Z-Wave node"}

--- a/test/grizzly/smart_start/meta_extesion/network_status_test.exs
+++ b/test/grizzly/smart_start/meta_extesion/network_status_test.exs
@@ -1,7 +1,7 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.NetworkStatusTest do
+defmodule Grizzly.SmartStart.MetaExtension.NetworkStatusTest do
   use ExUnit.Case, async: true
 
-  alias Grizzly.CommandClass.NodeProvisioning.MetaExtension.NetworkStatus
+  alias Grizzly.SmartStart.MetaExtension.NetworkStatus
 
   describe "create a NetworkStatus.t()" do
     test "when network status is :not_in_network" do

--- a/test/grizzly/smart_start/meta_extesion/product_id_test.exs
+++ b/test/grizzly/smart_start/meta_extesion/product_id_test.exs
@@ -1,6 +1,6 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.ProductIdTest do
+defmodule Grizzly.SmartStart.MetaExtension.ProductIdTest do
   use ExUnit.Case, async: true
-  alias Grizzly.CommandClass.NodeProvisioning.MetaExtension.ProductId
+  alias Grizzly.SmartStart.MetaExtension.ProductId
 
   describe "decode binary" do
     test "when all is okay" do

--- a/test/grizzly/smart_start/meta_extesion/product_type_test.exs
+++ b/test/grizzly/smart_start/meta_extesion/product_type_test.exs
@@ -1,7 +1,7 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.ProductTypeTest do
+defmodule Grizzly.SmartStart.MetaExtension.ProductTypeTest do
   use ExUnit.Case, async: true
 
-  alias Grizzly.CommandClass.NodeProvisioning.MetaExtension.ProductType
+  alias Grizzly.SmartStart.MetaExtension.ProductType
 
   describe "decode binary" do
     test "when all is okay" do

--- a/test/grizzly/smart_start/meta_extesion/smart_start_inclusion_setting_test.exs
+++ b/test/grizzly/smart_start/meta_extesion/smart_start_inclusion_setting_test.exs
@@ -1,7 +1,7 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.SmartStartInclusionSettingTest do
+defmodule Grizzly.SmartStart.MetaExtension.SmartStartInclusionSettingTest do
   use ExUnit.Case, async: true
 
-  alias Grizzly.CommandClass.NodeProvisioning.MetaExtension.SmartStartInclusionSetting
+  alias Grizzly.SmartStart.MetaExtension.SmartStartInclusionSetting
 
   test "encode pending setting" do
     setting = %SmartStartInclusionSetting{setting: :pending}

--- a/test/grizzly/smart_start/meta_extesion/uuid16_test.exs
+++ b/test/grizzly/smart_start/meta_extesion/uuid16_test.exs
@@ -1,7 +1,7 @@
-defmodule Grizzly.CommandClass.NodeProvisioning.MetaExtension.UUID16Test do
+defmodule Grizzly.SmartStart.MetaExtension.UUID16Test do
   use ExUnit.Case, async: true
 
-  alias Grizzly.CommandClass.NodeProvisioning.MetaExtension.UUID16
+  alias Grizzly.SmartStart.MetaExtension.UUID16
 
   describe "from binary" do
     test "when critical bit is set" do


### PR DESCRIPTION
Move the the meta extensions module out of the node provisioning command
class as they are not only used in that command class and Z-Wave
documentation has these under the SmartStart umbrella.