### PR TITLE
Support sending ack responses in the unsolicated server

### DIFF
--- a/lib/grizzly/transport.ex
+++ b/lib/grizzly/transport.ex
@@ -55,7 +55,7 @@ defmodule Grizzly.Transport do
 
   @callback handshake(t()) :: {:ok, t()} | {:error, any()}
 
-  @callback send(t(), binary()) :: :ok
+  @callback send(t(), binary(), keyword()) :: :ok
 
   @callback parse_response(any()) ::
               {:ok, Response.t()} | {:error, DecodeError.t()}
@@ -133,11 +133,11 @@ defmodule Grizzly.Transport do
   @doc """
   Send binary data using a transport
   """
-  @spec send(t(), binary()) :: :ok
-  def send(transport, binary) do
+  @spec send(t(), binary(), keyword()) :: :ok
+  def send(transport, binary, opts \\ []) do
     %__MODULE__{impl: transport_impl} = transport
 
-    transport_impl.send(transport, binary)
+    transport_impl.send(transport, binary, opts)
   end
 
   @doc """

--- a/lib/grizzly/transports/DTLS.ex
+++ b/lib/grizzly/transports/DTLS.ex
@@ -25,7 +25,7 @@ defmodule Grizzly.Transports.DTLS do
   end
 
   @impl Grizzly.Transport
-  def send(transport, binary) do
+  def send(transport, binary, _) do
     socket = Transport.assign(transport, :socket)
     :ssl.send(socket, binary)
   end

--- a/lib/grizzly/transports/UDP.ex
+++ b/lib/grizzly/transports/UDP.ex
@@ -44,7 +44,7 @@ defmodule Grizzly.Transports.UDP do
   end
 
   @impl Grizzly.Transport
-  def send(transport, binary) do
+  def send(transport, binary, []) do
     host = Transport.assign(transport, :ip_address)
     port = Transport.assign(transport, :port)
 
@@ -53,13 +53,22 @@ defmodule Grizzly.Transports.UDP do
     |> :gen_udp.send(host, port, binary)
   end
 
+  def send(transport, binary, opts) do
+    {ip_address, port} = Keyword.fetch!(opts, :to)
+
+    transport
+    |> Transport.assign(:socket)
+    |> :gen_udp.send(ip_address, port, binary)
+  end
+
   @impl Grizzly.Transport
-  def parse_response({:udp, _, ip_address, _, binary}) do
+  def parse_response({:udp, _, ip_address, port, binary}) do
     case ZWave.from_binary(binary) do
       {:ok, command} ->
         {:ok,
          %Response{
            ip_address: ip_address,
+           port: port,
            command: command
          }}
 

--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -1,0 +1,25 @@
+defmodule Grizzly.UnsolicitedServer.ResponseHandler do
+  @moduledoc false
+
+  alias Grizzly.Transport
+  alias Grizzly.UnsolicitedServer.Messages
+  alias Grizzly.ZWave
+  alias Grizzly.ZWave.Command
+  alias Grizzly.ZWave.Commands.ZIPPacket
+
+  @spec handle_response(Transport.t(), Transport.Response.t()) :: :ok
+  def handle_response(transport, response) do
+    case Command.param!(response.command, :flag) do
+      :ack_request ->
+        seq_number = Command.param!(response.command, :seq_number)
+        command = ZIPPacket.make_ack_response(seq_number)
+
+        binary = ZWave.to_binary(command)
+
+        :ok = Transport.send(transport, binary, to: {response.ip_address, response.port})
+
+      _ ->
+        :ok = Messages.broadcast(response.ip_address, response.command)
+    end
+  end
+end

--- a/lib/grizzly/unsolicited_server/socket.ex
+++ b/lib/grizzly/unsolicited_server/socket.ex
@@ -6,7 +6,7 @@ defmodule Grizzly.UnsolicitedServer.Socket do
   require Logger
 
   alias Grizzly.Transport
-  alias Grizzly.UnsolicitedServer.{SocketSupervisor, Messages}
+  alias Grizzly.UnsolicitedServer.{SocketSupervisor, ResponseHandler}
 
   @spec child_spec(Transport.t()) :: map()
   def child_spec(transport) do
@@ -52,7 +52,7 @@ defmodule Grizzly.UnsolicitedServer.Socket do
   def handle_info(response, transport) do
     case Transport.parse_response(transport, response) do
       {:ok, %Transport.Response{} = transport_response} ->
-        :ok = Messages.broadcast(transport_response.ip_address, transport_response.command)
+        ResponseHandler.handle_response(transport, transport_response)
         {:noreply, transport}
     end
   end

--- a/test/support/UDP.ex
+++ b/test/support/UDP.ex
@@ -33,7 +33,7 @@ defmodule GrizzlyTest.Transport.UDP do
   def handshake(transport), do: {:ok, transport}
 
   @impl Grizzly.Transport
-  def send(transport, binary) do
+  def send(transport, binary, _) do
     transport
     |> Transport.assign(:socket)
     |> :gen_udp.send(@test_host, @test_port, binary)


### PR DESCRIPTION
If we have a command sent to us from another device on the network with the `:ack_request` flag we have to respond to the command with the `:ack_response` packet per Z-Wave spec.