### PR TITLE
Send device reset notification

### DIFF
--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -280,7 +280,9 @@ defmodule Grizzly.Commands.Table do
       {:powerlevel_test_node_get,
        {Commands.PowerlevelTestNodeGet,
         handler: {WaitReport, complete_report: :powerlevel_test_node_report}}},
-      {:powerlevel_test_node_set, {Commands.PowerlevelTestNodeSet, handler: AckResponse}}
+      {:powerlevel_test_node_set, {Commands.PowerlevelTestNodeSet, handler: AckResponse}},
+      {:device_reset_locally_notification,
+       {Commands.DeviceResetLocallyNotification, handler: AckResponse}}
     ]
 
     defmacro __before_compile__(_) do


### PR DESCRIPTION
When the device Grizzly is running on network is reset, we have to send
the `DeviceResetNotification` command to the nodes that associated with
the lifeline association.