### PR TITLE
AssociationGroupCommandListGet support on unsolicited server

### DIFF
--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -14,6 +14,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     AssociationReport,
     AssociationGroupingsReport,
     AssociationGroupNameReport,
+    AssociationGroupCommandListReport,
     AssociationGroupInfoReport,
     AssociationSpecificGroupReport,
     SupervisionReport
@@ -168,11 +169,22 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     [{:send, report}]
   end
 
+  defp handle_command(%Command{name: :association_group_command_list_get}, _opts) do
+    {:ok, report} =
+      AssociationGroupCommandListReport.new(
+        group_id: 0x01,
+        commands: [:device_reset_locally_notification]
+      )
+
+    [{:send, report}]
+  end
+
   defp handle_command(%Command{name: :multi_command_encapsulated} = command, opts) do
     commands = Command.param!(command, :commands)
 
     extra_commands = [
       :supervision_get,
+      :association_group_command_list_get,
       :association_group_name_get,
       :association_group_info_get,
       :association_get,

--- a/lib/grizzly/zwave/commands/association_group_command_list_get.ex
+++ b/lib/grizzly/zwave/commands/association_group_command_list_get.ex
@@ -6,9 +6,7 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupCommandListGet do
 
     * `:allow_cache` - This field indicates that a Z-Wave Gateway device is allowed to intercept the request and return a
                        cached response on behalf of the specified target. (required)
-
     * `:group_id` - The group identifier (required)
-
   """
 
   @behaviour Grizzly.ZWave.Command
@@ -16,7 +14,7 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupCommandListGet do
   alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.CommandClasses.AssociationGroupInfo
 
-  @type param :: {:allow_cache, boolean} | {:group_id, byte}
+  @type param() :: {:allow_cache, boolean()} | {:group_id, byte()}
 
   @impl true
   @spec new([param()]) :: {:ok, Command.t()}

--- a/lib/grizzly/zwave/commands/association_group_command_list_report.ex
+++ b/lib/grizzly/zwave/commands/association_group_command_list_report.ex
@@ -5,9 +5,7 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupCommandListReport do
   Params:
 
     * `:group_id` - the group identifier
-
     * `:commands` - lists of commands
-
   """
 
   @behaviour Grizzly.ZWave.Command
@@ -18,7 +16,7 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupCommandListReport do
 
   require Logger
 
-  @type param :: {:group_id, byte} | {:commands, [atom]}
+  @type param() :: {:group_id, byte()} | {:commands, [atom()]}
 
   @impl true
   def new(params) do

--- a/test/grizzly/unsolicited_server/response_handler_test.exs
+++ b/test/grizzly/unsolicited_server/response_handler_test.exs
@@ -11,6 +11,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
     AssociationGroupingsGet,
     AssociationGroupNameGet,
     AssociationGroupInfoGet,
+    AssociationGroupCommandListGet,
     AssociationSet,
     AssociationSpecificGroupGet,
     SupervisionGet,
@@ -115,6 +116,15 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
 
       assert agir.name == :association_group_info_report
       assert Command.param!(agir, :groups_info) == [[group_id: 1, profile: :general_lifeline]]
+    end
+
+    test "command list get" do
+      {:ok, agclg} = AssociationGroupCommandListGet.new(cache_allowed: false, group_id: 1)
+
+      assert [{:send, agclr}] = ResponseHandler.handle_response(make_response(agclg))
+
+      assert agclr.name == :association_group_command_list_report
+      assert Command.param!(agclr, :commands) == [:device_reset_locally_notification]
     end
   end
 


### PR DESCRIPTION
Support when the `AssociationGroupCommandListGet` command is sent to the
unsolicited server.

It will always respond with the command list for the lifeline group as
of right we only support that group.