### PR TITLE
Don't crash when :crc16 is passed for Z-Wave security

### DIFF
--- a/lib/grizzly/zwave/commands/zip_packet/header_extensions/encapsulation_format_info.ex
+++ b/lib/grizzly/zwave/commands/zip_packet/header_extensions/encapsulation_format_info.ex
@@ -19,6 +19,7 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions.EncapsulationFormatI
   def security_to_security_to_byte(:s2_authenticated), do: 0x02
   def security_to_security_to_byte(:s2_access_control), do: 0x04
   def security_to_security_to_byte(:s0), do: 0x80
+  def security_to_security_to_byte(_not_security), do: 0x00
 
   def to_binary(security_classes) do
     security_class_byte =


### PR DESCRIPTION
This was happening when including a GE Jasco Z-Wave Plug-in Outdoor
Smart Switch and preventing it to complete successfully. Here's the
exception:

```
** (FunctionClauseError) no function clause matching in Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions.EncapsulationFormatInfo.security_to_security_to_byte/1
    (grizzly 0.15.6) lib/grizzly/zwave/commands/zip_packet/header_extensions/encapsulation_format_info.ex:17: Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions.EncapsulationFormatInfo.security_to_security_to_byte(:crc16)
    (grizzly 0.15.6) lib/grizzly/zwave/commands/zip_packet/header_extensions/encapsulation_format_info.ex:26: anonymous fn/2 in Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions.EncapsulationFormatInfo.to_binary/1
    (elixir 1.11.2) lib/enum.ex:2181: Enum."-reduce/3-lists^foldl/2-0-"/3
    (grizzly 0.15.6) lib/grizzly/zwave/commands/zip_packet/header_extensions/encapsulation_format_info.ex:25: Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions.EncapsulationFormatInfo.to_binary/1
    (grizzly 0.15.6) lib/grizzly/zwave/commands/zip_packet/header_extensions.ex:41: anonymous fn/2 in Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions.to_binary/1
    (elixir 1.11.2) lib/enum.ex:2181: Enum."-reduce/3-lists^foldl/2-0-"/3
    (grizzly 0.15.6) lib/grizzly/zwave/commands/zip_packet.ex:196: Grizzly.ZWave.Commands.ZIPPacket.maybe_add_header_extensions/2
    (grizzly 0.15.6) lib/grizzly/zwave/commands/zip_packet.ex:69: Grizzly.ZWave.Commands.ZIPPacket.encode_params/1
Last message: {:ssl, {:sslsocket, {:gen_udp, #Port<0.11012>, :dtls_connection}, [#PID<0.2855.6>]}, [35, 2, 128, 208, 209, 0, 0, 5, 132, 2, 0, 1, 134, 20, 122, 2]}
State: %Grizzly.Connections.SyncConnection.State{commands: %Grizzly.Connections.CommandList{commands: [{#PID<0.2857.6>, {#PID<0.2856.6>, #Reference<0.2669937355.3223060481.186154>}, #Reference<0.2669937355.3223060481.186156>}], keep_alive_command: nil}, keep_alive: %Grizzly.Connections.KeepAlive{command_runner: nil, interval: 25000, last_send: nil, node_id: 35, owner: #PID<0.2853.6>, ref: #Reference<0.2669937355.3223060481.186215>}, transport: %Grizzly.Transport{assigns: %{port: 41230, socket: {:sslsocket, {:gen_udp, #Port<0.11012>, :dtls_connection}, [#PID<0.2855.6>]}}, impl: Grizzly.Transports.DTLS}}
```

I'm not sure that this is the right fix since I didn't understand why
`:crc16` was being passed here. However, making this change did make it
possible for me to include the switch.