### PR TITLE
Refactor transport behaviour

### DIFF
--- a/lib/grizzly/supervisor.ex
+++ b/lib/grizzly/supervisor.ex
@@ -130,8 +130,8 @@ defmodule Grizzly.Supervisor do
 
       # TODO: move unsolicited server stuff to own supervisor
       Grizzly.UnsolicitedServer.Messages,
-      Grizzly.UnsolicitedServer,
       Grizzly.UnsolicitedServer.SocketSupervisor,
+      {Grizzly.UnsolicitedServer, options},
       ##########################
 
       # Supervisor for starting connections to Z-Wave nodes

--- a/lib/grizzly/transport.ex
+++ b/lib/grizzly/transport.ex
@@ -1,17 +1,152 @@
 defmodule Grizzly.Transport do
-  @moduledoc false
+  @moduledoc """
+  Behaviour and functions for communicating to `zipgateway`
+  """
+
+  defmodule Response do
+    @moduledoc """
+    The response from parse response
+    """
+
+    alias Grizzly.ZWave.Command
+
+    @type t() :: %__MODULE__{
+            port: :inet.port_number() | nil,
+            ip_address: :inet.ip_address() | nil,
+            command: Command.t()
+          }
+
+    @enforce_keys [:command]
+    defstruct port: nil, ip_address: nil, command: nil
+  end
 
   alias Grizzly.ZWave.{Command, DecodeError}
 
-  @type socket :: :ssl.sslsocket() | :inet.socket()
+  @opaque t() :: %__MODULE__{impl: module(), assigns: map()}
 
-  @callback open(:inet.ip_address(), :inet.port_number()) ::
-              {:ok, socket()} | {:error, :timeout}
+  @type socket() :: :ssl.sslsocket() | :inet.socket()
 
-  @callback send(socket(), binary()) :: :ok
+  @type args() :: [
+          ip_address: :inet.ip_address(),
+          port: :inet.port_number()
+        ]
+
+  @typedoc """
+  After starting a server options can be passed back to the caller so that the
+  caller can do any other work it might seem fit.
+
+  Options:
+
+    * - `:strategy` - this informs the caller if the transport needs to wait for
+        connects to accept or if the socket can just process incoming messages.
+        If the strategy is `:accept` that is to mean the socket is okay to start
+        accepting new connections.
+  """
+  @type listen_option() :: {:strategy, :none | :accept}
+
+  @enforce_keys [:impl]
+  defstruct assigns: %{}, impl: nil
+
+  @callback open(keyword()) :: {:ok, t()} | {:error, :timeout}
+
+  @callback listen(t()) :: {:ok, t(), [listen_option()]} | {:error, any()}
+
+  @callback accept(t()) :: {:ok, t()} | {:error, any()}
+
+  @callback handshake(t()) :: {:ok, t()} | {:error, any()}
+
+  @callback send(t(), binary()) :: :ok
 
   @callback parse_response(any()) ::
-              {:ok, Command.t()} | {:error, DecodeError.t()}
+              {:ok, Response.t()} | {:error, DecodeError.t()}
 
-  @callback close(socket()) :: :ok
+  @callback close(t()) :: :ok
+
+  @doc """
+  Make a new `Grizzly.Transport`
+
+  If need to optionally assign some priv data you can map that into this function.
+  """
+  @spec new(module(), map()) :: t()
+  def new(impl, assigns \\ %{}) do
+    %__MODULE__{
+      impl: impl,
+      assigns: assigns
+    }
+  end
+
+  @doc """
+  Update the assigns with this field and value
+  """
+  @spec assigns(t(), atom(), any()) :: t()
+  def assigns(transport, assign, assign_value) do
+    new_assigns = Map.put(transport.assigns, assign, assign_value)
+
+    %__MODULE__{transport | assigns: new_assigns}
+  end
+
+  @doc """
+  Get the assign value for the field
+  """
+  @spec assign(t(), atom(), any()) :: any()
+  def assign(transport, assign, default \\ nil),
+    do: Map.get(transport.assigns, assign, default)
+
+  @doc """
+  Listen using a transport
+  """
+  @spec listen(t()) :: {:ok, t(), [listen_option()]} | {:error, any()}
+  def listen(transport) do
+    %__MODULE__{impl: transport_impl} = transport
+
+    transport_impl.listen(transport)
+  end
+
+  @doc """
+  Accept a new connection
+  """
+  @spec accept(t()) :: {:ok, t()} | {:error, any()}
+  def accept(transport) do
+    %__MODULE__{impl: transport_impl} = transport
+
+    transport_impl.accept(transport)
+  end
+
+  @doc """
+  Preform the handshake
+  """
+  @spec handshake(t()) :: {:ok, t()} | {:error, any()}
+  def handshake(transport) do
+    %__MODULE__{impl: transport_impl} = transport
+
+    transport_impl.handshake(transport)
+  end
+
+  @doc """
+  Open the transport
+  """
+  @spec open(module(), args()) :: {:ok, t()} | {:error, :timeout}
+  def open(transport_module, args) do
+    transport_module.open(args)
+  end
+
+  @doc """
+  Send binary data using a transport
+  """
+  @spec send(t(), binary()) :: :ok
+  def send(transport, binary) do
+    %__MODULE__{impl: transport_impl} = transport
+
+    transport_impl.send(transport, binary)
+  end
+
+  @doc """
+  Parse the response for the transport
+  """
+  @spec parse_response(t(), any()) :: {:ok, Response.t()} | {:error, DecodeError.t()}
+  def parse_response(transport, response) do
+    %__MODULE__{impl: transport_impl} = transport
+
+    transport_impl.parse_response(response)
+  end
 end

