### PR TITLE
Refactor extra command handling

### DIFF
--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -6,44 +6,48 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
 
   require Logger
 
-  alias Grizzly.SeqNumber
   alias Grizzly.Transport
-  alias Grizzly.{Associations, SeqNumber, Transport, ZWave}
-  alias Grizzly.UnsolicitedServer.Messages
+  alias Grizzly.{Associations, ZWave}
   alias Grizzly.ZWave.Command
 
   alias Grizzly.ZWave.Commands.{
     AssociationReport,
     AssociationGroupingsReport,
-    AssociationSpecificGroupReport,
-    ZIPPacket
+    AssociationSpecificGroupReport
   }
+
+  @type opt() :: {:association_server, GenServer.name()}
+
+  @type handle_response_result() :: :ok | {:notify, Command.t()} | {:send, Command.t()}
 
   @doc """
   When a transport receives a response from the Z-Wave network handle it
   and send any other commands back over the Z-Wave PAN if needed
   """
-  @spec handle_response(Transport.t(), Transport.Response.t()) :: :ok
-  def handle_response(transport, response) do
+  @spec handle_response(Transport.Response.t(), [opt()]) :: handle_response_result()
+  def handle_response(response, opts \\ []) do
     internal_command = Command.param!(response.command, :command)
 
-    case handle_command(internal_command) do
-      {:ok, zip_packet} ->
-        binary = ZWave.to_binary(zip_packet)
-        Transport.send(transport, binary, to: {response.ip_address, response.port})
+    case handle_command(internal_command, opts) do
+      {:ok, command} ->
+        # binary = ZWave.to_binary(zip_packet)
+        # Transport.send(transport, binary, to: {response.ip_address, response.port})
+        {:send, command}
 
       :notification ->
-        :ok = Messages.broadcast(response.ip_address, response.command)
+        # :ok = Messages.broadcast(response.ip_address, response.command)
+        {:notify, internal_command}
 
       {:notification, command} ->
-        :ok = Messages.broadcast(response.ip_address, command)
+        # :ok = Messages.broadcast(response.ip_address, command)
+        {:notify, command}
 
       :ok ->
         :ok
     end
   end
 
-  defp handle_command(%Command{name: :supervision_get} = command) do
+  defp handle_command(%Command{name: :supervision_get} = command, _) do
     encapsulated_command = Command.param!(command, :encapsulated_command)
 
     case ZWave.from_binary(encapsulated_command) do
@@ -61,33 +65,37 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     end
   end
 
-  defp handle_command(%Command{name: :association_specific_group_get}) do
-    seq_number = SeqNumber.get_and_inc()
-    {:ok, report} = AssociationSpecificGroupReport.new(group: 0)
-
-    ZIPPacket.with_zwave_command(report, seq_number)
+  defp handle_command(%Command{name: :association_specific_group_get}, _) do
+    AssociationSpecificGroupReport.new(group: 0)
   end
 
-  defp handle_command(%Command{name: :association_get}) do
-    seq_number = SeqNumber.get_and_inc()
+  defp handle_command(%Command{name: :association_get}, opts) do
     # According the the Z-Wave specification if a get request contains an
     # unsupported grouping identifier then we should report back the grouping
     # information for group number 1. Since right now we only support that
     # group we don't need to check because we will always just send back the
     # grouping information for group id 1.
-    association = Associations.get(1)
+    associations_server = Keyword.get(opts, :associations_server, Associations)
 
-    {:ok, association_report} =
-      AssociationReport.new(
-        grouping_identifier: association.grouping_identifier,
-        max_nodes_supported: 1,
-        nodes: association.nodes
-      )
+    case Associations.get(associations_server, 1) do
+      nil ->
+        AssociationReport.new(
+          grouping_identifier: 1,
+          max_nodes_supported: 1,
+          nodes: []
+        )
 
-    ZIPPacket.with_zwave_command(association_report, seq_number, flag: nil)
+      association ->
+        AssociationReport.new(
+          grouping_identifier: association.grouping_id,
+          max_nodes_supported: 1,
+          nodes: association.node_ids
+        )
+    end
   end
 
-  defp handle_command(%Command{name: :association_set} = command) do
+  defp handle_command(%Command{name: :association_set} = command, opts) do
+    associations_server = Keyword.get(opts, :associations_server, Associations)
     grouping_identifier = Command.param!(command, :grouping_identifier)
 
     # According the Z-Wave specification we should just ignore grouping ids that
@@ -95,21 +103,18 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     # if the command contains something other than one we will just move along.
     if grouping_identifier == 1 do
       nodes = Command.param!(command, :nodes)
-      Associations.save(grouping_identifier, nodes)
+      Associations.save(associations_server, grouping_identifier, nodes)
     else
       :ok
     end
   end
 
-  defp handle_command(%Command{name: :association_groupings_get}) do
-    seq_number = SeqNumber.get_and_inc()
-
-    {:ok, groupings_report} = AssociationGroupingsReport.new(supported_groupings: 1)
-
-    ZIPPacket.with_zwave_command(groupings_report, seq_number, flag: nil)
+  defp handle_command(%Command{name: :association_groupings_get}, _opts) do
+    AssociationGroupingsReport.new(supported_groupings: 1)
   end
 
