### PR TITLE
Support AssociationGroupNameGet in unsolicited server

### DIFF
--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -13,6 +13,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
   alias Grizzly.ZWave.Commands.{
     AssociationReport,
     AssociationGroupingsReport,
+    AssociationGroupNameReport,
     AssociationSpecificGroupReport
   }
 
@@ -140,6 +141,12 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
       _ ->
         :ok
     end
+  end
+
+  defp handle_command(%Command{name: :association_group_name_get}, _opts) do
+    # Always just return the lifeline group (group_id == 1) as of right now
+    # because that is all that Grizzly supports right now.
+    AssociationGroupNameReport.new(group_id: 1, name: "Lifeline")
   end
 
   defp handle_command(_command, _opts), do: :notification

--- a/lib/grizzly/zwave/commands/association_group_name_get.ex
+++ b/lib/grizzly/zwave/commands/association_group_name_get.ex
@@ -13,9 +13,10 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupNameGet do
   alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.CommandClasses.AssociationGroupInfo
 
-  @type param :: {:group_id, byte}
+  @type param() :: {:group_id, byte}
 
   @impl true
+  @spec new([param()]) :: {:ok, Command.t()}
   def new(params) do
     command = %Command{
       name: :association_group_name_get,

--- a/lib/grizzly/zwave/commands/association_group_name_report.ex
+++ b/lib/grizzly/zwave/commands/association_group_name_report.ex
@@ -5,7 +5,6 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupNameReport do
   Params:
 
     * `:group_id` - the group id
-
     * `:name` - the group's name
 
   """
@@ -15,9 +14,10 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupNameReport do
   alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.CommandClasses.AssociationGroupInfo
 
-  @type param :: {:group_id, byte} | {:name, String.t()}
+  @type param() :: {:group_id, byte} | {:name, String.t()}
 
   @impl true
+  @spec new([param()]) :: {:ok, Command.t()}
   def new(params) do
     command = %Command{
       name: :association_group_name_report,

--- a/test/grizzly/unsolicited_server/response_handler_test.exs
+++ b/test/grizzly/unsolicited_server/response_handler_test.exs
@@ -9,6 +9,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
   alias Grizzly.ZWave.Commands.{
     AssociationGet,
     AssociationGroupingsGet,
+    AssociationGroupNameGet,
     AssociationSet,
     AssociationSpecificGroupGet,
     SupervisionGet,
@@ -98,6 +99,27 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
     assert {:send, agr} = ResponseHandler.handle_response(make_response(agg))
 
     assert agr.name == :association_groupings_report
+  end
+
+  describe "association group" do
+    test "name get - known group (lifeline)" do
+      {:ok, agng} = AssociationGroupNameGet.new(group_id: 1)
+      assert {:send, agnr} = ResponseHandler.handle_response(make_response(agng))
+
+      assert agnr.name == :association_group_name_report
+      assert Command.param!(agnr, :group_id) == 1
+      assert Command.param!(agnr, :name) == "Lifeline"
+    end
+
+    test "name get - unknown group" do
+      {:ok, agng} = AssociationGroupNameGet.new(group_id: 123)
+
+      assert {:send, agnr} = ResponseHandler.handle_response(make_response(agng))
+
+      assert agnr.name == :association_group_name_report
+      assert Command.param!(agnr, :group_id) == 1
+      assert Command.param!(agnr, :name) == "Lifeline"
+    end
   end
 
   defp make_response(command) do


### PR DESCRIPTION
When a node requests an association group name we respond with the name
report for the lifeline association.

If the `group_id` name requested is not supported we are to respond with
the name report for the lifeline association. As of right now we are
going to support only the lifeline association so this codes will always
return with the lifeline association name.

Also, so nitpick clean up that has no effect on code functionality.