### PR TITLE
Fix queued commands

### DIFF
--- a/lib/grizzly/commands/command.ex
+++ b/lib/grizzly/commands/command.ex
@@ -31,11 +31,12 @@ defmodule Grizzly.Commands.Command do
             timeout_ref: nil,
             ref: nil
 
-  def from_zwave_command(zwave_command, owner, timeout_ref \\ nil, opts \\ []) do
+  def from_zwave_command(zwave_command, owner, opts \\ []) do
     {handler, handler_init_args} = get_handler_spec(zwave_command, opts)
     {:ok, handler_state} = handler.init(handler_init_args)
     retries = Keyword.get(opts, :retries, 2)
     command_ref = Keyword.get(opts, :reference, make_ref())
+    timeout_ref = Keyword.get(opts, :timeout_ref)
 
     %__MODULE__{
       handler: handler,

--- a/lib/grizzly/connections/async_connection.ex
+++ b/lib/grizzly/connections/async_connection.ex
@@ -160,8 +160,8 @@ defmodule Grizzly.Connections.AsyncConnection do
           send(waiter, {:grizzly, :send_command, {:error, :nack_response}})
           %State{state | commands: new_comamnd_list}
 
-        {waiter, {:queued, queued_seconds, new_comamnd_list}} ->
-          send(waiter, {:grizzly, :send_command, {:queued, queued_seconds}})
+        {waiter, {:queued, ref, queued_seconds, new_comamnd_list}} ->
+          GenServer.reply(waiter, {:queued, ref, queued_seconds})
           %State{state | commands: new_comamnd_list}
 
         {waiter, {:complete, response, new_comamnd_list}} ->

--- a/lib/grizzly/connections/keep_alive.ex
+++ b/lib/grizzly/connections/keep_alive.ex
@@ -47,7 +47,7 @@ defmodule Grizzly.Connections.KeepAlive do
   """
   @spec make_command(t()) :: t()
   def make_command(keep_alive) do
-    {:ok, keep_alive_command} = ZIPKeepAlive.new()
+    {:ok, keep_alive_command} = ZIPKeepAlive.new(ack_flag: :ack_request)
     {:ok, command_runner} = Commands.create_command(keep_alive_command)
 
     %__MODULE__{keep_alive | command_runner: command_runner}

--- a/lib/grizzly/connections/sync_connection.ex
+++ b/lib/grizzly/connections/sync_connection.ex
@@ -35,7 +35,7 @@ defmodule Grizzly.Connections.SyncConnection do
   end
 
   @spec send_command(Grizzly.node_id(), Command.t(), [send_opt()]) ::
-          :ok | {:ok, Command.t()} | {:queued, Command.delay_seconds()}
+          :ok | {:ok, Command.t()} | {:queued, reference(), Command.delay_seconds()}
   def send_command(node_id, command, opts \\ []) do
     name = Connections.make_name(node_id)
     GenServer.call(name, {:send_command, command, opts}, 140_000)
@@ -129,8 +129,8 @@ defmodule Grizzly.Connections.SyncConnection do
           GenServer.reply(waiter, {:error, :nack_response})
           %State{state | commands: new_comamnd_list}
 
-        {waiter, {:queued, queued_seconds, new_comamnd_list}} ->
-          GenServer.reply(waiter, {:queued, queued_seconds})
+        {waiter, {:queued, ref, queued_seconds, new_comamnd_list}} ->
+          GenServer.reply(waiter, {:queued, ref, queued_seconds})
           %State{state | commands: new_comamnd_list}
 
         {waiter, {:complete, response, new_comamnd_list}} ->

--- a/lib/grizzly/zwave/commands/zip_keep_alive.ex
+++ b/lib/grizzly/zwave/commands/zip_keep_alive.ex
@@ -10,7 +10,7 @@ defmodule Grizzly.ZWave.Commands.ZIPKeepAlive do
 
   @impl true
   @spec new(keyword()) :: {:ok, Command.t()}
-  def new(params \\ []) do
+  def new(params) do
     command = %Command{
       name: :keep_alive,
       command_byte: 0x03,

--- a/lib/grizzly/zwave/commands/zip_packet/header_extensions.ex
+++ b/lib/grizzly/zwave/commands/zip_packet/header_extensions.ex
@@ -34,7 +34,14 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions do
   @spec to_binary([extension()]) :: binary()
   def to_binary(extensions) do
     Enum.reduce(extensions, <<>>, fn
-      {:expected_delay, seconds}, bin -> bin <> ExpectedDelay.to_binary(seconds)
+      {:expected_delay, seconds}, bin ->
+        bin <> ExpectedDelay.to_binary(seconds)
+
+      {:encapsulation_format_info, security_classes}, bin ->
+        bin <> EncapsulationFormatInfo.to_binary(security_classes)
+
+      :multicast_addressing, bin ->
+        bin <> <<0x05, 0x00>>
     end)
   end
 

--- a/lib/grizzly/zwave/commands/zip_packet/header_extensions/encapsulation_format_info.ex
+++ b/lib/grizzly/zwave/commands/zip_packet/header_extensions/encapsulation_format_info.ex
@@ -1,4 +1,6 @@
 defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions.EncapsulationFormatInfo do
+  import Bitwise
+
   @type security ::
           :non_secure | :s2_unauthenticated | :s2_authenticated | :s2_access_control | :s0
 
@@ -7,6 +9,21 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions.EncapsulationFormatI
   def security_to_security_from_byte(0x02), do: :s2_authenticated
   def security_to_security_from_byte(0x04), do: :s2_access_control
   def security_to_security_from_byte(0x80), do: :s0
+
+  def security_to_security_to_byte(:non_secure), do: 0x00
+  def security_to_security_to_byte(:s2_unauthenticated), do: 0x01
+  def security_to_security_to_byte(:s2_authenticated), do: 0x02
+  def security_to_security_to_byte(:s2_access_control), do: 0x04
+  def security_to_security_to_byte(:s0), do: 0x80
+
+  def to_binary(security_classes) do
+    security_class_byte =
+      Enum.reduce(security_classes, 0, fn security_class, mask ->
+        mask ||| security_to_security_to_byte(security_class)
+      end)
+
+    <<0x84, 0x02, security_class_byte, 0x00>>
+  end
 
   def crc16_from_byte(crc16_byte) do
     <<_::size(7), crc16_bit::size(1)>> = <<crc16_byte>>

--- a/test/grizzly/commands/command_runner_test.exs
+++ b/test/grizzly/commands/command_runner_test.exs
@@ -80,10 +80,11 @@ defmodule Grizzly.Commands.CommandRunnerTest do
   test "handles a queued command" do
     {:ok, command} = SwitchBinaryGet.new()
     {:ok, runner} = CommandRunner.start_link(command)
+    command_ref = CommandRunner.reference(runner)
 
     nack_waiting = ZIPPacket.make_nack_waiting_response(CommandRunner.seq_number(runner), 3)
 
-    assert {:queued, 3} == CommandRunner.handle_zip_command(runner, nack_waiting)
+    assert {:queued, command_ref, 3} == CommandRunner.handle_zip_command(runner, nack_waiting)
   end
 
   test "encodes a command" do

--- a/test/grizzly/commands/command_test.exs
+++ b/test/grizzly/commands/command_test.exs
@@ -87,7 +87,7 @@ defmodule Grizzly.Commands.CommandTest do
 
   test "handles Z/IP Packet for nack response with no retires" do
     {:ok, zwave_command} = SwitchBinaryGet.new()
-    grizzly_command = Command.from_zwave_command(zwave_command, self(), nil, retries: 0)
+    grizzly_command = Command.from_zwave_command(zwave_command, self(), retries: 0)
 
     nack_response = ZIPPacket.make_nack_response(grizzly_command.seq_number)
 
@@ -97,7 +97,7 @@ defmodule Grizzly.Commands.CommandTest do
 
   test "if Z/IP keep alive command, does not encode as a Z/IP Packet" do
     {:ok, keep_alive} = ZIPKeepAlive.new(ack_flag: :ack_request)
-    grizzly_command = Command.from_zwave_command(keep_alive, self(), nil)
+    grizzly_command = Command.from_zwave_command(keep_alive, self())
     expected_binary = <<ZIP.byte(), 0x03, 0x80>>
 
     assert expected_binary == Command.to_binary(grizzly_command)

--- a/test/grizzly/connections/command_list_test.exs
+++ b/test/grizzly/connections/command_list_test.exs
@@ -44,15 +44,15 @@ defmodule Grizzly.Connections.CommandListTest do
   test "response for queued" do
     {:ok, zwave_command} = SwitchBinaryGet.new()
 
-    {:ok, runner, _ref, command_list} =
+    {:ok, runner, ref, command_list} =
       CommandList.create(CommandList.empty(), zwave_command, self())
 
     queued_response = ZIPPacket.make_nack_waiting_response(CommandRunner.seq_number(runner), 3)
 
-    assert {self(), {:queued, 3, CommandList.empty()}} ==
+    assert {self(), {:queued, ref, 3, command_list}} ==
              CommandList.response_for_zip_packet(command_list, queued_response)
 
-    refute Process.alive?(runner)
+    assert Process.alive?(runner)
   end
 
   test "response for retry" do

--- a/test/grizzly/connections/sync_connection_test.exs
+++ b/test/grizzly/connections/sync_connection_test.exs
@@ -30,7 +30,9 @@ defmodule Grizzly.Connections.SyncConnectionTest do
     {:ok, command} = SwitchBinaryGet.new()
 
     # 102 will always respond with nack waiting with 2 seconds
-    assert {:queued, 2} == SyncConnection.send_command(102, command)
+    assert {:queued, ref, 2} = SyncConnection.send_command(102, command)
+
+    assert is_reference(ref)
   end
 
   @tag :integration

--- a/test/grizzly/connections/sync_connection_test.exs
+++ b/test/grizzly/connections/sync_connection_test.exs
@@ -3,6 +3,7 @@ defmodule Grizzly.Connections.SyncConnectionTest do
 
   alias Grizzly.Connection
   alias Grizzly.Connections.SyncConnection
+  alias Grizzly.ZWave.Command, as: ZWaveCommand
   alias Grizzly.ZWave.Commands.SwitchBinaryGet
 
   setup do
@@ -33,6 +34,12 @@ defmodule Grizzly.Connections.SyncConnectionTest do
     assert {:queued, ref, 2} = SyncConnection.send_command(102, command)
 
     assert is_reference(ref)
+
+    assert_receive {:grizzly, :queued_command_response, ^ref,
+                    %ZWaveCommand{} = zwave_command_response},
+                   2_500
+
+    assert zwave_command_response.name == :switch_binary_report
   end
 
   @tag :integration

--- a/test/grizzly_test.exs
+++ b/test/grizzly_test.exs
@@ -31,4 +31,11 @@ defmodule Grizzly.Test do
     assert SwitchBinaryReport.new(target_value: :off) ==
              Grizzly.send_command(50, :switch_binary_get)
   end
+
+  @tag :integration
+  test "send a command to a device that is sleeping" do
+    {:queued, ref, 2} = Grizzly.send_command(102, :battery_get)
+
+    assert is_reference(ref)
+  end
 end


### PR DESCRIPTION
Adds support for the queued commands.

When sending a command you get `{:queued, reference, queued_for_seconds}`

Z/IP pings an update about the remaining time every, 60 seconds, during that time there is a message sent in this form `{:grizzly, :queued_ping, reference, remaining_seconds}` where the reference is the same as the one return from the original `send_command` call.

Also, every 10 minutes there is a `ack_request` UDP ping from zipgateway to ensure there is someone still waiting for the command. So I added support for handling that.

If for some reason the command never gets sent at the time given to use by zipgateway you will receive a timeout like so:

`{:grizzly, queued_command_response, {:error, :timeout}`

All other responses are in this format too but with the response from the original command sent in the last item of the tuple:

`{:grizzly, :queued_command_response, :ok}` or `{:grizzly, :queued_command_response, %Grizzly.ZWave.Command{}}`