### PR TITLE
Fix duplicate :security field

### DIFF
--- a/lib/grizzly/node.ex
+++ b/lib/grizzly/node.ex
@@ -29,7 +29,6 @@ defmodule Grizzly.Node do
           conn: Conn.t() | nil,
           associations: [Association.t()],
           listening?: boolean(),
-          security: security(),
           home_id: pos_integer()
         }
 
@@ -44,7 +43,6 @@ defmodule Grizzly.Node do
             associations: [],
             conn: nil,
             listening?: false,
-            security: :none,
             home_id: nil
 
   @spec new(opts :: keyword) :: t


### PR DESCRIPTION
This is a warning on Elixir 1.10.