### PR TITLE
Add and update to use Grizzly.Report

### DIFF
--- a/example/lib/example.ex
+++ b/example/lib/example.ex
@@ -1,4 +1,5 @@
 defmodule Example do
+  alias Grizzly.Report
   alias Grizzly.ZWave.Command
 
   def turn_switch_on(switch_id) do
@@ -11,7 +12,7 @@ defmodule Example do
 
   def get_switch_state(switch_id) do
     case Grizzly.send_command(switch_id, :switch_binary_get) do
-      {:ok, command} ->
+      {:ok, %Report{status: :complete, type: :command, command: command}} ->
         {:ok, Command.param!(command, :target_value)}
     end
   end
@@ -47,14 +48,14 @@ defmodule Example do
 
   def get_lock_state(lock_id) do
     case Grizzly.send_command(lock_id, :dor_lock_operation_get) do
-      {:ok, command} ->
+      {:ok, %Report{status: :complete, type: :command, command: command}} ->
         {:ok, Command.param!(command, :mode)}
     end
   end
 
   def get_thermostat_heating_setpoint(thermostat_id) do
     case Grizzly.send_command(thermostat_id, :thermostat_setpoint_get, type: :heating) do
-      {:ok, command} ->
+      {:ok, %Report{status: :complete, type: :command, command: command}} ->
         {:ok, Command.param!(command, :value)}
     end
   end
@@ -71,7 +72,7 @@ defmodule Example do
 
   def get_thermostat_cooling_setpoint(thermostat_id) do
     case Grizzly.send_command(thermostat_id, :thermostat_setpoint_get, type: :cooling) do
-      {:ok, command} ->
+      {:ok, %Report{status: :complete, type: :command, command: command}} ->
         {:ok, Command.param(command, :value)}
     end
   end

--- a/lib/grizzly/command_handlers/aggregate_report.ex
+++ b/lib/grizzly/command_handlers/aggregate_report.ex
@@ -31,7 +31,7 @@ defmodule Grizzly.CommandHandlers.AggregateReport do
     rtf = Command.param!(command, :reports_to_follow)
 
     if rtf == 0 do
-      {:complete, {:ok, prepare_aggregate_data(command, state)}}
+      {:complete, prepare_aggregate_data(command, state)}
     else
       {:continue, aggregate(command, state)}
     end

--- a/lib/grizzly/command_handlers/wait_report.ex
+++ b/lib/grizzly/command_handlers/wait_report.ex
@@ -21,10 +21,10 @@ defmodule Grizzly.CommandHandlers.WaitReport do
   def handle_ack(state), do: {:continue, state}
 
   @spec handle_command(Command.t(), state()) ::
-          {:continue, state} | {:complete, {:ok, Command.t()}}
+          {:continue, state} | {:complete, Command.t()}
   def handle_command(command, state) do
     if state.complete_report == :any or command.name == state.complete_report do
-      {:complete, {:ok, command}}
+      {:complete, command}
     else
       {:continue, state}
     end

--- a/lib/grizzly/commands.ex
+++ b/lib/grizzly/commands.ex
@@ -4,6 +4,7 @@ defmodule Grizzly.Commands do
   # module for providing away to setup and tie Z-Wave commands into the
   # Grizzly runtime for handling commands
 
+  alias Grizzly.ZWave
   alias Grizzly.Commands.{CommandRunner, CommandRunnerSupervisor}
   alias Grizzly.ZWave.Command
 
@@ -13,9 +14,9 @@ defmodule Grizzly.Commands do
   This command process is supervised and will stop once the command has
   completed its life cycle or until the timeout has expired
   """
-  @spec create_command(Command.t(), keyword()) :: {:ok, pid()}
-  def create_command(zwave_command, opts \\ []) do
-    CommandRunnerSupervisor.start_runner(zwave_command, opts)
+  @spec create_command(Command.t(), ZWave.node_id(), keyword()) :: {:ok, pid()}
+  def create_command(zwave_command, node_id, opts \\ []) do
+    CommandRunnerSupervisor.start_runner(zwave_command, node_id, opts)
   end
 
   @doc """