--- a/lib/grizzly/transports/UDP.ex
+++ b/lib/grizzly/transports/UDP.ex
@@ -1,0 +1,69 @@
+defmodule Grizzly.Transports.UDP do
+  @moduledoc """
+  Grizzly transport implementation for UDP
+  """
+  @behaviour Grizzly.Transport
+
+  alias Grizzly.{Transport, ZWave}
+  alias Grizzly.Transport.Response
+
+  @impl Grizzly.Transport
+  def open(args) do
+    priv = Enum.into(args, %{})
+
+    case :gen_udp.open(4000, [:binary, {:active, true}, :inet6]) do
+      {:ok, socket} ->
+        {:ok, Transport.new(__MODULE__, Map.put(priv, :socket, socket))}
+
+      error ->
+        error
+    end
+  end
+
+  @impl Transport
+  def listen(transport) do
+    {:ok, transport, strategy: :none}
+  end
+
+  @impl Transport
+  def accept(transport) do
+    {:ok, transport}
+  end
+
+  @impl Transport
+  def handshake(transport) do
+    {:ok, transport}
+  end
+
+  @impl Grizzly.Transport
+  def send(transport, binary) do
+    host = Transport.assign(transport, :ip_address)
+    port = Transport.assign(transport, :port)
+
+    transport
+    |> Transport.assign(:socket)
+    |> :gen_udp.send(host, port, binary)
+  end
+
+  @impl Grizzly.Transport
+  def parse_response({:udp, _, ip_address, _, binary}) do
+    case ZWave.from_binary(binary) do
+      {:ok, command} ->
+        {:ok,
+         %Response{
+           ip_address: ip_address,
+           command: command
+         }}
+
+      error ->
+        error
+    end
+  end
+
+  @impl Grizzly.Transport
+  def close(transport) do
+    transport
+    |> Transport.assign(:socket)
+    |> :gen_udp.close()
+  end
+end

--- a/lib/grizzly/unsolicited_server.ex
+++ b/lib/grizzly/unsolicited_server.ex
@@ -4,73 +4,55 @@ defmodule Grizzly.UnsolicitedServer do
 
   require Logger
 
-  alias Grizzly.ZIPGateway
+  alias Grizzly.{Options, Transport, ZIPGateway}
   alias Grizzly.UnsolicitedServer.SocketSupervisor
 
-  defmodule State do
-    @moduledoc false
-    defstruct ip_address: nil, socket: nil
-  end
-
-  def start_link(_) do
-    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  @spec start_link(Options.t()) :: GenServer.on_start()
+  def start_link(grizzly_opts) do
+    GenServer.start_link(__MODULE__, grizzly_opts, name: __MODULE__)
   end
 
   @impl true
-  def init(_) do
-    {:ok, %State{ip_address: ZIPGateway.unsolicited_server_ip()}, {:continue, :listen}}
+  def init(grizzly_opts) do
+    transport =
+      Transport.new(grizzly_opts.transport, %{
+        ip_address: ZIPGateway.unsolicited_server_ip(),
+        port: 41230
+      })
+
+    {:ok, transport, {:continue, :listen}}
   end
 
   @impl true
