### PR TITLE
Add NodeProvisioning command meta extension support

### DIFF
--- a/lib/grizzly/command/encoding.ex
+++ b/lib/grizzly/command/encoding.ex
@@ -49,11 +49,20 @@ defmodule Grizzly.Command.Encoding do
               {:ok, maybe_encoded_value} ->
                 {:cont, {:ok, Map.put(acc, arg_name, maybe_encoded_value)}}
 
-              _ ->
+              {:error, _} ->
                 error =
                   EncodeError.new({:invalid_argument_value, arg_name, value, command_module})
 
                 {:halt, {:error, error}}
+
+              {:error, _, _} ->
+                error =
+                  EncodeError.new({:invalid_argument_value, arg_name, value, command_module})
+
+                {:halt, {:error, error}}
+
+              maybe_encoded_value ->
+                {:cont, {:ok, Map.put(acc, arg_name, maybe_encoded_value)}}
             end
         end
       end

--- a/lib/grizzly/command_class/node_provisioning/get.ex
+++ b/lib/grizzly/command_class/node_provisioning/get.ex
@@ -5,12 +5,13 @@ defmodule Grizzly.CommandClass.NodeProvisioning.Get do
     * `:dsk` - A DSK string to look up the device in the provisioning
       list. See `Grizzly.DSK` for more information
     * `:seq_number` - The sequence number of the Z/IP Packet
