### PR TITLE
Support responding to AssociationGroupInfoGet via unsolicited server

### DIFF
--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -14,6 +14,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     AssociationReport,
     AssociationGroupingsReport,
     AssociationGroupNameReport,
+    AssociationGroupInfoReport,
     AssociationSpecificGroupReport,
     SupervisionReport
   }
@@ -157,12 +158,23 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     end
   end
 
+  defp handle_command(%Command{name: :association_group_info_get}, _opts) do
+    {:ok, report} =
+      AssociationGroupInfoReport.new(
+        dynamic: false,
+        groups_info: [[group_id: 1, profile: :general_lifeline]]
+      )
+
+    [{:send, report}]
+  end
+
   defp handle_command(%Command{name: :multi_command_encapsulated} = command, opts) do
     commands = Command.param!(command, :commands)
 
     extra_commands = [
       :supervision_get,
       :association_group_name_get,
+      :association_group_info_get,
       :association_get,
       :association_set,
       :association_remove,

--- a/lib/grizzly/zwave/commands/association_group_info_get.ex
+++ b/lib/grizzly/zwave/commands/association_group_info_get.ex
@@ -5,9 +5,7 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupInfoGet do
   Params:
 
     * `:refresh_cache` - Whether to refresh cached info
-
     * `:all` - Get info on all assocation groups
-
     * `:group_id` - get info on this association group (required if `all` is false)
 
   """

--- a/lib/grizzly/zwave/commands/association_group_info_report.ex
+++ b/lib/grizzly/zwave/commands/association_group_info_report.ex
@@ -14,8 +14,8 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupInfoReport do
   alias Grizzly.ZWave.{Command, DecodeError}
   alias Grizzly.ZWave.CommandClasses.AssociationGroupInfo
 
-  @type group_info :: [group_id: byte, profile: atom]
-  @type param :: {:groups_info, [group_info]} | {:dynamic, boolean}
+  @type group_info() :: [group_id: byte(), profile: atom()]
+  @type param() :: {:groups_info, [group_info()]} | {:dynamic, boolean()}
 
   @impl true
   @spec new([param()]) :: {:ok, Command.t()}

--- a/test/grizzly/unsolicited_server/response_handler_test.exs
+++ b/test/grizzly/unsolicited_server/response_handler_test.exs
@@ -10,6 +10,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
     AssociationGet,
     AssociationGroupingsGet,
     AssociationGroupNameGet,
+    AssociationGroupInfoGet,
     AssociationSet,
     AssociationSpecificGroupGet,
     SupervisionGet,
@@ -104,6 +105,16 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
       assert agnr.name == :association_group_name_report
       assert Command.param!(agnr, :group_id) == 1
       assert Command.param!(agnr, :name) == "Lifeline"
+    end
+
+    test "info get" do
+      {:ok, agig} =
+        AssociationGroupInfoGet.new(refresh_cache: false, group_id: 1, refresh_cache: false)
+
+      assert [{:send, agir}] = ResponseHandler.handle_response(make_response(agig))
+
+      assert agir.name == :association_group_info_report
+      assert Command.param!(agir, :groups_info) == [[group_id: 1, profile: :general_lifeline]]
     end
   end
 


### PR DESCRIPTION
When the command for getting association group info comes in we response
by send the lifeline group info.