### PR TITLE
Support multi command encapsulated in unsolicited server

### DIFF
--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -7,7 +7,7 @@ defmodule Grizzly.Commands.Table do
 
   defmodule Generate do
     @moduledoc false
-    alias Grizzly.CommandHandlers.{AckResponse, WaitReport, AggregateReport}
+    alias Grizzly.CommandHandlers.{AckResponse, AggregateReport, WaitReport}
 
     alias Grizzly.ZWave.Commands
 

--- a/lib/grizzly/unsolicited_server.ex
+++ b/lib/grizzly/unsolicited_server.ex
@@ -4,7 +4,7 @@ defmodule Grizzly.UnsolicitedServer do
 
   require Logger
 
-  alias Grizzly.{Options, SeqNumber, Transport, ZWave}
+  alias Grizzly.{Options, Report, SeqNumber, Transport, ZWave}
   alias Grizzly.ZWave.Commands.ZIPPacket
   alias Grizzly.UnsolicitedServer.{SocketSupervisor, ResponseHandler, Messages}
 
@@ -80,6 +80,34 @@ defmodule Grizzly.UnsolicitedServer do
 
   defp run_response_action(_transport, response, {:notify, command}) do
     :ok = Messages.broadcast(response.ip_address, command)
+  end
+
+  defp run_response_action(transport, response, {:forward_to_controller, command}) do
+    case Grizzly.send_command(1, command.name, command.params) do
+      {:ok, report} ->
+        handle_grizzly_report(report, transport, response)
+
+      error ->
+        error
+    end
+  end
+
+  defp handle_grizzly_report(%Report{type: :ack_response}, transport, response) do
+    %Transport.Response{ip_address: ip_address, port: port} = response
+    zip_packet = ZIPPacket.make_ack_response(SeqNumber.get_and_inc())
+
+    binary = ZWave.to_binary(zip_packet)
+
+    Transport.send(transport, binary, to: {ip_address, port})
+  end
+
+  defp handle_grizzly_report(%Report{type: :command, command: command}, transport, response) do
+    %Transport.Response{ip_address: ip_address, port: port} = response
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(command, SeqNumber.get_and_inc(), flag: nil)
+
+    binary = ZWave.to_binary(zip_packet)
+
+    Transport.send(transport, binary, to: {ip_address, port})
   end
 
   def listen(transport) do


### PR DESCRIPTION
This supports when the unsolicited server receives the multi command
encapsulated command.

It will inspect each command that in encapsulated.

If the command is part of the extra command classes we will pass that
long to the handler_command function for that command.

If the command is the `:alarm_report` we will still notify. We have to
provide this explicitly because we explicitly check the command against
the extra command classes so we are not blindly calling
`handler_command/2` function.

If the command does not meet either of those requirements we will tell
whoever is calling this function that they should pass it to the Z-Wave
controller (Z/IP Gateway) and send the report back that requesting node.