--- a/lib/grizzly/commands/command_runner.ex
+++ b/lib/grizzly/commands/command_runner.ex
@@ -5,29 +5,27 @@ defmodule Grizzly.Commands.CommandRunner do
 
   use GenServer
 
+  alias Grizzly.Report
   alias Grizzly.Commands.Command
   alias Grizzly.ZWave.Command, as: ZWaveCommand
 
-  def child_spec([_command, _opts] = args) do
+  def child_spec([_command, _node_id, _opts] = args) do
     # Don't restart the command if there is a failure
     # TODO: type out opts correctly!!
     %{id: __MODULE__, start: {__MODULE__, :start_link, args}, restart: :temporary}
   end
 
   @spec start_link(Command.t(), [Grizzly.command_opt()]) :: GenServer.on_start()
-  def start_link(command, opts \\ []) do
+  def start_link(command, node_id, opts \\ []) do
     opts = Keyword.merge([owner: self(), timeout: 5_000], opts)
-    GenServer.start_link(__MODULE__, [command, opts])
+    GenServer.start_link(__MODULE__, [command, node_id, opts])
   end
 
   @spec handle_zip_command(pid(), ZWaveCommand.t()) ::
-          :continue
+          Report.t()
+          | :continue
           | {:error, :nack_response}
-          | {:queued, reference(), non_neg_integer()}
-          | {:queued_ping, reference(), non_neg_integer()}
-          | {:queued_complete, reference(), ZWaveCommand.t() | :ok}
           | :retry
-          | {:complete, any()}
   def handle_zip_command(runner, zip_packet) do
     GenServer.call(runner, {:handle_zip_command, zip_packet})
   end
@@ -50,13 +48,13 @@ defmodule Grizzly.Commands.CommandRunner do
   def stop(runner), do: GenServer.stop(runner, :normal)
 
   @impl true
-  def init([command, opts]) do
+  def init([command, node_id, opts]) do
     owner = Keyword.fetch!(opts, :owner)
     timeout = Keyword.fetch!(opts, :timeout)
     timeout_ref = start_timeout_counter(timeout)
     opts = Keyword.merge(opts, timeout_ref: timeout_ref)
 
-    {:ok, Command.from_zwave_command(command, owner, opts)}
+    {:ok, Command.from_zwave_command(command, node_id, owner, opts)}
   end
 
   @impl true
@@ -64,24 +62,18 @@ defmodule Grizzly.Commands.CommandRunner do
 
   def handle_call({:handle_zip_command, zip_packet}, _from, command) do
     case Command.handle_zip_command(command, zip_packet) do
+      {%Report{status: :inflight} = report, new_command} ->
+        new_command = update_timeout(new_command, report.queued_delay)
+        {:reply, report, new_command}
+
+      {%Report{status: :complete} = report, new_command} ->
+        {:stop, :normal, report, new_command}
+
       {:continue, new_command} ->
         {:reply, :continue, new_command}
 
-      {:complete, result, new_command} ->
-        {:stop, :normal, {:complete, result}, new_command}
-
       {:error, :nack_response, new_command} ->
         {:stop, :normal, {:error, :nack_response}, new_command}
-
-      {:queued_complete, result, new_command} ->
-        {:stop, :normal, {:queued_complete, new_command.ref, result}, new_command}
-
-      {:queued_ping, seconds, new_command} ->
-        {:reply, {:queued_ping, command.ref, seconds}, new_command}
-
-      {:queued, seconds, new_command} ->
-        new_command = update_timeout(new_command, seconds)
-        {:reply, {:queued, command.ref, seconds}, new_command}
 
       {:retry, new_command} ->
         {:reply, :retry, new_command}

