### PR TITLE
Support the multi channel association get, set, remove handling

### DIFF
--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -18,6 +18,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     AssociationGroupInfoReport,
     AssociationSpecificGroupReport,
     MultiChannelAssociationGroupingsReport,
+    MultiChannelAssociationReport,
     SupervisionReport
   }
 
@@ -186,6 +187,84 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     [{:send, report}]
   end
 
+  defp handle_command(%Command{name: :multi_channel_association_get}, opts) do
+    # According the the Z-Wave specification if a get request contains an
+    # unsupported grouping identifier then we should report back the grouping
+    # information for group number 1. Since right now we only support that
+    # group we don't need to check because we will always just send back the
+    # grouping information for group id 1.
+    associations_server = Keyword.get(opts, :associations_server, Associations)
+
+    {:ok, respond_with_command} =
+      case Associations.get(associations_server, 1) do
+        nil ->
+          MultiChannelAssociationReport.new(
+            grouping_identifier: 1,
+            max_nodes_supported: 1,
+            nodes: []
+          )
+
+        association ->
+          MultiChannelAssociationReport.new(
+            grouping_identifier: association.grouping_id,
+            max_nodes_supported: 1,
+            nodes: association.node_ids
+          )
+      end
+
+    [{:send, respond_with_command}]
+  end
+
+  defp handle_command(%Command{name: :multi_channel_association_set} = command, opts) do
+    associations_server = Keyword.get(opts, :associations_server, Associations)
+    grouping_identifier = Command.param!(command, :grouping_identifier)
+
+    # According the Z-Wave specification we should just ignore grouping ids that
+    # we don't support. As of right now we are only supporting grouping id 1, so
+    # if the command contains something other than one we will just move along.
+    if grouping_identifier == 1 do
+      nodes = Command.param!(command, :nodes)
+      :ok = Associations.save(associations_server, grouping_identifier, nodes)
+    end
+
+    []
+  end
+
+  defp handle_command(%Command{name: :multi_channel_association_remove} = command, opts) do
+    associations_server = Keyword.get(opts, :associations_server, Associations)
+    grouping_id = Command.param!(command, :grouping_identifier)
+    nodes = Command.param!(command, :nodes)
+
+    # This case matching is based off a table from the Z-Wave specification
+    # Right now we only have one association grouping, so the first and third
+    # match are the same right now. I want to keep the matching explicit right
+    # now as I hope it will enable quicker understand to any future work that
+    # will be as it maps nicely to the documentation found in the Z-Wave
+    # specification.
+    case {grouping_id, nodes} do
+      {1, []} ->
+        :ok = Associations.delete_all_nodes_from_grouping(associations_server, grouping_id)
+        []
+
+      {1, nodes} ->
+        case Associations.delete_nodes_from_grouping(associations_server, grouping_id, nodes) do
+          :ok -> []
+          error -> error
+        end
+
+      {0, []} ->
+        :ok = Associations.delete_all(associations_server)
+        []
+
+      {0, nodes} ->
+        :ok = Associations.delete_nodes_from_all_groupings(associations_server, nodes)
+        []
+
+      _ ->
+        []
+    end
+  end
+
   defp handle_command(%Command{name: :multi_command_encapsulated} = command, opts) do
     commands = Command.param!(command, :commands)
 
@@ -199,7 +278,10 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
       :association_remove,
       :association_groupings_get,
       :association_specific_group_get,
