### PR TITLE
Fix connection supervisor not being ready for connection check

### DIFF
--- a/lib/grizzly/supervisor.ex
+++ b/lib/grizzly/supervisor.ex
@@ -42,6 +42,7 @@ defmodule Grizzly.Supervisor do
   use Supervisor
 
   alias Grizzly.Options
+  alias Grizzly.ZIPGateway.ReadyChecker
 
   @typedoc """
   Arguments for running `Grizzly.Supervisor`
@@ -146,12 +147,21 @@ defmodule Grizzly.Supervisor do
       Grizzly.Commands.CommandRunnerSupervisor
     ]
     |> maybe_run_zipgateway_supervisor(options)
+    |> maybe_start_on_ready_checker(options)
   end
 
   defp maybe_run_zipgateway_supervisor(children, options) do
     if options.run_zipgateway do
       # Supervisor for the zipgateway binary
       [{Grizzly.ZIPGateway.Supervisor, options} | children]
+    else
+      children
+    end
+  end
+
+  defp maybe_start_on_ready_checker(children, opts) do
+    if opts.on_ready do
+      children ++ [{ReadyChecker, opts.on_ready}]
     else
       children
     end

--- a/lib/grizzly/zipgateway/supervisor.ex
+++ b/lib/grizzly/zipgateway/supervisor.ex
@@ -5,7 +5,7 @@ defmodule Grizzly.ZIPGateway.Supervisor do
   use Supervisor
 
   alias Grizzly.Options
-  alias Grizzly.ZIPGateway.{Config, ReadyChecker}
+  alias Grizzly.ZIPGateway.Config
 
   @spec start_link(Options.t()) :: Supervisor.on_start()
   def start_link(options) do
@@ -20,7 +20,6 @@ defmodule Grizzly.ZIPGateway.Supervisor do
   defp children(options) do
     if options.run_zipgateway do
       [make_zipgateway_child_spec(options)]
-      |> maybe_start_on_ready_checker(options)
     else
       []
     end
@@ -87,14 +86,6 @@ defmodule Grizzly.ZIPGateway.Supervisor do
 
       {:ok, _stat} ->
         :ok
-    end
-  end
-
-  defp maybe_start_on_ready_checker(children, opts) do
-    if opts.on_ready do
-      children ++ [{ReadyChecker, opts.on_ready}]
-    else
-      children
     end
   end
 end


### PR DESCRIPTION
When the argument `:on_ready` is passed to the Grizzly supervisor it
will start a process that polls the connection to the Z-Wave controller
node until it gets a connection to let the consuming application know
that it can now safety control devices.

This moved the checker down to the last process to start to ensure that
the connection supervisor was up and running able to start new
connections to devices.