--- a/lib/grizzly/commands/command_runner_supervisor.ex
+++ b/lib/grizzly/commands/command_runner_supervisor.ex
@@ -5,6 +5,7 @@ defmodule Grizzly.Commands.CommandRunnerSupervisor do
 
   use DynamicSupervisor
 
+  alias Grizzly.ZWave
   alias Grizzly.ZWave.Command, as: ZWaveCommand
   alias Grizzly.Commands.{CommandRunner, Command}
 
@@ -15,10 +16,11 @@ defmodule Grizzly.Commands.CommandRunnerSupervisor do
   @doc """
   Start a new supervised runtime for a command
   """
-  @spec start_runner(ZWaveCommand.t(), [Command.opt()]) :: DynamicSupervisor.on_start_child()
-  def start_runner(command, command_opts) do
+  @spec start_runner(ZWaveCommand.t(), ZWave.node_id(), [Command.opt()]) ::
+          DynamicSupervisor.on_start_child()
+  def start_runner(command, node_id, command_opts) do
     command_opts = Keyword.merge([owner: self()], command_opts)
-    child_spec = CommandRunner.child_spec([command, command_opts])
+    child_spec = CommandRunner.child_spec([command, node_id, command_opts])
 
     DynamicSupervisor.start_child(__MODULE__, child_spec)
   end

--- a/lib/grizzly/inclusion_handler.ex
+++ b/lib/grizzly/inclusion_handler.ex
@@ -26,8 +26,8 @@ defmodule Grizzly.InclusionHandler do
 
   """
 
-  alias Grizzly.ZWave.Command
+  alias Grizzly.Report
 
-  @callback handle_command(Command.t(), keyword()) :: :ok
+  @callback handle_report(Report.t(), keyword()) :: :ok
   @callback handle_timeout(atom, keyword()) :: :ok
 end

--- a/lib/grizzly/inclusions.ex
+++ b/lib/grizzly/inclusions.ex
@@ -58,17 +58,17 @@ defmodule Grizzly.Inclusions do
       {:reply, :ok, state}
     end
 
-    def handle_info({:grizzly, :inclusion, command}, state) do
-      case Command.param!(command, :status) do
+    def handle_info({:grizzly, :inclusion, report}, state) do
+      case Command.param!(report.command, :status) do
         :done ->
-          node_id = Command.param!(command, :node_id)
+          node_id = Command.param!(report.command, :node_id)
           Logger.info("Node added with id: " <> node_id)
 
         :failed ->
           Logger.warn("Adding node failed :(")
 
         :security_failed ->
-          node_id = Command.param!(command, :node_id)
+          node_id = Command.param!(report.command, :node_id)
           Logger.warn("Node added with id: " <> node_id <> "but the security failed")
       end
 
@@ -155,8 +155,8 @@ defmodule Grizzly.Inclusions do
 
     require Logger
 
-    def handle_command(command, opts) do
-      Logger.info("Got command: " <> command.name <> " with callback arguments " <> inspect opts)
+    def handle_report(report, opts) do
+      Logger.info("Got command: " <> report.command.name <> " with callback arguments " <> inspect opts)
       :ok
     end
   end

--- a/lib/grizzly/inclusions/inclusion_runner_supervisor.ex
+++ b/lib/grizzly/inclusions/inclusion_runner_supervisor.ex
@@ -27,7 +27,7 @@ defmodule Grizzly.Inclusions.InclusionRunnerSupervisor do
   end
 
   defp get_inclusion_handler() do
-    case Application.get_env(:girzzly, :handlers) do
+    case Application.get_env(:grizzly, :handlers) do
       nil ->
         self()
 

--- a/lib/grizzly/node.ex
+++ b/lib/grizzly/node.ex
@@ -60,7 +60,8 @@ defmodule Grizzly.Node do
     * `:extra_node_ids` - any extra nodes to set add to the association
       group
   """
