### PR TITLE
Handle when the association get command is received via PAN

### DIFF
--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -1,25 +1,62 @@
 defmodule Grizzly.UnsolicitedServer.ResponseHandler do
   @moduledoc false
 
+  # module helper for handling various different responses from the Z-Wave PAN
+  # network
+
+  alias Grizzly.SeqNumber
   alias Grizzly.Transport
   alias Grizzly.UnsolicitedServer.Messages
   alias Grizzly.ZWave
   alias Grizzly.ZWave.Command
-  alias Grizzly.ZWave.Commands.ZIPPacket
+  alias Grizzly.ZWave.Commands.{AssociationReport, ZIPPacket}
 
+  @doc """
+  When a transport receives a response from the Z-Wave network handle it
+  and send any other commands back over the Z-Wave PAN if needed
+  """
   @spec handle_response(Transport.t(), Transport.Response.t()) :: :ok
   def handle_response(transport, response) do
     case Command.param!(response.command, :flag) do
       :ack_request ->
         seq_number = Command.param!(response.command, :seq_number)
         command = ZIPPacket.make_ack_response(seq_number)
-
         binary = ZWave.to_binary(command)
 
         :ok = Transport.send(transport, binary, to: {response.ip_address, response.port})
+        :ok = maybe_handle_extra_command(transport, response)
 
       _ ->
         :ok = Messages.broadcast(response.ip_address, response.command)
     end
   end
+
+  defp maybe_handle_extra_command(transport, response) do
+    internal_command = Command.param!(response.command, :command)
+
+    case handle_command(internal_command) do
+      {:ok, zip_packet} ->
+        binary = ZWave.to_binary(zip_packet)
+        Transport.send(transport, binary, to: {response.ip_address, response.port})
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp handle_command(%Command{name: :association_get} = command) do
+    grouping_identifier = Command.param!(command, :grouping_identifier)
+    seq_number = SeqNumber.get_and_inc()
+
+    {:ok, association_report} =
+      AssociationReport.new(
+        grouping_identifier: grouping_identifier,
+        max_nodes_supported: 1,
+        nodes: []
+      )
+
+    ZIPPacket.with_zwave_command(association_report, seq_number, flag: nil)
+  end
+
+  defp handle_command(_command), do: :ok
 end

--- a/lib/grizzly/zwave/commands/zip_packet.ex
+++ b/lib/grizzly/zwave/commands/zip_packet.ex
@@ -22,7 +22,7 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket do
 
   @type param ::
           {:command, Command.t() | nil}
-          | {:flag, flag()}
+          | {:flag, flag() | nil}
           | {:seq_number, ZWave.seq_number()}
           | {:source, ZWave.node_id()}
           | {:dest, ZWave.node_id()}


### PR DESCRIPTION
This is the first pass at this functionality as when we can handle the
association set command we will actually send really data back.

This is mostly meant to help stub out the code for support more commands
from the Z-Wave PAN and some basic support for association get.