### PR TITLE
Remove unnecessary logging

### DIFF
--- a/lib/grizzly/connection.ex
+++ b/lib/grizzly/connection.ex
@@ -44,7 +44,7 @@ defmodule Grizzly.Connection do
   @spec send_command(ZWave.node_id(), Command.t(), [Grizzly.command_opt()]) ::
           Grizzly.send_command_response()
   def send_command(node_id, command, opts \\ []) do
-    _ = Logger.debug("Sending: #{inspect(command)}")
+    _ = Logger.debug("Sending Cmd: #{inspect(command)}")
 
     case Keyword.get(opts, :type, :sync) do
       :sync ->

--- a/lib/grizzly/connections/sync_connection.ex
+++ b/lib/grizzly/connections/sync_connection.ex
@@ -119,7 +119,6 @@ defmodule Grizzly.Connections.SyncConnection do
   def handle_info(data, state) do
     case state.transport.parse_response(data) do
       {:ok, zip_packet} ->
-        _ = Logger.debug("Recv Z/IP Packet: #{inspect(zip_packet)}")
         new_state = handle_commands(zip_packet, state)
         {:noreply, new_state}
     end
@@ -130,6 +129,8 @@ defmodule Grizzly.Connections.SyncConnection do
   end
 
   defp handle_commands(zip_packet, state) do
+    _ = Logger.debug("Recv Z/IP Packet: #{inspect(zip_packet)}")
+
     case Command.param!(zip_packet, :flag) do
       :ack_request ->
         handle_ack_request(zip_packet, state)

--- a/lib/grizzly/transports/DTLS.ex
+++ b/lib/grizzly/transports/DTLS.ex
@@ -23,7 +23,6 @@ defmodule Grizzly.Transports.DTLS do
   @impl true
   def parse_response({:ssl, {:sslsocket, {:gen_udp, _, :dtls_connection}, _}, bin_list}) do
     binary = :erlang.list_to_binary(bin_list)
-    _ = Logger.debug("Z/IP Packet rec: #{inspect(binary, base: :hex)}")
 
     # TODO: handle errors
     {:ok, _result} = result = ZWave.from_binary(binary)


### PR DESCRIPTION
This removes the extra binary response from Z-Wave log and removes the keep-alive ack response.

A keep-alive message has to be sent every 25 seconds of inactivity of communication, which is 12 logs/5minutes if there is no communication. The number of logs every 5 minutes will go up by 12 for each device on the Z-Wave network. So, if you have just 3 devices on your network that would be 36 logs every 5 minutes.

This can cause things such as RingLogger to wrap and start losing log messages from the past rather quickly.