### PR TITLE
Update DoorLockOperationReport timeout for new spec

### DIFF
--- a/lib/grizzly/zwave/commands/door_lock_operation_report.ex
+++ b/lib/grizzly/zwave/commands/door_lock_operation_report.ex
@@ -68,7 +68,7 @@ defmodule Grizzly.ZWave.Commands.DoorLockOperationReport do
   """
   @type door_state :: :open | :closed
 
-  @type timeout_minutes :: 0x00..0xFC | :undefined
+  @type timeout_minutes :: 0x00..0xFD | :undefined
 
   @type timeout_seconds :: 0x00..0x3B | :undefined
 
@@ -299,7 +299,7 @@ defmodule Grizzly.ZWave.Commands.DoorLockOperationReport do
     end
   end
 
-  defp timeout_minutes_from_byte(m) when m >= 0 and m <= 0xFC, do: {:ok, m}
+  defp timeout_minutes_from_byte(m) when m >= 0 and m <= 0xFD, do: {:ok, m}
   defp timeout_minutes_from_byte(0xFE), do: {:ok, :undefined}
 
   defp timeout_minutes_from_byte(byte),


### PR DESCRIPTION
The newly released Z-Wave specification updated the door lock operation
report timeout in minutes max minutes from `0xFC` to `0xFD`. This is a
fix in their documentation has they had stated that `253` (`0xFD`) is
valid. This should be no-op for most Grizzly users and will mostly add a
greater range of support for locks that contain `0xFD` in the report.

See `SDS13781 Z-Wave Application Command Class Specification.pdf`
provided by Silicon Labs document revision 15 for more information.