-    * `:retries` - The number of times to try to send the command (default 2) 
+    * `:retries` - The number of times to try to send the command (default 2)
   """
   @behaviour Grizzly.Command
 
   alias Grizzly.{Packet, DSK}
   alias Grizzly.Command.{EncodeError, Encoding}
+  alias Grizzly.SmartStart.MetaExtension
 
   @type t :: %__MODULE__{
           dsk: DSK.dsk_string(),
@@ -45,7 +46,7 @@ defmodule Grizzly.CommandClass.NodeProvisioning.Get do
   @spec handle_response(t, Packet.t()) ::
           {:continue, t}
           | {:done, {:error, :nack_response | :not_found}}
-          | {:done, {:ok, String.t()}}
+          | {:done, {:ok, %{dsk: DSK.dsk_string(), meta_extensions: [MetaExtension.t()]}}}
   def handle_response(%__MODULE__{seq_number: seq_number} = command, %Packet{
         seq_number: seq_number,
         types: [:ack_response]
@@ -73,7 +74,8 @@ defmodule Grizzly.CommandClass.NodeProvisioning.Get do
           body: %{
             command_class: :node_provisioning,
             command: :report,
-            dsk: dsk
+            dsk: dsk,
+            meta_extensions: extensions
           }
         }
       ) do
@@ -82,7 +84,7 @@ defmodule Grizzly.CommandClass.NodeProvisioning.Get do
         {:done, {:error, :not_found}}
 
       _dsk ->
-        {:done, {:ok, dsk}}
+        {:done, {:ok, %{dsk: dsk, meta_extensions: extensions}}}
     end
   end
 

--- a/lib/grizzly/command_class/thermostat_setpoint.ex
+++ b/lib/grizzly/command_class/thermostat_setpoint.ex
@@ -54,7 +54,8 @@ defmodule Grizzly.CommandClass.ThermostatSetpoint do
   def encode_setpoint_type(:full_power), do: {:ok, 0x0F}
   def encode_setpoint_type(0x00), do: {:error, :invalid_arg, 0x00}
   def encode_setpoint_type(byte) when byte in 0x03..0x06, do: {:error, :invalid_arg, byte}
-  def encode_setpoint_type(byte), do: byte
+  def encode_setpoint_type(byte) when byte in 0x00..0xFF, do: {:ok, byte}
+  def encode_setpoint_type(byte), do: {:error, :invalid_arg, byte}
 
   @spec decode_setpoint_type(byte) :: setpoint_type
   def decode_setpoint_type(0x01), do: :heating

--- a/test/grizzly/command_class/node_provisioning/get_test.exs
+++ b/test/grizzly/command_class/node_provisioning/get_test.exs
@@ -61,13 +61,15 @@ defmodule Grizzly.CommandClass.NodeProvisioning.GetTest do
       report = %{
         command_class: :node_provisioning,
         command: :report,
-        dsk: expected_dsk
+        dsk: expected_dsk,
+        meta_extensions: []
       }
 
       {:ok, command} = Get.init(seq_number: 0x01)
       packet = Packet.new(body: report)
 
-      assert {:done, {:ok, expected_dsk}} == Get.handle_response(command, packet)
+      assert {:done, {:ok, %{dsk: expected_dsk, meta_extensions: []}}} ==
+               Get.handle_response(command, packet)
     end
 
     test "handles other responses" do

--- a/test/grizzly/packet/body_parser_test.exs
+++ b/test/grizzly/packet/body_parser_test.exs
@@ -409,7 +409,28 @@ defmodule Grizzly.Packet.BodyParser.Test do
       assert parsed == %{
                command_class: :node_provisioning,
                command: :report,
-               dsk: dsk_string
+               dsk: dsk_string,
+               meta_extensions: []
+             }
+    end
+
+    test "parses node provisioning report with dsk and meta extensions" do
+      dsk_binary = <<196, 109, 73, 131, 38, 196, 119, 227, 62, 101, 131, 175, 15, 165, 14, 39>>
+      extension_binary = <<0x69, 0x01, 0x00>>
+      binary = <<0x78, 0x06, 0x01, 0x10>> <> dsk_binary <> extension_binary
+
+      {:ok, dsk_string} = Grizzly.DSK.binary_to_string(dsk_binary)
+
+      {:ok, extensions} =
+        Grizzly.SmartStart.MetaExtension.extensions_from_binary(extension_binary)
+
+      parsed = BodyParser.parse(binary)
+
+      assert parsed == %{
+               command_class: :node_provisioning,
+               command: :report,
+               dsk: dsk_string,
+               meta_extensions: extensions
              }
     end
 
@@ -424,7 +445,31 @@ defmodule Grizzly.Packet.BodyParser.Test do
       assert parsed == %{
                command_class: :node_provisioning,
                command: :list_iteration_report,
-               value: %{seq_number: 8, remaining_count: 1, dsk: dsk_string}
+               value: %{seq_number: 8, remaining_count: 1, dsk: dsk_string, meta_extensions: []}
+             }
+    end
+
+    test "parses node provisioning list iteration report and extensions" do
+      dsk_binary = <<196, 109, 73, 131, 38, 196, 119, 227, 62, 101, 131, 175, 15, 165, 14, 39>>
+      extensions_binary = <<0x69, 0x01, 0x00, 0x04, 0x01, 0x54>>
+      binary = <<0x78, 0x04, 0x08, 0x01, 0x02>> <> dsk_binary <> extensions_binary
+
+      {:ok, dsk_string} = Grizzly.DSK.binary_to_string(dsk_binary)
+
+      {:ok, extensions} =
+        Grizzly.SmartStart.MetaExtension.extensions_from_binary(extensions_binary)
+
+      parsed = BodyParser.parse(binary)
+
+      assert parsed == %{
+               command_class: :node_provisioning,
+               command: :list_iteration_report,
+               value: %{
+                 seq_number: 8,
+                 remaining_count: 1,
+                 dsk: dsk_string,
+                 meta_extensions: extensions
+               }
              }
     end
 


### PR DESCRIPTION
Added the support to parse and provide SmartStart meta extensions
information to users when calling the commands in the NodeProvisioning
command class.

Had to make a fix to the encoding validation stuff, which showed a bug in our `TheremostatSetpoint.encode_setpoint_type` function, but the fix was trivial
so I just did it here.