### PR TITLE
Report firmware versions as standard version.sub

### DIFF
--- a/lib/grizzly/command_class/version.ex
+++ b/lib/grizzly/command_class/version.ex
@@ -20,10 +20,8 @@ defmodule Grizzly.CommandClass.Version do
 
   @type version_report :: %{
           protocol_library: library_type(),
-          protocol_version: byte(),
-          protocol_sub_version: byte(),
-          firmware_version: byte(),
-          firmware_sub_version: byte()
+          protocol_version: String.t(),
+          firmware_version: String.t()
         }
 
   @doc """
@@ -53,10 +51,8 @@ defmodule Grizzly.CommandClass.Version do
       {:ok,
        %{
          protocol_library: library_type,
-         protocol_version: protocol_version,
-         protocol_sub_version: protocol_sub_version,
-         firmware_version: firmware_version,
-         firmware_sub_version: firmware_sub_version
+         protocol_version: "#{protocol_version}.#{protocol_sub_version}",
+         firmware_version: "#{firmware_version}.#{firmware_sub_version}"
        }}
     else
       {:error, :invalid_library_type, library_type} ->

--- a/lib/grizzly/packet/body_parser.ex
+++ b/lib/grizzly/packet/body_parser.ex
@@ -557,7 +557,20 @@ defmodule Grizzly.Packet.BodyParser do
       target_firmware_ids: target_firmware_ids
     }
 
-    _ = Logger.info("[Grizzly] Firmware update metadata report v5 = #{inspect(report)}")
+    %{
+      command_class: FirmwareUpdateMD,
+      command: :report,
+      value: report
+    }
+  end
+
+  # version >= 1
+  def parse(
+        <<0x7A, 0x02, manufacturer_id::size(2)-integer-unsigned-unit(8),
+          firmware_id::size(2)-integer-unsigned-unit(8),
+          checksum::size(2)-integer-unsigned-unit(8), _rest::binary>>
+      ) do
+    report = %{manufacturer_id: manufacturer_id, firmware_id: firmware_id, checksum: checksum}
 
     %{
       command_class: FirmwareUpdateMD,

--- a/test/grizzly/command_class/version/get_test.exs
+++ b/test/grizzly/command_class/version/get_test.exs
@@ -44,10 +44,8 @@ defmodule Grizzly.CommandClass.Version.GetTest do
         command_class: Version,
         command: :version_report,
         protocol_library: :controller,
-        protocol_version: 1,
-        protocol_sub_version: 1,
-        firmware_version: 1,
-        firmware_sub_version: 1
+        protocol_version: "1.1",
+        firmware_version: "1.1"
       }
 
       packet = Packet.new(body: report)

--- a/test/grizzly/command_class/version_test.exs
+++ b/test/grizzly/command_class/version_test.exs
@@ -52,10 +52,8 @@ defmodule Grizzly.CommandClass.Version.Test do
   test "decoding the version report" do
     report = %{
       protocol_library: :controller,
-      protocol_version: 1,
-      protocol_sub_version: 1,
-      firmware_version: 1,
-      firmware_sub_version: 1
+      protocol_version: "1.1",
+      firmware_version: "1.1"
     }
 
     assert {:ok, report} == Version.decode_version_report(<<0x02, 0x01, 0x01, 0x01, 0x01>>)

--- a/test/grizzly/packet/body_parser_test.exs
+++ b/test/grizzly/packet/body_parser_test.exs
@@ -859,10 +859,8 @@ defmodule Grizzly.Packet.BodyParser.Test do
                command_class: Version,
                command: :version_report,
                protocol_library: :controller,
-               protocol_version: 1,
-               protocol_sub_version: 1,
-               firmware_version: 1,
-               firmware_sub_version: 1
+               protocol_version: "1.1",
+               firmware_version: "1.1"
              }
     end
   end


### PR DESCRIPTION
Instead of separate version and sub-versions in COMMAND_CLASS_VERSION CC