### PR TITLE
Fix timeout on NodeProvisioning.Get for missing DSK

### DIFF
--- a/lib/grizzly/packet/body_parser.ex
+++ b/lib/grizzly/packet/body_parser.ex
@@ -580,7 +580,8 @@ defmodule Grizzly.Packet.BodyParser do
     %{
       command_class: :node_provisioning,
       command: :report,
-      dsk: :not_found
+      dsk: :not_found,
+      meta_extensions: []
     }
   end
 

--- a/test/grizzly/packet/body_parser_test.exs
+++ b/test/grizzly/packet/body_parser_test.exs
@@ -394,7 +394,8 @@ defmodule Grizzly.Packet.BodyParser.Test do
       assert parsed == %{
                command_class: :node_provisioning,
                command: :report,
-               dsk: :not_found
+               dsk: :not_found,
+               meta_extensions: []
              }
     end
 


### PR DESCRIPTION
When a DSK that is not part of the provisioning list was requested
the command would just hang. This fixes that by making the node
provisioning report the same for all binary strings that contain
a node provisioning report.