### PR TITLE
Set extra classes via zipgateway.cfg

### DIFF
--- a/lib/grizzly/zipgateway/zipgateway_cfg.ex
+++ b/lib/grizzly/zipgateway/zipgateway_cfg.ex
@@ -23,7 +23,8 @@ defmodule Grizzly.ZIPGateway.Config do
           hardware_version: non_neg_integer() | nil,
           product_id: non_neg_integer() | nil,
           product_type: non_neg_integer() | nil,
-          serial_log: String.t() | nil
+          serial_log: String.t() | nil,
+          extra_classes: [byte()]
         }
 
   defstruct unsolicited_destination_ip6: "fd00:aaaa::2",
@@ -43,7 +44,8 @@ defmodule Grizzly.ZIPGateway.Config do
             product_id: nil,
             product_type: nil,
             hardware_version: nil,
-            manufacturer_id: nil
+            manufacturer_id: nil,
+            extra_classes: [0x85, 0x59, 0x5A, 0x8E, 0x6C, 0x8F]
 
   @doc """
   Make a new `ZipgatewayCfg.t()` from the supplied options
@@ -97,6 +99,18 @@ defmodule Grizzly.ZIPGateway.Config do
     |> maybe_put_config_item(cfg, :manufacturer_id, "ZipManufacturerID")
     |> maybe_put_config_item(cfg, :hardware_version, "ZipHardwareVersion")
     |> maybe_put_config_item(cfg, :product_type, "ZipProductType")
+    |> maybe_put_config_item(cfg, :extra_classes, "ExtraClasses")
+  end
+
+  defp maybe_put_config_item(config_string, cfg, :extra_classes = field, cfg_name) do
+    case Map.get(cfg, field) do
+      nil ->
+        config_string
+
+      extra_command_classes ->
+        extra_command_classes_string = Enum.join(extra_command_classes, " ")
+        config_string <> "#{cfg_name}= #{extra_command_classes_string}\n"
+    end
   end
 
   defp maybe_put_config_item(config_string, cfg, field, cfg_name) do

--- a/lib/mix/tasks/zipgateway.cfg.ex
+++ b/lib/mix/tasks/zipgateway.cfg.ex
@@ -1,0 +1,20 @@
+defmodule Mix.Tasks.Zipgateway.Cfg do
+  @moduledoc """
+  Prints the generated zipgateway config to the console
+
+    mix zipgateway.cfg
+  """
+
+  use Mix.Task
+  alias Grizzly.ZIPGateway.Config
+
+  @shortdoc "Print the zipgateway configuration to the console"
+
+  def run(_args) do
+    config = Application.get_env(:grizzly, :zipgateway_cfg, %{})
+
+    Config.new(config)
+    |> Config.to_string()
+    |> IO.puts()
+  end
+end

--- a/test/grizzly/zipgateway/config_test.exs
+++ b/test/grizzly/zipgateway/config_test.exs
@@ -19,6 +19,7 @@ defmodule Grizzly.ZIPGateway.ConfigTest do
     ZipLanIp6=fd00:aaaa::1
     ZipLanGw6=::1
     ZipPSK=123456789012345678901234567890AA
+    ExtraClasses= 133 89 90 142 108 143
     """
 
     cfg = Config.new()
@@ -42,6 +43,7 @@ defmodule Grizzly.ZIPGateway.ConfigTest do
     ZipLanGw6=::1
     ZipPSK=123456789012345678901234567890AA
     ZipProductID = 1
+    ExtraClasses= 133 89 90 142 108 143
     """
 
     cfg = Config.new(%{product_id: 1})
@@ -66,6 +68,7 @@ defmodule Grizzly.ZIPGateway.ConfigTest do
     ZipLanIp6=fd00:aaaa::1
     ZipLanGw6=::1
     ZipPSK=123456789012345678901234567890AA
+    ExtraClasses= 133 89 90 142 108 143
     """
 
     assert :ok = Config.write(cfg)


### PR DESCRIPTION
Adds the necessary extra command classes to the configuration file and provides a mix task help to get some introspect to the zipgateway config that I have wanted for debugging reason in the past.

From the documentation generated from `make doc` on `zipgateway` source code.

![image](https://user-images.githubusercontent.com/6612164/86294596-b47a4300-bba9-11ea-8bd3-d57f9d4cdcf2.png)

Varifying this configuration works:

```elixir
iex(5)> Grizzly.send_command(1, :application_node_info_get)
{:ok,
 %Grizzly.ZWave.Command{
   command_byte: 13,
   command_class: Grizzly.ZWave.CommandClasses.ZIPGateway,
   impl: Grizzly.ZWave.Commands.ApplicationNodeInfoReport,
   name: :application_node_info_report,
   params: [
     command_classes: [
       non_secure_supported: [:association, :association_group_info,
        :device_rest_locally, :multi_channel_association, :supervision,
        :multi_cmd],
       non_secure_controlled: [],
       secure_supported: [],
       secure_controlled: []
     ]
   ]
 }}
```

Closes: #248 