-  @spec set_lifeline_association(ZWave.node_id(), [lifeline_opts()]) :: :ok
+  @spec set_lifeline_association(ZWave.node_id(), [lifeline_opts()]) ::
+          Grizzly.send_command_response()
   def set_lifeline_association(node_id, opts \\ []) do
     controller_id = Keyword.get(opts, :controller_id, 1)
     extra_node_ids = Keyword.get(opts, :extra_node_ids, [])

--- a/lib/grizzly/report.ex
+++ b/lib/grizzly/report.ex
@@ -1,0 +1,238 @@
+defmodule Grizzly.Report do
+  @moduledoc """
+  Reports from Z-Wave commands
+
+  When you send a command in Z-Wave you will receive a report back.
+
+  ## When Things Go Well
+
+  There are two primary reports that are returned when sending a command.
+
+  The first is `:command` report and the second is an `:ack_response` report.
+  These both will have a status of `:complete`.
+
+  Normally, an `:ack_response` report is returned when you set a value on a
+  device. This means the device received the command and is processing it,
+  not that the device has already processed it. You might have to go read the
+  value back after setting it if you want to make the device ran the set
+  based command.
+
+  A `:command` report type is returned often after reading a value from a
+  device. This report will have its `:command` field filled with a Z-Wave
+  command.
+
+  ```elixir
+  case Grizzly.send_command(node_id, command, command_args, command_opts) do
+    {:ok, %Grizzly.Report{status: :complete, type: :command} = report} ->
+      # do something withe report.command
+    {:ok, %Grizzly.Report{status: :complete, type: :ack_response}} ->
+      # do whatever
+  end
+  ```
+
+  ## Queued Commands
+
+  When sending a command to a device that sleeping, normally battery powered
+  devices, the command will be queued internally. The command will still be
+  considered `:inflight` as it has not reached the device yet. You know when
+  a command has been queued when the report's `:status` field is `:inflight`
+  and the `:type` field is `:queued_delayed`. Fields to help you manage queued
+  commands are `:command_ref`, `:queued_delay`, and `:node_id`
+
+  During the command's queued lifetime the system sends pings back to the
+  caller to ensure that the low level connection is still established. This
+  also provides an updated delayed time before the device wakes up.
+
+  ```elixir
+  case Grizzly.send_command(node_id, command, command_args, command_opts) do
+    {:ok, %Grizzly.Report{status: :inflight, type: :queued_delay}} ->
+      # the command was just queued
+  end
+  ```
+
+  Once the command has been queued the calling process will receive messages
+  about the queued command like so:
+
+  ```elixir
+  {:grizzly, :report, %Report{}}
+  ```
+
+  This report can take two forms. One for a completed queued command and one
+  for a queued ping.
+
+
+  ```elixir
+  def handle_info({:grizzly, :report, report}, state) do
+    case report do
+      %Grizzly.Report{status: :inflight, type: :queued_ping} ->
+        # handle the ping if you want
+        # an updated queue delay will be found in the :queued_delay
+        # field of the report
+      %Grizzly.Report{status: :complete, type: :command, queued: true} ->
+        # here if the :queued field is marked has true and the report is
+        # complete that will indicate a command has made it to the sleeping
+        # device and the device has received the command
+      %Grizzly.Report{status: :complete, type: :timeout, queued: true} ->
+        # The woke up and the controller sent the command but for reason
+        # the command's processing timed out
+    end
+  end
+  ```
+
+  ## Timeouts
+
+  If sending the command times out you will get a command with the `:type` of
+  `:timeout`
+
+  ```elixir
+  case Grizzly.send_command(node_id, command, command_args, command_opts) do
+    {:ok, %Grizzly.Report{status: :complete, type: :timeout}} ->
+      # handle the timeout
+  end
+  ```
+
+  The reason why this is considered okay is because the command that was sent
+  was valid and we were able to establish a connect to the desired device but
+  it just did not provide any report back.
+
+  ## Full Example
+
+  The below example shows the various ways one might match after calling
+  `Grizzly.send_command/4`.
+
+  ```elixir
+  case Grizzly.send_command(node_id, command, command_args, command_opts) do
+    {:ok, %Grizzly.Report{status: :complete, type: :command} = report} ->
+      handle_complete_report(report)
+    {:ok, %Grizzly.Report{status: :complete, type: :ack_response} = report} ->
+      handle_complete_report(report)
+    {:ok, %Grizzly.Report{status: :complete, type: :timeout} = report} ->
+      handle_timeout(report)
+    {:ok, %Grizzly.Report{status: :inflight, type: :queued} = report} ->
+      handle_queued_command(report)
+  end
+  ```
+
+  note: the `handle_*` functions will need to implemented and are only used in
+  the example for illustration purposes
+  """
+
+  alias Grizzly.ZWave
+  alias Grizzly.ZWave.Command
+
+  @typedoc """
+  All the data for the status and type of a report.
+
+  Fields
+
+    - `:status` - this indicates if the report is complete, inflight, or
+      timed out
+    - `:type` - this indicates if the report is contains a command or information
+      about being queued.
+    - `:command` - if the status is `:complete` and the type is `:command` then
+      this field will contain a Z-Wave command in the report.
+    - `:transmission_stats` - provides transmission stats for the command that
+      was sent
+    - `:queued_delay` - the delay time remaining if the report type is
+      `:queued_delay` or `:queued_ping`
+    - `:command_ref` - a reference to the command. This is mostly useful for
+      tracking queued commands
+    - `:node_id` - the node the report is responding from
+    - `:queued` - this flag marks if the command was ever queued before
+      completing
+  """
+  @type t() :: %__MODULE__{
+          status: status(),
+          type: type(),
+          command: Command.t() | nil,
+          transmission_stats: [transmission_stat()],
+          queued_delay: non_neg_integer(),
+          command_ref: reference() | nil,
+          node_id: ZWave.node_id(),
+          queued: boolean()
+        }
+
+  @type type() ::
+          :ack_response
+          | :command
+          | :queued_ping
+          | :unsolicited
+          | :queued_delay
+          | :timeout
+
+  @type status() :: :inflight | :complete
+
+  @type opt() ::
+          {:transmission_stats, [transmission_stat()]}
+          | {:queued_delay, non_neg_integer()}
+          | {:command, Command.t()}
+          | {:command_ref, reference()}
+          | {:queued, boolean()}
+
+  @typedoc """
+  The RSSI value between each device that command had to route through to get
+  to the destination node
+
+  If the value is `:not_available` that means data for that hop in not available
+  or a hope did not take place. To see the nodes that the command was routed
+  through see the `:last_working_route` field of the transmission stats.
+  """
+  @type rssi_value() :: integer() | :not_available
+
+  @type transmit_speed() :: float() | non_neg_integer()
+
+  @typedoc """
+  The various transmission stats that are provide by the Z-Wave network when
+  sending a command.
+
+    - `:transmit_channel` - the RF channel the command was transmitted on
+    - `:ack_channel` - the RF channel the acknowledgement report was
+      transmitted on
+    - `:rssi` - a 5 tuple that contains RSSI values for each hop in the Z-Wave
+      network
+    - `:last_working_route` - this contains a 4 tuple that shows what nodes the
+      Z-Wave command was routed through to the destination node. Also this
+      contains the speed by which the Z-Wave command was transmitted to the
+      destination
+    - `:transmission_time` - the length of time until the reception of an
+      acknowledgement in milliseconds
+    - `:route_changed` - this indicates if the route was changed for the
+      current transmission
+  """
+  @type transmission_stat() ::
+          {:transmit_channel, non_neg_integer()}
+          | {:ack_channel, non_neg_integer()}
+          | {:rssi, {rssi_value(), rssi_value(), rssi_value(), rssi_value(), rssi_value()}}
+          | {:last_working_route,
+             {ZWave.node_id(), ZWave.node_id(), ZWave.node_id(), ZWave.node_id()},
+             {transmit_speed(), :kbit_sec}}
+          | {:transmission_time, non_neg_integer()}
+          | {:route_changed, :not_changed | :changed}
+
+  @enforce_keys [:status, :type, :node_id]
+  defstruct status: nil,
+            command: nil,
+            transmission_stats: [],
+            queued_delay: 0,
+            command_ref: nil,
+            node_id: nil,
+            type: nil,
+            queued: false
+
+  @doc """
+  Make a new `Grizzly.Report`
+  """
+  @spec new(status(), type(), ZWave.node_id(), [opt()]) :: t()
+  def new(status, type, node_id, opts \\ []) do
+    %__MODULE__{
+      status: status,
+      type: type,
+      node_id: node_id,
+      command_ref: Keyword.get(opts, :command_ref, nil),
+      transmission_stats: Keyword.get(opts, :transmission_stats, []),
+      queued_delay: Keyword.get(opts, :queued_delay, 0),
+      command: Keyword.get(opts, :command),
+      queued: Keyword.get(opts, :queued, false)
+    }
+  end
+end