-  defp handle_command(%Command{name: :association_remove} = command) do
+  defp handle_command(%Command{name: :association_remove} = command, opts) do
+    associations_server = Keyword.get(opts, :associations_server, Associations)
     grouping_id = Command.param!(command, :grouping_identifier)
     nodes = Command.param!(command, :nodes)
 
@@ -121,21 +126,21 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     # specification.
     case {grouping_id, nodes} do
       {1, []} ->
-        Associations.delete_all_nodes_from_grouping(grouping_id)
+        Associations.delete_all_nodes_from_grouping(associations_server, grouping_id)
 
       {1, nodes} ->
-        Associations.delete_nodes_from_grouping(grouping_id, nodes)
+        Associations.delete_nodes_from_grouping(associations_server, grouping_id, nodes)
 
       {0, []} ->
-        Associations.delete_all()
+        Associations.delete_all(associations_server)
 
       {0, nodes} ->
-        Associations.delete_nodes_from_all_groupings(nodes)
+        Associations.delete_nodes_from_all_groupings(associations_server, nodes)
 
       _ ->
         :ok
     end
   end
 
-  defp handle_command(_command), do: :notification
+  defp handle_command(_command, _opts), do: :notification
 end

--- a/test/grizzly/unsolicited_server/response_handler_test.exs
+++ b/test/grizzly/unsolicited_server/response_handler_test.exs
@@ -1,0 +1,107 @@
+defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.{Associations, Options, ZWave}
+  alias Grizzly.UnsolicitedServer.ResponseHandler
+  alias Grizzly.Transport.Response
+  alias Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.Commands.{
+    AssociationGet,
+    AssociationGroupingsGet,
+    AssociationSet,
+    AssociationSpecificGroupGet,
+    SupervisionGet,
+    SwitchBinaryReport,
+    ZIPPacket
+  }
+
+  setup do
+    options = %Options{associations_file: "/tmp/response_handler_assocs"}
+    {:ok, _} = Associations.start_link(options, name: :response_handler_assocs)
+
+    on_exit(fn ->
+      File.rm("/tmp/response_handler_assocs")
+    end)
+
+    {:ok, %{assoc_server: :response_handler_assocs}}
+  end
+
+  test "handle supervision get" do
+    {:ok, report} = SwitchBinaryReport.new(target_value: :on)
+
+    {:ok, supervision_get} =
+      SupervisionGet.new(
+        encapsulated_command: ZWave.to_binary(report),
+        session_id: 1,
+        status_updates: :one_now
+      )
+
+    response = make_response(supervision_get)
+
+    assert {:notify, report} == ResponseHandler.handle_response(response)
+  end
+
+  test "handle non-extra command" do
+    {:ok, report} = SwitchBinaryReport.new(target_value: :off)
+    response = make_response(report)
+
+    assert {:notify, report} == ResponseHandler.handle_response(response)
+  end
+
+  test "handle association specific group get" do
+    {:ok, asgg} = AssociationSpecificGroupGet.new()
+
+    response = make_response(asgg)
+
+    assert {:send, asgr} = ResponseHandler.handle_response(response)
+
+    assert asgr.name == :association_specific_group_report
+    assert Command.param!(asgr, :group) == 0
+  end
+
+  test "handle association get for known support grouping identifier", %{assoc_server: server} do
+    {:ok, assoc_get} = AssociationGet.new(grouping_identifier: 1)
+
+    response = make_response(assoc_get)
+
+    assert {:send, assoc_report} =
+             ResponseHandler.handle_response(response, associations_server: server)
+
+    assert assoc_report.name == :association_report
+    assert Command.param!(assoc_report, :grouping_identifier) == 1
+  end
+
+  test "handles association get for an unknown grouping identifier", %{assoc_server: server} do
+    {:ok, assoc_get} = AssociationGet.new(grouping_identifier: 100)
+
+    response = make_response(assoc_get)
+
+    assert {:send, assoc_report} =
+             ResponseHandler.handle_response(response, associations_server: server)
+
+    assert assoc_report.name == :association_report
+    # should return the lifeline grouping if the requested identifier is unknown
+    assert Command.param!(assoc_report, :grouping_identifier) == 1
+  end
+
+  test "handle association set", %{assoc_server: server} do
+    {:ok, assoc_set} = AssociationSet.new(grouping_identifier: 1, nodes: [1, 2, 3])
+
+    response = make_response(assoc_set)
+
+    assert :ok == ResponseHandler.handle_response(response, associations_server: server)
+  end
+
+  test "handle association groupings get" do
+    {:ok, agg} = AssociationGroupingsGet.new()
+    assert {:send, agr} = ResponseHandler.handle_response(make_response(agg))
+
+    assert agr.name == :association_groupings_report
+  end
+
+  defp make_response(command) do
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(command, 1)
+    %Response{port: 1234, ip_address: {0, 0, 0, 0}, command: zip_packet}
+  end
+end


### PR DESCRIPTION
This refactor allows for the testability of how Grizzly responses to
extra commands. Responding to extra commands correctly is important and
as such should be tested. Plus, some of the code became a bit hard to
reason about thus causing more risk to maintain.

This transforms the unsolicited server response handler to return data
structures rather than handling the broadcasting of notifications or
sending binary data to the Z-Wave network.

Also, makes an option for providing the associations server as an option
and allows for us to make testing more reproducible and limits the
amount of runtime dependencies.