### PR TITLE
Support V2 binary switch

### DIFF
--- a/lib/grizzly/command_class/switch_binary.ex
+++ b/lib/grizzly/command_class/switch_binary.ex
@@ -1,10 +1,17 @@
 defmodule Grizzly.CommandClass.SwitchBinary do
-  @type switch_state :: :on | :off
-  @type switch_state_byte :: 0x00 | 0xFF
+  @type switch_state :: :on | :off | :unknown
+  @type switch_state_byte :: 0x00 | 0xFF | 0xFE | 1..99
 
   @spec encode_switch_state(switch_state) ::
           {:ok, switch_state_byte} | {:error, :invalid_arg, any()}
   def encode_switch_state(:on), do: {:ok, 0xFF}
   def encode_switch_state(:off), do: {:ok, 0x00}
+  def encode_switch_state(:unknown), do: {:ok, 0xFE}
   def encode_switch_state(arg), do: {:error, :invalid_arg, arg}
+
+  @spec decode_switch_state(switch_state_byte()) :: switch_state | 1..99
+  def decode_switch_state(0x00), do: :off
+  def decode_switch_state(0xFF), do: :on
+  def decode_switch_state(0xFE), do: :unknown
+  def decode_switch_state(value) when value in 1..99, do: value
 end

--- a/lib/grizzly/packet/body_parser.ex
+++ b/lib/grizzly/packet/body_parser.ex
@@ -41,6 +41,7 @@ defmodule Grizzly.Packet.BodyParser do
     ThermostatSetback,
     UserCode,
     Version,
+    SwitchBinary,
     SwitchMultilevel,
     NetworkManagementInclusion,
     MultilevelSensor,
@@ -270,11 +271,21 @@ defmodule Grizzly.Packet.BodyParser do
     alarm
   end
 
-  def parse(<<0x25, 0x03, switch_state>>) do
+  def parse(<<0x25, 0x03, value>>) do
     %{
       command_class: :switch_binary,
       command: :report,
-      value: encode_switch_state(switch_state)
+      value: SwitchBinary.decode_switch_state(value)
+    }
+  end
+
+  def parse(<<0x25, 0x03, value, target_value, duration>>) do
+    %{
+      command_class: :switch_binary,
+      command: :report,
+      value: SwitchBinary.decode_switch_state(value),
+      target_value: SwitchBinary.decode_switch_state(target_value),
+      duration: duration
     }
   end
 
@@ -1022,10 +1033,6 @@ defmodule Grizzly.Packet.BodyParser do
       value: body
     }
   end
-
-  defp encode_switch_state(0x00), do: :off
-  defp encode_switch_state(0xFF), do: :on
-  defp encode_switch_state(0xFE), do: :unknown
 
   defp encode_basic_value(0x00), do: :off
   defp encode_basic_value(0xFF), do: :on

--- a/test/grizzly/packet/body_parser_test.exs
+++ b/test/grizzly/packet/body_parser_test.exs
@@ -563,6 +563,19 @@ defmodule Grizzly.Packet.BodyParser.Test do
                value: :unknown
              }
     end
+
+    test "when report is v2" do
+      binary_switch_report = <<0x025, 0x03, 0x00, 0xFF, 0x01>>
+      parsed = BodyParser.parse(binary_switch_report)
+
+      assert parsed == %{
+               command_class: :switch_binary,
+               command: :report,
+               value: :off,
+               target_value: :on,
+               duration: 0x01
+             }
+    end
   end
 
   describe "parses basic report" do


### PR DESCRIPTION
AlloyHome BinarySwitches are V2 so this will help ensure they work with the SmartRent hub.

Better long support will be done as part of #29.