--- a/lib/grizzly/unsolicited_server/messages.ex
+++ b/lib/grizzly/unsolicited_server/messages.ex
@@ -3,8 +3,7 @@ defmodule Grizzly.UnsolicitedServer.Messages do
 
   require Logger
 
-  alias Grizzly.ZIPGateway
-  alias Grizzly.ZWave
+  alias Grizzly.{Report, ZIPGateway, ZWave}
   alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.Commands.ZIPPacket
 
@@ -48,8 +47,15 @@ defmodule Grizzly.UnsolicitedServer.Messages do
 
         Registry.dispatch(@registry, ZIPPacket.command_name(zip_packet), fn listeners ->
           for {pid, _} <- listeners,
-              do: send(pid, {:grizzly, :event, node_id, Command.param!(zip_packet, :command)})
+              do: send_report(pid, node_id, zip_packet)
         end)
     end
+  end
+
+  defp send_report(pid, node_id, zip_packet) do
+    report =
+      Report.new(:complete, :unsolicited, node_id, command: Command.param!(zip_packet, :command))
+
+    send(pid, {:grizzly, :report, report})
   end
 end

--- a/lib/grizzly/zwave/commands/zip_packet.ex
+++ b/lib/grizzly/zwave/commands/zip_packet.ex
@@ -165,6 +165,9 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket do
     end)
   end
 
