### PR TITLE
Fix missing code markdown ` in docs

### DIFF
--- a/lib/grizzly/zwave/commands/switch_binary_report.ex
+++ b/lib/grizzly/zwave/commands/switch_binary_report.ex
@@ -4,7 +4,7 @@ defmodule Grizzly.ZWave.Commands.SwitchBinaryReport do
 
   Params:
 
-    * `:target_value` - `:on`, :off`, or `:unknown` (required)
+    * `:target_value` - `:on`, `:off`, or `:unknown` (required)
     * `:duration` - 0-255 (required V2)
     * `:current_value` - `:on`, `:off`, or `:unknown` (required V2)
   """


### PR DESCRIPTION
This was creating warnings in when running `mix docs` and causing the
docs layout to break for the `SwitchBinaryReport` doc page.