### PR TITLE
Send binary to respond from another controller

### DIFF
--- a/lib/grizzly.ex
+++ b/lib/grizzly.ex
@@ -119,9 +119,13 @@ defmodule Grizzly do
   @type command :: atom()
 
   @doc """
-  Send a command to the node via the node id
+  Send a command to the node via the node id or to Z/IP Gateway
+
+  If you want to send a command to the Gateway directly please see the
+  `Grizzly.Network` module first as there are many helpers in there that will
+  be default talk your controller by default.
   """
-  @spec send_command(ZWave.node_id(), command(), args :: list(), [command_opt()]) ::
+  @spec send_command(ZWave.node_id() | :gateway, command(), args :: list(), [command_opt()]) ::
           send_command_response()
   def send_command(node_id, command_name, args \\ [], opts \\ []) do
     # always open a connection. If the connection is already opened this

--- a/lib/grizzly/connection.ex
+++ b/lib/grizzly/connection.ex
@@ -11,12 +11,12 @@ defmodule Grizzly.Connection do
   @type opt() :: {:mode, :sync | :async | :binary} | {:owner, pid()}
 
   @doc """
-  Open a connection to a node
+  Open a connection to a node or the Z/IP Gateway
 
   If the DTLS connection cannot be opened after some time this will return
   `{:error, :timeout}`
   """
-  @spec open(ZWave.node_id(), [opt()]) :: {:ok, pid()} | {:error, :timeout}
+  @spec open(ZWave.node_id() | :gateway, [opt()]) :: {:ok, pid()} | {:error, :timeout}
   def open(node_id, opts \\ []) do
     Supervisor.start_connection(node_id, opts)
   end

--- a/lib/grizzly/connection_registry.ex
+++ b/lib/grizzly/connection_registry.ex
@@ -3,7 +3,11 @@ defmodule Grizzly.ConnectionRegistry do
 
   alias Grizzly.ZWave
 
-  @type name() :: ZWave.node_id() | {:async, ZWave.node_id()} | {:binary, ZWave.node_id(), pid()}
+  @type name() ::
+          ZWave.node_id()
+          | :gateway
+          | {:async, ZWave.node_id()}
+          | {:binary, ZWave.node_id(), pid()}
 
   @spec via_name(name()) ::
           {:via, Registry, {__MODULE__, Grizzly.node_id()}} | pid()

--- a/lib/grizzly/connections/supervisor.ex
+++ b/lib/grizzly/connections/supervisor.ex
@@ -10,7 +10,10 @@ defmodule Grizzly.Connections.Supervisor do
     DynamicSupervisor.start_link(__MODULE__, options, name: __MODULE__)
   end
 
-  @spec start_connection(ZWave.node_id(), [Connection.opt()]) ::
+  @doc """
+  Start a connection to a Z-Wave Node or the Z/IP Gateway
+  """
+  @spec start_connection(ZWave.node_id() | :gateway, [Connection.opt()]) ::
           {:ok, pid()} | {:error, :timeout}
   def start_connection(node_id, opts \\ []) do
     case Keyword.get(opts, :mode, :sync) do

--- a/lib/grizzly/node.ex
+++ b/lib/grizzly/node.ex
@@ -19,7 +19,7 @@ defmodule Grizzly.Node do
   def get_info(node_id) do
     seq_number = SeqNumber.get_and_inc()
 
-    Grizzly.send_command(1, :node_info_cached_get,
+    Grizzly.send_command(:gateway, :node_info_cached_get,
       seq_number: seq_number,
       node_id: node_id
     )
@@ -29,8 +29,10 @@ defmodule Grizzly.Node do
   Get a node's dsk.
 
   The response to this command is the `DSKReport` command
+
+  Sending this command with `:gateway` will always go to your Z-Wave controller
   """
-  @spec get_dsk(ZWave.node_id(), :add | :learn, [Grizzly.command_opt()]) ::
+  @spec get_dsk(ZWave.node_id() | :gateway, :add | :learn, [Grizzly.command_opt()]) ::
           Grizzly.send_command_response()
   def get_dsk(node_id, add_mode, opts \\ []) do
     Grizzly.send_command(

--- a/lib/grizzly/zip_gateway.ex
+++ b/lib/grizzly/zip_gateway.ex
@@ -12,8 +12,8 @@ defmodule Grizzly.ZIPGateway do
   @doc """
   Get the IP address for the node id based of the LAN or PAN IP addresses
   """
-  @spec host_for_node(ZWave.node_id(), Options.t()) :: :inet.ip_address()
-  def host_for_node(1, options), do: options.lan_ip
+  @spec host_for_node(ZWave.node_id() | :gateway, Options.t()) :: :inet.ip_address()
+  def host_for_node(:gateway, options), do: options.lan_ip
 
   def host_for_node(node_id, options) do
     options.pan_ip

--- a/lib/grizzly/zipgateway/ready_checker.ex
+++ b/lib/grizzly/zipgateway/ready_checker.ex
@@ -22,7 +22,7 @@ defmodule Grizzly.ZIPGateway.ReadyChecker do
 
   @impl GenServer
   def handle_continue(:try_connect, on_ready) do
-    case Connection.open(1) do
+    case Connection.open(:gateway) do
       {:ok, _} ->
         {m, f, a} = on_ready
         :ok = apply(m, f, a)

--- a/test/grizzly/zip_gateway_test.exs
+++ b/test/grizzly/zip_gateway_test.exs
@@ -5,8 +5,13 @@ defmodule Grizzly.ZIPGatewayTest do
   alias GrizzlyTest.Utils
 
   test "get IP for node id 1 with IPv6" do
-    assert {0xFD00, 0xAAAA, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01} ==
+    assert {0xFD00, 0xBBBB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01} ==
              ZIPGateway.host_for_node(1, Options.new())
+  end
+
+  test "get IP for Gateway with IPv6" do
+    assert {0xFD00, 0xAAAA, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01} ==
+             ZIPGateway.host_for_node(:gateway, Options.new())
   end
 
   test "get IP for node id 1 with IPv4" do


### PR DESCRIPTION
This sends a binary response for commands that a received via the unsolicited server while the Z-Wave node isn't the main controller.

A problem Grizzly had was that it assumed that our gateway controller would always be node id 1, but when we are included in another controller's network that might be true.

A discovery uncovered that there is a PAN and LAN. The LAN will always be to the gateway and anytime we want to send a command to a node on the Z-Wave network we use the PAN. Since we can never know our controller's node id for sure this enables talking directly to the gateway by passing `:gateway` to send command.

I think that this will need to be iterated on a bit but unblocks us from testing and going through the certification process.