+  @doc """
+  Make a Z/IP Packet Command that encapsulates another Z-Wave command
+  """
   @spec with_zwave_command(Command.t(), ZWave.seq_number(), [param()]) :: {:ok, Command.t()}
   def with_zwave_command(zwave_command, seq_number, params \\ []) do
     params =

--- a/lib/grizzly/zwave/commands/zip_packet/header_extensions.ex
+++ b/lib/grizzly/zwave/commands/zip_packet/header_extensions.ex
@@ -42,6 +42,9 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions do
 
       :multicast_addressing, bin ->
         bin <> <<0x05, 0x00>>
+
+      :install_and_maintenance_get, bin ->
+        bin <> <<0x02, 0x00>>
     end)
   end
 

--- a/test/grizzly/connection_test.exs
+++ b/test/grizzly/connection_test.exs
@@ -1,7 +1,7 @@
 defmodule Grizzly.ConnectionTest do
   use ExUnit.Case
 
-  alias Grizzly.Connection
+  alias Grizzly.{Connection, Report}
 
   test "open a connection" do
     assert {:ok, _connection} = Connection.open(1)
@@ -15,6 +15,7 @@ defmodule Grizzly.ConnectionTest do
 
     # the send command should reconnect when trying to send a command and
     # work as if no connection closing happened.
