### PR TITLE
Support supervision get command fully for unsolicited server

### DIFF
--- a/lib/grizzly/zwave/commands/supervision_get.ex
+++ b/lib/grizzly/zwave/commands/supervision_get.ex
@@ -7,9 +7,7 @@ defmodule Grizzly.ZWave.Commands.SupervisionGet do
 
     * `:status_updates` - used to allow a receiving node to advertise application status updates in future Supervision
                           Report Commands (required)
-
     * `:session_id` - used to detect redundant invocations due to retransmissions (required)
-
     * `:encapsulated_command` - an encapsulated command  (required) -see ZWave Transport Encapsulation Command Class Specifications
 
   """

--- a/lib/grizzly/zwave/commands/supervision_report.ex
+++ b/lib/grizzly/zwave/commands/supervision_report.ex
@@ -5,14 +5,10 @@ defmodule Grizzly.ZWave.Commands.SupervisionReport do
   Params:
 
     * `:more_status_updates` - used to advertise if more Supervision Reports follow for the actual Session ID (required)
-
     * `:session_id` - carries the same value as the Session ID field of the Supervision Get Command which
                       initiated this session (required)
-
     * `:status` - the current status of the command process, one of :no_support, :working, :fail or :success (required)
-
     * `:duration` - the time in seconds needed to complete the current operation (required)
-
   """
 
   @behaviour Grizzly.ZWave.Command
@@ -20,14 +16,16 @@ defmodule Grizzly.ZWave.Commands.SupervisionReport do
   alias Grizzly.ZWave.{Command, DecodeError}
   alias Grizzly.ZWave.CommandClasses.Supervision
 
-  @type more_status_updates :: :last_report | :more_reports
-  @type status :: :no_support | :working | :fail | :success
-  @type param ::
+  @type more_status_updates() :: :last_report | :more_reports
+  @type status() :: :no_support | :working | :fail | :success
+  @type param() ::
           {:more_status_updates, more_status_updates}
           | {:status, status}
           | {:duration, :unknown | non_neg_integer()}
+          | {:session_id, byte()}
 
   @impl true
+  @spec new([param()]) :: {:ok, Command.t()}
   def new(params) do
     command = %Command{
       name: :supervision_report,


### PR DESCRIPTION
When the unsolicited command for supervision get, we use to just notify
listeners of the internal command that was sent, now we reply back with
the `SupervisionReport` command as outlined in the Z-Wave spec.

Also, did some clean up and switched the private functions in the
`ResponseHandler` module to return the `actions` list as outlined in the
type spec.