### PR TITLE
Support sending binary packets

### DIFF
--- a/lib/grizzly/connection.ex
+++ b/lib/grizzly/connection.ex
@@ -4,11 +4,11 @@ defmodule Grizzly.Connection do
   require Logger
 
   alias Grizzly.Connections.Supervisor
-  alias Grizzly.Connections.{SyncConnection, AsyncConnection}
+  alias Grizzly.Connections.{BinaryConnection, SyncConnection, AsyncConnection}
   alias Grizzly.ZWave
   alias Grizzly.ZWave.Command
 
-  @type opt() :: {:mode, :sync | :async} | {:owner, pid()}
+  @type opt() :: {:mode, :sync | :async | :binary} | {:owner, pid()}
 
   @doc """
   Open a connection to a node
@@ -53,5 +53,12 @@ defmodule Grizzly.Connection do
       :async ->
         AsyncConnection.send_command(node_id, command, opts)
     end
+  end
+
+  def send_binary(node_id, binary, opts \\ []) do
+    base = Keyword.get(opts, :format, :hex)
+    _ = Logger.debug("Sending binary: #{inspect(binary, base: base)}")
+
+    BinaryConnection.send_binary(node_id, binary)
   end
 end

--- a/lib/grizzly/connection_registry.ex
+++ b/lib/grizzly/connection_registry.ex
@@ -1,7 +1,11 @@
 defmodule Grizzly.ConnectionRegistry do
   @moduledoc false
 
-  @spec via_name(Grizzly.node_id() | {:async, Grizzly.node_id()} | pid()) ::
+  alias Grizzly.ZWave
+
+  @type name() :: ZWave.node_id() | {:async, ZWave.node_id()} | {:binary, ZWave.node_id(), pid()}
+
+  @spec via_name(name()) ::
           {:via, Registry, {__MODULE__, Grizzly.node_id()}} | pid()
   def via_name(pid) when is_pid(pid), do: pid
 

--- a/lib/grizzly/connections/binary_connection.ex
+++ b/lib/grizzly/connections/binary_connection.ex
@@ -1,0 +1,91 @@
+defmodule Grizzly.Connections.BinaryConnection do
+  @moduledoc false
+
+  # A special connection that only handles send and receiving binary data
+  # This connection works when using `Grizzly.send_binary/2` by using the
+  # the calling process as part of the GenServer name to ensure that many
+  # calling sites can send these commands to the same node id with getting
+  # each other's messages.
+
+  # As of right now this connection won't use keep alive and will close it self
+  # after 25 seconds of inactivity. For the known use cases for this connection
+  # the behavior is ideal. Namely debugging and quick one off commands like when
+  # another device asks us something about our device.
+
+  use GenServer
+
+  alias Grizzly.{Connections, Options, Transport, ZIPGateway, ZWave}
+
+  defmodule State do
+    @moduledoc false
+
+    @enforce_keys [:transport, :owner]
+    defstruct transport: nil, owner: nil
+  end
+
+  def child_spec(node_id, opts) do
+    %{id: __MODULE__, start: {__MODULE__, :start_link, [node_id, opts]}, restart: :transient}
+  end
+
+  @doc """
+  Start the BinaryConnection
+  """
+  @spec start_link(Options.t(), ZWave.node_id(), keyword()) :: GenServer.on_start()
+  def start_link(grizzly_options, node_id, opts) do
+    owner = Keyword.fetch!(opts, :owner)
+    name = Connections.make_name({:binary, node_id, owner})
+    GenServer.start_link(__MODULE__, [grizzly_options, node_id, owner], name: name)
+  end
+
+  @doc """
+  Send a binary packet to the Z-Wave node
+  """
+  @spec send_binary(ZWave.node_id(), binary()) :: :ok
+  def send_binary(node_id, binary) do
+    name = Connections.make_name({:binary, node_id, self()})
+    GenServer.call(name, {:send_binary, binary})
+  end
+
+  @impl GenServer
+  def init([grizzly_options, node_id, owner]) do
+    host = ZIPGateway.host_for_node(node_id, grizzly_options)
+    transport_impl = grizzly_options.transport
+
+    transport_opts = [
+      ip_address: host,
+      port: grizzly_options.zipgateway_port
+    ]
+
+    case Transport.open(transport_impl, transport_opts) do
+      {:ok, transport} ->
+        {:ok,
+         %State{
+           transport: transport,
+           owner: owner
+         }}
+
+      {:error, :timeout} ->
+        {:stop, :timeout}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:send_binary, binary}, _from, state) do
+    %State{transport: transport} = state
+
+    Transport.send(transport, binary)
+
+    {:reply, :ok, state}
+  end
+
+  @impl GenServer
+  def handle_info(data, state) do
+    %State{transport: transport, owner: owner} = state
+
+    case Transport.parse_response(transport, data, raw: true) do
+      {:ok, binary} ->
+        send(owner, {:grizzly, :binary_response, binary})
+        {:noreply, state}
+    end
+  end
+end

--- a/lib/grizzly/connections/supervisor.ex
+++ b/lib/grizzly/connections/supervisor.ex
@@ -3,7 +3,7 @@ defmodule Grizzly.Connections.Supervisor do
   use DynamicSupervisor
 
   alias Grizzly.{Connection, Options, ZWave}
-  alias Grizzly.Connections.{AsyncConnection, SyncConnection}
+  alias Grizzly.Connections.{AsyncConnection, BinaryConnection, SyncConnection}
 
   @spec start_link(Options.t()) :: Supervisor.on_start()
   def start_link(options) do
@@ -22,6 +22,9 @@ defmodule Grizzly.Connections.Supervisor do
 
       :sync ->
         do_start_connection(SyncConnection, node_id)
+
+      :binary ->
+        do_start_connection(BinaryConnection, node_id, owner: self())
     end
   end
 

--- a/lib/grizzly/transport.ex
+++ b/lib/grizzly/transport.ex
@@ -31,6 +31,8 @@ defmodule Grizzly.Transport do
           port: :inet.port_number()
         ]
 
+  @type parse_opt() :: {:raw, boolean()}
+
   @typedoc """
   After starting a server options can be passed back to the caller so that the
   caller can do any other work it might seem fit.