-      :multi_channel_association_groupings_get
+      :multi_channel_association_groupings_get,
+      :multi_channel_association_set,
+      :multi_channel_association_get,
+      :multi_channel_association_remove
     ]
 
     Enum.reduce(commands, [], fn cmd, actions ->

--- a/lib/grizzly/zwave/commands/multi_channel_association_get.ex
+++ b/lib/grizzly/zwave/commands/multi_channel_association_get.ex
@@ -5,7 +5,6 @@ defmodule Grizzly.ZWave.Commands.MultiChannelAssociationGet do
   Params:
 
     * `:grouping_identifier` - the actual association group
-
   """
 
   @behaviour Grizzly.ZWave.Command
@@ -13,10 +12,10 @@ defmodule Grizzly.ZWave.Commands.MultiChannelAssociationGet do
   alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.CommandClasses.MultiChannelAssociation
 
-  @type param :: {:grouping_identifier, byte()}
+  @type param() :: {:grouping_identifier, byte()}
 
   @impl true
-  @spec new([param]) :: {:ok, Command.t()}
+  @spec new([param()]) :: {:ok, Command.t()}
   def new(params) do
     command = %Command{
       name: :multi_channel_association_get,

--- a/lib/grizzly/zwave/commands/multi_channel_association_remove.ex
+++ b/lib/grizzly/zwave/commands/multi_channel_association_remove.ex
@@ -6,11 +6,8 @@ defmodule Grizzly.ZWave.Commands.MultiChannelAssociationRemove do
   Params:
 
    * `:grouping_identifier` - the association grouping identifier (required)
-
-    * `:nodes` - list of nodes to add the grouping identifier (required)
-
-    * `:node_endpoints` - Endpoints of multichannel nodes
-
+   * `:nodes` - list of nodes to add the grouping identifier (required)
+   * `:node_endpoints` - Endpoints of multichannel nodes
   """
 
   @behaviour Grizzly.ZWave.Command
@@ -19,7 +16,7 @@ defmodule Grizzly.ZWave.Commands.MultiChannelAssociationRemove do
   alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.CommandClasses.MultiChannelAssociation
 
-  @type param ::
+  @type param() ::
           {:grouping_identifier, byte()}
           | {:nodes, [ZWave.node_id()]}
           | {:node_endpoints, [MultiChannelAssociation.node_endpoint()]}

--- a/lib/grizzly/zwave/commands/multi_channel_association_report.ex
+++ b/lib/grizzly/zwave/commands/multi_channel_association_report.ex
@@ -5,16 +5,12 @@ defmodule Grizzly.ZWave.Commands.MultiChannelAssociationReport do
   Params:
 
     * `:grouping_identifier` - the association grouping identifier (required)
-
     * `:max_nodes_supported` - the maximum number of destinations supported by the advertised association group. Each destination
                                may be a NodeID destination or an End Point destination.
-
     * `:reports_to_follow` - if the full destination list is too long for one
                              report this field reports the number of follow up reports (optional
                              default `0`)
-
     * `:nodes` - list of nodes to add the grouping identifier (required)
-
     * `:node_endpoints` - Endpoints of multichannel nodes
 
   """
@@ -25,7 +21,7 @@ defmodule Grizzly.ZWave.Commands.MultiChannelAssociationReport do
   alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.CommandClasses.MultiChannelAssociation
 
-  @type param ::
+  @type param() ::
           {:grouping_identifier, byte()}
           | {:max_nodes_supported, byte()}
           | {:reports_to_follow, byte()}

--- a/lib/grizzly/zwave/commands/multi_channel_association_set.ex
+++ b/lib/grizzly/zwave/commands/multi_channel_association_set.ex
@@ -6,11 +6,8 @@ defmodule Grizzly.ZWave.Commands.MultiChannelAssociationSet do
   Params:
 
     * `:grouping_identifier` - the association grouping identifier (required)
-
     * `:nodes` - list of nodes to add the grouping identifier (required)
-
     * `:node_endpoints` - Endpoints of multichannel nodes
-
   """
 
   @behaviour Grizzly.ZWave.Command


### PR DESCRIPTION
This supports the multi channel association commands get, set, and
remove handling in the unsolicited server.

This assumes right now that the device using Grizzly does not support
multi channels and if I understand the specification correctly that
means we are to mirror how we support this in the non-multi channel
association command class.

There is some duplicate code here however, after more testing I will
imagine that code will be cleaned up as we get a better understanding of
the specification.