### PR TITLE
Refactor ResponseHandler to return a list of actions to run

### DIFF
--- a/lib/grizzly/unsolicited_server.ex
+++ b/lib/grizzly/unsolicited_server.ex
@@ -57,26 +57,29 @@ defmodule Grizzly.UnsolicitedServer do
 
     case Transport.parse_response(transport, message) do
       {:ok, transport_response} ->
-        %Transport.Response{ip_address: ip_address, port: port} = transport_response
-
         case ResponseHandler.handle_response(transport_response) do
-          :ok ->
+          [] ->
             :ok
 
-          {:send, command} ->
-            {:ok, zip_packet} =
-              ZIPPacket.with_zwave_command(command, SeqNumber.get_and_inc(), flag: nil)
-
-            binary = ZWave.to_binary(zip_packet)
-
-            Transport.send(transport, binary, to: {ip_address, port})
-
-          {:notify, command} ->
-            :ok = Messages.broadcast(transport_response.ip_address, command)
+          actions ->
+            Enum.each(actions, &run_response_action(transport, transport_response, &1))
         end
 
         {:noreply, state}
     end
+  end
+
+  defp run_response_action(transport, response, {:send, command}) do
+    %Transport.Response{ip_address: ip_address, port: port} = response
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(command, SeqNumber.get_and_inc(), flag: nil)
+
+    binary = ZWave.to_binary(zip_packet)
+
+    Transport.send(transport, binary, to: {ip_address, port})
+  end
+
+  defp run_response_action(_transport, response, {:notify, command}) do
+    :ok = Messages.broadcast(response.ip_address, command)
   end
 
   def listen(transport) do

--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -19,13 +19,13 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
 
   @type opt() :: {:association_server, GenServer.name()}
 
-  @type handle_response_result() :: :ok | {:notify, Command.t()} | {:send, Command.t()}
+  @type action() :: {:notify, Command.t()} | {:send, Command.t()}
 
   @doc """
   When a transport receives a response from the Z-Wave network handle it
   and send any other commands back over the Z-Wave PAN if needed
   """
-  @spec handle_response(Transport.Response.t(), [opt()]) :: handle_response_result()
+  @spec handle_response(Transport.Response.t(), [opt()]) :: [action()]
   def handle_response(response, opts \\ []) do
     internal_command = Command.param!(response.command, :command)
 
@@ -33,18 +33,18 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
       {:ok, command} ->
         # binary = ZWave.to_binary(zip_packet)
         # Transport.send(transport, binary, to: {response.ip_address, response.port})
-        {:send, command}
+        [{:send, command}]
 
       :notification ->
         # :ok = Messages.broadcast(response.ip_address, response.command)
-        {:notify, internal_command}
+        [{:notify, internal_command}]
 
       {:notification, command} ->
         # :ok = Messages.broadcast(response.ip_address, command)
-        {:notify, command}
+        [{:notify, command}]
 
       :ok ->
-        :ok
+        []
     end
   end
 

--- a/test/grizzly/unsolicited_server/response_handler_test.exs
+++ b/test/grizzly/unsolicited_server/response_handler_test.exs
@@ -40,14 +40,14 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
 
     response = make_response(supervision_get)
 
-    assert {:notify, report} == ResponseHandler.handle_response(response)
+    assert [{:notify, report}] == ResponseHandler.handle_response(response)
   end
 
   test "handle non-extra command" do
     {:ok, report} = SwitchBinaryReport.new(target_value: :off)
     response = make_response(report)
 
-    assert {:notify, report} == ResponseHandler.handle_response(response)
+    assert [{:notify, report}] == ResponseHandler.handle_response(response)
   end
 
   test "handle association specific group get" do
@@ -55,7 +55,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
 
     response = make_response(asgg)
 
-    assert {:send, asgr} = ResponseHandler.handle_response(response)
+    assert [{:send, asgr}] = ResponseHandler.handle_response(response)
 
     assert asgr.name == :association_specific_group_report
     assert Command.param!(asgr, :group) == 0
@@ -66,7 +66,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
 
     response = make_response(assoc_get)
 
-    assert {:send, assoc_report} =
+    assert [{:send, assoc_report}] =
              ResponseHandler.handle_response(response, associations_server: server)
 
     assert assoc_report.name == :association_report
@@ -78,7 +78,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
 
     response = make_response(assoc_get)
 
-    assert {:send, assoc_report} =
+    assert [{:send, assoc_report}] =
              ResponseHandler.handle_response(response, associations_server: server)
 
     assert assoc_report.name == :association_report
@@ -91,12 +91,12 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
 
     response = make_response(assoc_set)
 
-    assert :ok == ResponseHandler.handle_response(response, associations_server: server)
+    assert [] == ResponseHandler.handle_response(response, associations_server: server)
   end
 
   test "handle association groupings get" do
     {:ok, agg} = AssociationGroupingsGet.new()
-    assert {:send, agr} = ResponseHandler.handle_response(make_response(agg))
+    assert [{:send, agr}] = ResponseHandler.handle_response(make_response(agg))
 
     assert agr.name == :association_groupings_report
   end
@@ -104,7 +104,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
   describe "association group" do
     test "name get - known group (lifeline)" do
       {:ok, agng} = AssociationGroupNameGet.new(group_id: 1)
-      assert {:send, agnr} = ResponseHandler.handle_response(make_response(agng))
+      assert [{:send, agnr}] = ResponseHandler.handle_response(make_response(agng))
 
       assert agnr.name == :association_group_name_report
       assert Command.param!(agnr, :group_id) == 1
@@ -114,7 +114,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
     test "name get - unknown group" do
       {:ok, agng} = AssociationGroupNameGet.new(group_id: 123)
 
-      assert {:send, agnr} = ResponseHandler.handle_response(make_response(agng))
+      assert [{:send, agnr}] = ResponseHandler.handle_response(make_response(agng))
 
       assert agnr.name == :association_group_name_report
       assert Command.param!(agnr, :group_id) == 1


### PR DESCRIPTION
This will allow support for some commands that will need to have many
things happen after we handle it. For example the supervision get
command will need Grizzly to both notify any listeners and reply back
with the supervision report command.

Right now there is some code duplication. I hope this gets cleaned up
with future refactors and as we learn more how to better support these
extra commands.