@@ -57,8 +59,8 @@ defmodule Grizzly.Transport do
 
   @callback send(t(), binary(), keyword()) :: :ok
 
-  @callback parse_response(any()) ::
-              {:ok, Response.t()} | {:error, DecodeError.t()}
+  @callback parse_response(any(), [parse_opt()]) ::
+              {:ok, Response.t()} | {:error, DecodeError.t()} | {:ok, binary()}
 
   @callback close(t()) :: :ok
 
@@ -144,9 +146,9 @@ defmodule Grizzly.Transport do
   Parse the response for the transport
   """
   @spec parse_response(t(), any()) :: {:ok, Response.t()} | {:error, DecodeError.t()}
-  def parse_response(transport, response) do
+  def parse_response(transport, response, opts \\ []) do
     %__MODULE__{impl: transport_impl} = transport
 
-    transport_impl.parse_response(response)
+    transport_impl.parse_response(response, opts)
   end
 end

--- a/lib/grizzly/transports/UDP.ex
+++ b/lib/grizzly/transports/UDP.ex
@@ -62,8 +62,11 @@ defmodule Grizzly.Transports.UDP do
   end
 
   @impl Grizzly.Transport
-  def parse_response({:udp, _, ip_address, port, binary}) do
-    case ZWave.from_binary(binary) do
+  def parse_response({:udp, _, ip_address, port, binary}, opts) do
+    case parse_zip_packet(binary, opts) do
+      {:ok, bin} when is_binary(bin) ->
+        {:ok, bin}
+
       {:ok, command} ->
         {:ok,
          %Response{
@@ -74,6 +77,14 @@ defmodule Grizzly.Transports.UDP do
 
       error ->
         error
+    end
+  end
+
+  defp parse_zip_packet(bin, opts) do
+    if Keyword.get(opts, :raw, false) do
+      {:ok, bin}
+    else
+      ZWave.from_binary(bin)
     end
   end
 

--- a/test/support/UDP.ex
+++ b/test/support/UDP.ex
@@ -40,10 +40,14 @@ defmodule GrizzlyTest.Transport.UDP do
   end
 
   @impl Grizzly.Transport
-  def parse_response({:udp, _, ip, _, binary}) do
-    case ZWave.from_binary(binary) do
-      {:ok, command} ->
-        {:ok, %Response{ip_address: ip, command: command}}
+  def parse_response({:udp, _, ip, _, binary}, opts) do
+    if Keyword.get(opts, :raw, false) do
+      {:ok, binary}
+    else
+      case ZWave.from_binary(binary) do
+        {:ok, command} ->
+          {:ok, %Response{ip_address: ip, command: command}}
+      end
     end
   end
 


### PR DESCRIPTION
This adds support for sending binary packets to a Z-Wave node.

This will enable control over packets that do not have a long lived
life cycle such as debugging packets and communication with other Z-Wave
nodes that send us commands.