-    assert :ok == Grizzly.send_command(555, :switch_binary_set, target_value: :off)
+    assert {:ok, %Report{status: :complete, type: :ack_response, node_id: 555}} =
+             Grizzly.send_command(555, :switch_binary_set, target_value: :off)
   end
 end

--- a/test/grizzly/connections/async_connection_test.exs
+++ b/test/grizzly/connections/async_connection_test.exs
@@ -24,8 +24,8 @@ defmodule Grizzly.Connections.AsyncConnectionTest do
     {:ok, command_ref} =
       AsyncConnection.send_command(400, command, timeout: 1_000, handler: AckResponse)
 
-    assert_receive {:grizzly, :send_command, {:error, :timeout, timeout_ref}}, 2_000
+    assert_receive {:grizzly, :report, report}, 2_000
 
-    assert command_ref == timeout_ref
+    assert report.command_ref == command_ref
   end
 end

--- a/test/grizzly/connections/keep_alive_test.exs
+++ b/test/grizzly/connections/keep_alive_test.exs
@@ -5,14 +5,14 @@ defmodule Grizzly.Connections.KeepAliveTest do
 
   @tag :integration
   test "receive message after" do
-    KeepAlive.init(2_000)
+    KeepAlive.init(1, 2_000)
 
     assert_receive :keep_alive_tick, 2_100
   end
 
   @tag :integration
   test "resets the timer early" do
-    ka = KeepAlive.init(2_000)
+    ka = KeepAlive.init(1, 2_000)
 
     :timer.sleep(1_000)
 
@@ -24,7 +24,7 @@ defmodule Grizzly.Connections.KeepAliveTest do
 
   @tag :integration
   test "stops keep alive" do
-    ka = KeepAlive.init(2_000) |> KeepAlive.timer_clear()
+    ka = KeepAlive.init(1, 2_000) |> KeepAlive.timer_clear()
 
     refute_receive :keep_alive_tick, 2_100
     assert ka.ref == nil

--- a/test/grizzly/firmware_updates/firmware_update_runner_test.exs
+++ b/test/grizzly/firmware_updates/firmware_update_runner_test.exs
@@ -16,7 +16,7 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunnerTest do
       )
 
     :ok = FirmwareUpdateRunner.start_firmware_update(runner, image_path)
-    assert_receive {:grizzly, :firmware_update, received_command}, 500
+    assert_receive {:grizzly, :report, received_command}, 500
     assert received_command.name == :firmware_update_md_request_report
   end
 
@@ -31,13 +31,13 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunnerTest do
       )
 
     :ok = FirmwareUpdateRunner.start_firmware_update(runner, image_path)
-    assert_receive {:grizzly, :firmware_update, received_command}, 500
+    assert_receive {:grizzly, :report, received_command}, 500
     assert received_command.name == :firmware_update_md_request_report
     :timer.sleep(500)
-    assert_receive {:grizzly, :firmware_update, get_command}, 500
+    assert_receive {:grizzly, :report, get_command}, 500
     assert get_command.name == :firmware_update_md_get
     :timer.sleep(500)
-    assert_receive {:grizzly, :firmware_update, status_command}, 500
+    assert_receive {:grizzly, :report, status_command}, 500
     assert status_command.name == :firmware_update_md_status_report
   end
 end


### PR DESCRIPTION
This change breaks the API. However, this helps provide a bit more semantic meaning around the communication process between sending a and command getting a report. Also, wrapping a command in a report allows us to provide meta information to the caller in a consistent way. These metadata fields are things such as the delay of the command, the command reference, and transmission stats. Now instead of 3 or 4 success command send returns we get one `{:ok, %Grizzly.Report{}}`.

A nice side effect is some of the more complex implementation code was cleaned up a little so hopefully, both maintenance and reliability both improve around that code.