### PR TITLE
Add support for the multi channel association grouping get

### DIFF
--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -17,6 +17,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     AssociationGroupCommandListReport,
     AssociationGroupInfoReport,
     AssociationSpecificGroupReport,
+    MultiChannelAssociationGroupingsReport,
     SupervisionReport
   }
 
@@ -179,6 +180,12 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     [{:send, report}]
   end
 
+  defp handle_command(%Command{name: :multi_channel_association_groupings_get}, _opts) do
+    {:ok, report} = MultiChannelAssociationGroupingsReport.new(supported_groupings: 1)
+
+    [{:send, report}]
+  end
+
   defp handle_command(%Command{name: :multi_command_encapsulated} = command, opts) do
     commands = Command.param!(command, :commands)
 
@@ -191,7 +198,8 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
       :association_set,
       :association_remove,
       :association_groupings_get,
-      :association_specific_group_get
+      :association_specific_group_get,
+      :multi_channel_association_groupings_get
     ]
 
     Enum.reduce(commands, [], fn cmd, actions ->

--- a/lib/grizzly/zwave/commands/multi_channel_association_groupings_get.ex
+++ b/lib/grizzly/zwave/commands/multi_channel_association_groupings_get.ex
@@ -12,7 +12,7 @@ defmodule Grizzly.ZWave.Commands.MultiChannelAssociationGroupingsGet do
   alias Grizzly.ZWave.CommandClasses.MultiChannelAssociation
 
   @impl true
-  def new(params) do
+  def new(params \\ []) do
     command = %Command{
       name: :multi_channel_association_groupings_get,
       command_byte: 0x05,

--- a/lib/grizzly/zwave/commands/multi_channel_association_groupings_report.ex
+++ b/lib/grizzly/zwave/commands/multi_channel_association_groupings_report.ex
@@ -14,7 +14,7 @@ defmodule Grizzly.ZWave.Commands.MultiChannelAssociationGroupingsReport do
   alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.CommandClasses.MultiChannelAssociation
 
-  @type param :: {:supported_groupings, byte()}
+  @type param() :: {:supported_groupings, byte()}
 
   @impl true
   @spec new([param()]) :: {:ok, Command.t()}

--- a/test/grizzly/unsolicited_server/response_handler_test.exs
+++ b/test/grizzly/unsolicited_server/response_handler_test.exs
@@ -14,6 +14,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
     AssociationGroupCommandListGet,
     AssociationSet,
     AssociationSpecificGroupGet,
+    MultiChannelAssociationGroupingsGet,
     SupervisionGet,
     SwitchBinaryReport,
     ZIPPacket
@@ -146,6 +147,18 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
       assert Command.param!(report, :session_id) == 11
       assert Command.param!(report, :more_status_updates) == :last_report
       assert Command.param!(report, :status) == :success
+    end
+  end
+
+  describe "multi channel association" do
+    test "groupings get" do
+      {:ok, mcagg} = MultiChannelAssociationGroupingsGet.new()
+
+      assert [{:send, mcagr}] = ResponseHandler.handle_response(make_response(mcagg))
+
+      assert mcagr.name == :multi_channel_association_groupings_report
+
+      assert Command.param!(mcagr, :supported_groupings) == 1
     end
   end
 


### PR DESCRIPTION
Unsolicited server will responding with the
`MultiChannelAssociationGroupingsGet` command with the report that
grouping `1` is support. As of right now that is the only grouping we
are trying to support.