-  def handle_continue(:listen, state) do
-    case ssl_listen(state.ip_address) do
-      {:ok, listensocket} ->
-        start_accepting_sockets(listensocket)
-        {:noreply, %{state | socket: nil}}
+  def handle_continue(:listen, transport) do
+    case listen(transport) do
+      {:ok, listening_transport, listen_opts} ->
+        maybe_start_accept_sockets(listening_transport, listen_opts)
+        {:noreply, transport}
 
       _error ->
         # wait 2 seconds to try again
         _ = Logger.warn("[Grizzly]: Unsolicited server unable to listen")
         :timer.sleep(2000)
-        {:noreply, state, {:continue, :listen}}
+        {:noreply, transport, {:continue, :listen}}
     end
   end
 
-  def ssl_listen(ip_address) do
+  def listen(transport) do
     try do
-      :ssl.listen(41230, opts(ip_address))
+      Transport.listen(transport)
     rescue
       error -> error
     end
   end
 
-  def start_accepting_sockets(listensocket) do
-    Enum.each(1..10, fn _ -> SocketSupervisor.start_socket(listensocket) end)
+  def maybe_start_accept_sockets(listening_transport, listen_opts) do
+    case Keyword.get(listen_opts, :strategy) do
+      :accept ->
+        Enum.each(1..10, fn _ -> SocketSupervisor.start_socket(listening_transport) end)
+
+      :none ->
+        :ok
+    end
   end
-
-  def user_lookup(:psk, _username, userstate), do: {:ok, userstate}
-
-  def opts(ip_address) do
-    [
-      :binary,
-      {:ssl_imp, :new},
-      {:active, true},
-      {:verify, :verify_none},
-      {:versions, [:dtlsv1]},
-      {:protocol, :dtls},
-      {:ciphers, [{:psk, :aes_128_cbc, :sha}]},
-      {:psk_identity, 'Client_identity'},
-      {:user_lookup_fun,
-       {&user_lookup/3,
-        <<0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56, 0x78,
-          0x90, 0xAA>>}},
-      {:cb_info, {:gen_udp, :udp, :udp_close, :udp_error}},
-      ip_version_from_address(ip_address),
-      {:ifaddr, ip_address}
-    ]
-  end
-
-  # move to ZIPPacket
-  defp ip_version_from_address({_, _, _, _}), do: :inet
-  defp ip_version_from_address({_, _, _, _, _, _, _, _}), do: :inet6
 end

--- a/lib/grizzly/unsolicited_server/socket_supervisor.ex
+++ b/lib/grizzly/unsolicited_server/socket_supervisor.ex
@@ -2,15 +2,16 @@ defmodule Grizzly.UnsolicitedServer.SocketSupervisor do
   @moduledoc false
   use DynamicSupervisor
 
+  alias Grizzly.Transport
   alias Grizzly.UnsolicitedServer.Socket
 
   def start_link(_) do
     DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
-  @spec start_socket(:ssl.sslsocket()) :: DynamicSupervisor.on_start_child()
-  def start_socket(ssl_listen_sock) do
-    child_spec = Socket.child_spec(ssl_listen_sock)
+  @spec start_socket(Transport.t()) :: DynamicSupervisor.on_start_child()
+  def start_socket(transport) do
+    child_spec = Socket.child_spec(transport)
 
     __MODULE__
     |> DynamicSupervisor.start_child(child_spec)

--- a/test/grizzly/unsolicited_server/messages_test.exs
+++ b/test/grizzly/unsolicited_server/messages_test.exs
@@ -1,7 +1,7 @@
 defmodule Grizzly.UnsolicitedServer.MessagesTest do
   use ExUnit.Case
 
-  alias Grizzly.{Report, ZWave}
+  alias Grizzly.Report
   alias Grizzly.ZWave.Commands.{SwitchBinaryGet, ZIPPacket}
   alias Grizzly.UnsolicitedServer.Messages
 
@@ -13,7 +13,7 @@ defmodule Grizzly.UnsolicitedServer.MessagesTest do
 
     Messages.broadcast(
       {0, 0, 0, 2},
-      ZWave.to_binary(zip_packet)
+      zip_packet
     )
 
     assert_receive {:grizzly, :report, %Report{} = report}, 500


### PR DESCRIPTION
Refactor transport for these reason:

1. Support more than just DTLS
1. Allows for local development against the unsolicited server (useful for testing extra command support)
1. Has the unsolicited server and main connections use the same transport - cleans up duplicate code
1. Will allow with experimenting with disabling DTLS in the future