### PR TITLE
Support getting and reporting application node info

### DIFF
--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -170,7 +170,10 @@ defmodule Grizzly.Commands.Table do
       # Multi Channel
       {:multi_channel_endpoint_get,
        {Commands.MultiChannelEndpointGet,
-        handler: {WaitReport, complete_report: :multi_channel_endpoint_report}}}
+        handler: {WaitReport, complete_report: :multi_channel_endpoint_report}}},
+      {:application_node_info_get,
+       {Commands.ApplicationNodeInfoGet,
+        handler: {WaitReport, complete_report: :application_node_info_report}}}
     ]
 
     defmacro __before_compile__(_) do

--- a/lib/grizzly/zwave/command_classes.ex
+++ b/lib/grizzly/zwave/command_classes.ex
@@ -314,8 +314,10 @@ defmodule Grizzly.ZWave.CommandClasses do
     secure_supported_bin = for cc <- secure_supported, into: <<>>, do: <<to_byte(cc)>>
     secure_controlled_bin = for cc <- secure_controlled, into: <<>>, do: <<to_byte(cc)>>
 
-    <<non_secure_supported_bin::binary, 0xEF, non_secure_controlled_bin::binary, 0xF1, 0x00,
-      secure_supported_bin::binary, 0xEF, secure_controlled_bin::binary>>
+    non_secure_supported_bin
+    |> maybe_concat_command_classes(:non_secure_controlled, non_secure_controlled_bin)
+    |> maybe_concat_command_classes(:secure_supported, secure_supported_bin)
+    |> maybe_concat_command_classes(:secure_controlled, secure_controlled_bin)
   end
 
   @doc """
@@ -359,4 +361,15 @@ defmodule Grizzly.ZWave.CommandClasses do
 
     command_classes
   end
+
+  def maybe_concat_command_classes(binary, _, <<>>), do: binary
+
+  def maybe_concat_command_classes(binary, :non_secure_controlled_bin, ccs_bin),
+    do: binary <> <<0xEF, ccs_bin::binary>>
+
+  def maybe_concat_command_classes(binary, :secure_supported, ccs_bin),
+    do: binary <> <<0xF1, 0x00, ccs_bin::binary>>
+
+  def maybe_concat_command_classes(binary, :secure_controlled, ccs_bin),
+    do: binary <> <<0xEF, ccs_bin::binary>>
 end

--- a/lib/grizzly/zwave/command_classes/zip_gateway.ex
+++ b/lib/grizzly/zwave/command_classes/zip_gateway.ex
@@ -1,0 +1,15 @@
+defmodule Grizzly.ZWave.CommandClasses.ZIPGateway do
+  @moduledoc """
+  ZIPGateway Command Class
+
+  This command class is used for configuration Z/IP Gateway at runtime
+  """
+
+  @behaviour Grizzly.ZWave.CommandClass
+
+  @impl true
+  def byte(), do: 0x5F
+
+  @impl true
+  def name(), do: :zip_gateway
+end

--- a/lib/grizzly/zwave/commands/application_node_info_get.ex
+++ b/lib/grizzly/zwave/commands/application_node_info_get.ex
@@ -1,0 +1,38 @@
+defmodule Grizzly.ZWave.Commands.ApplicationNodeInfoGet do
+  @moduledoc """
+  Get the node information frame of for the Z/IP Gateway controller
+
+  Params: -none-
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.{Command, DecodeError}
+  alias Grizzly.ZWave.CommandClasses.ZIPGateway
+
+  @impl true
+  @spec new(keyword()) :: {:ok, Command.t()}
+  def new(params \\ []) do
+    command = %Command{
+      name: :application_node_info_get,
+      command_byte: 0x0C,
+      command_class: ZIPGateway,
+      params: params,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl true
+  @spec encode_params(Command.t()) :: binary()
+  def encode_params(_command) do
+    <<>>
+  end
+
+  @impl true
+  @spec decode_params(binary()) :: {:ok, keyword()} | {:error, DecodeError.t()}
+  def decode_params(_binary) do
+    {:ok, []}
+  end
+end

--- a/lib/grizzly/zwave/commands/application_node_info_report.ex
+++ b/lib/grizzly/zwave/commands/application_node_info_report.ex
@@ -1,0 +1,51 @@
+defmodule Grizzly.ZWave.Commands.ApplicationNodeInfoReport do
+  @moduledoc """
+  Reports the Application Node Info with regards to the command classes that
+  are supported
+
+  Params:
+
+    * `:command_classes` - list of command classes
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.{Command, CommandClasses, DecodeError}
+  alias Grizzly.ZWave.CommandClasses.ZIPGateway
+
+  @type tagged_command_classes ::
+          {:non_secure_supported, [CommandClasses.command_class()]}
+          | {:non_secure_controlled, [CommandClasses.command_class()]}
+          | {:secure_supported, [CommandClasses.command_class()]}
+          | {:secure_controlled, [CommandClasses.command_class()]}
+
+  @type param :: {:command_classes, [tagged_command_classes()]}
+
+  @impl true
+  @spec new([param()]) :: {:ok, Command.t()}
+  def new(params) do
+    command = %Command{
+      name: :application_node_info_report,
+      command_byte: 0x0D,
+      command_class: ZIPGateway,
+      params: params,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl true
+  @spec encode_params(Command.t()) :: binary()
+  def encode_params(command) do
+    command_classes = Command.param!(command, :command_classes)
+    CommandClasses.command_class_list_to_binary(command_classes)
+  end
+
+  @impl true
+  @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
+  def decode_params(command_class_list_binary) do
+    command_classes = CommandClasses.command_class_list_from_binary(command_class_list_binary)
+    {:ok, [command_classes: command_classes]}
+  end
+end

--- a/lib/grizzly/zwave/decoder.ex
+++ b/lib/grizzly/zwave/decoder.ex
@@ -60,6 +60,9 @@ defmodule Grizzly.ZWave.Decoder do
       {0x59, 0x04, Commands.AssociationGroupInfoReport},
       {0x59, 0x05, Commands.AssociationGroupCommandListGet},
       {0x59, 0x06, Commands.AssociationGroupCommandListReport},
+      # Z/IP Gateway
+      {0x5F, 0x0C, Commands.ApplicationNodeInfoGet},
+      {0x5F, 0x0D, Commands.ApplicationNodeInfoReport},
       # Door Lock
       {0x62, 0x01, Commands.DoorLockOperationSet},
       {0x62, 0x02, Commands.DoorLockOperationGet},

--- a/test/grizzly/zwave/command_classes_test.exs
+++ b/test/grizzly/zwave/command_classes_test.exs
@@ -12,7 +12,7 @@ defmodule Grizzly.ZWave.CommandClassesTest do
         secure_controlled: [:door_lock, :user_code]
       ]
 
-      expected_binary = <<0x20, 0x32, 0xEF, 0xF1, 0x00, 0x71, 0x25, 0xEF, 0x62, 0x63>>
+      expected_binary = <<0x20, 0x32, 0xF1, 0x00, 0x71, 0x25, 0xEF, 0x62, 0x63>>
       assert expected_binary == CommandClasses.command_class_list_to_binary(command_classes)
     end
 

--- a/test/grizzly/zwave/commands/application_node_info_get_test.exs
+++ b/test/grizzly/zwave/commands/application_node_info_get_test.exs
@@ -1,0 +1,23 @@
+defmodule Grizzly.ZWave.Commands.ApplicationNodeInfoGetTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave
+  alias Grizzly.ZWave.Commands.ApplicationNodeInfoGet
+
+  test "creates the command and validates params" do
+    assert {:ok, command} = ApplicationNodeInfoGet.new()
+    assert command.command_byte == 0x0C
+  end
+
+  test "encodes params correctly" do
+    {:ok, command} = ApplicationNodeInfoGet.new()
+    assert <<0x5F, 0x0C>> == ZWave.to_binary(command)
+  end
+
+  test "decodes params correctly" do
+    binary = <<0x5F, 0x0C>>
+    {:ok, expected_command} = ApplicationNodeInfoGet.new()
+
+    assert {:ok, expected_command} == ZWave.from_binary(binary)
+  end
+end

--- a/test/grizzly/zwave/commands/application_node_info_report_test.exs
+++ b/test/grizzly/zwave/commands/application_node_info_report_test.exs
@@ -1,0 +1,35 @@
+defmodule Grizzly.ZWave.Commands.ApplicationNodeInfoReportTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave
+  alias Grizzly.ZWave.Commands.ApplicationNodeInfoReport
+
+  test "creates the command and validates params" do
+    command_classes = [non_secure_supported: [:association_group_info]]
+    assert {:ok, command} = ApplicationNodeInfoReport.new(command_classes: command_classes)
+
+    assert command.command_byte == 0x0D
+  end
+
+  test "encodes params correctly" do
+    command_classes = [non_secure_supported: [:association_group_info]]
+    {:ok, command} = ApplicationNodeInfoReport.new(command_classes: command_classes)
+    expected_binary = <<0x5F, 0xD, 0x59>>
+
+    assert expected_binary == ZWave.to_binary(command)
+  end
+
+  test "decodes params correctly" do
+    command_classes = [
+      non_secure_supported: [:association_group_info],
+      non_secure_controlled: [],
+      secure_supported: [],
+      secure_controlled: []
+    ]
+
+    {:ok, expected_command} = ApplicationNodeInfoReport.new(command_classes: command_classes)
+    binary = <<0x5F, 0xD, 0x59>>
+
+    assert {:ok, expected_command} == ZWave.from_binary(binary)
+  end
+end


### PR DESCRIPTION
```elixir
iex(20)> Grizzly.send_command(1, :application_node_info_get)
{:ok,
 %Grizzly.ZWave.Command{
   command_byte: 13,
   command_class: Grizzly.ZWave.CommandClasses.ZIPGateway,
   impl: Grizzly.ZWave.Commands.ApplicationNodeInfoReport,
   name: :application_node_info_report,
   params: [
     command_classes: [
       non_secure_supported: [:association_group_info],
       non_secure_controlled: [],
       secure_supported: [],
       secure_controlled: []
     ]
   ]
 }}

```

I had to update the command list encoding because if there is no controlled
command classes, then there is are no marks, for example, no `0xEF` or 
`0xF1 0x00` will not be in the command class report.

These two commands will allow us to both actually report and check that we
reporting the extra command classes to another controlling Z-Wave node.

There are two ways to get the extra command class support into zipgateway.

First programmatically and the other is via the `zipgateway.cfg`. From experimenting
updating the configuration code for zipgateway is going to be lower resistance and more
reliable, so I will have another PR to update the configuration generation code.

```elixir