### PR TITLE
Fix when sending the same command to the same node

### DIFF
--- a/lib/grizzly/connections/sync_connection.ex
+++ b/lib/grizzly/connections/sync_connection.ex
@@ -176,9 +176,9 @@ defmodule Grizzly.Connections.SyncConnection do
           GenServer.reply(waiter, {:queued, ref, queued_seconds})
           %State{state | commands: new_comamnd_list}
 
-        {waiter, {:complete, response, new_comamnd_list}} ->
+        {waiter, {:complete, response, new_command_list}} ->
           GenServer.reply(waiter, response)
-          %State{state | commands: new_comamnd_list}
+          %State{state | commands: new_command_list}
       end
 
     %State{updated_state | keep_alive: KeepAlive.timer_restart(state.keep_alive)}

--- a/lib/grizzly/inclusions/inclusion_runner.ex
+++ b/lib/grizzly/inclusions/inclusion_runner.ex
@@ -173,6 +173,10 @@ defmodule Grizzly.Inclusions.InclusionRunner do
     handle_incoming_command(command, inclusion)
   end
 
+  def handle_info({:grizzly, :send_command, :ok}, inclusion) do
+    {:noreply, inclusion}
+  end
+
   @impl true
   def terminate(:normal, inclusion) do
     :ok = AsyncConnection.stop(inclusion.controller_id)


### PR DESCRIPTION
When sending the same command to one node from two different processes
one command would be completed and the other would be marked as
completed as well, but that was wrong. Since both commands wait for the
same the report we one only complete one and allow the other to wait for
the next report that it is waiting for to allow it to be marked as
complete.