### PR TITLE
Fix when using crc16 in the Encapsulation Info header extension

### DIFF
--- a/test/grizzly/zwave/commands/zip_packet/header_extensions_test.exs
+++ b/test/grizzly/zwave/commands/zip_packet/header_extensions_test.exs
@@ -2,6 +2,7 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensionsTest do
   use ExUnit.Case, async: true
 
   alias Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions
+  alias Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions.EncapsulationFormatInfo
 
   test "parses for expected delay" do
     header_ext = HeaderExtensions.from_binary(<<0x01, 0x03, 0x00, 0x00, 0x01>>)
@@ -27,8 +28,15 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensionsTest do
   test "parses encapsulation format info" do
     info_binary = <<0x84, 0x02, 0x80, 0x01>>
     header_ext = HeaderExtensions.from_binary(info_binary)
+    encap_info = %EncapsulationFormatInfo{security_classes: [:s0], crc16: true}
 
-    assert [{:encapsulation_format_info, [:crc16, :s0]}] == header_ext
+    assert [{:encapsulation_format_info, encap_info}] == header_ext
+  end
+
+  test "makes the encapsulation format info into a binary" do
+    encapinfo = EncapsulationFormatInfo.new(:non_secure, true)
+
+    assert <<0x84, 0x02, 0x00, 0x01>> == EncapsulationFormatInfo.to_binary(encapinfo)
   end
 
   test "parse multicast addressing" do


### PR DESCRIPTION
From #396  I learned that the `crc16` flag was being added to the security level list which is not correct. Updated the code to have that flag marked separately so that we can parse and decode them without mashing them together. Added tests to ensure this both encoded and decoded correctly.