### PR TITLE
Respond to version queries for extra commands

### DIFF
--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -6,7 +6,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
 
   require Logger
 
-  alias Grizzly.Transport
+  alias Grizzly.{Transport, VersionReports}
   alias Grizzly.{Associations, ZWave}
   alias Grizzly.ZWave.Command
 
@@ -296,6 +296,18 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
         end
       end
     end)
+  end
+
+  defp handle_command(%Command{name: :command_class_get} = command, _opts) do
+    command_class = Command.param!(command, :command_class)
+
+    case VersionReports.version_report_for(command_class) do
+      {:ok, report} ->
+        [{:send, report}]
+
+      {:error, _} ->
+        []
+    end
   end
 
   defp handle_command(command, _opts), do: [{:notify, command}]

--- a/lib/grizzly/version_reports.ex
+++ b/lib/grizzly/version_reports.ex
@@ -1,0 +1,44 @@
+defmodule Grizzly.VersionReports do
+  @moduledoc false
+
+  # This module is for supporting extra commands version reports
+  # as of right now this is focused on providing the version reports
+  # as needed for Z-Wave certification and can be extended to support
+  # other command classes and versions.
+
+  alias Grizzly.ZWave.{Command, CommandClasses}
+  alias Grizzly.ZWave.Commands.CommandClassReport
+
+  @doc """
+  Get the version report for the command class
+  """
+  @spec version_report_for(CommandClasses.command_class()) ::
+          {:ok, Command.t()} | {:error, :command_not_supported}
+  def version_report_for(:association = name) do
+    CommandClassReport.new(command_class: name, version: 3)
+  end
+
+  def version_report_for(:association_group_info = name) do
+    CommandClassReport.new(command_class: name, version: 1)
+  end
+
+  def version_report_for(:device_reset_locally = name) do
+    CommandClassReport.new(command_class: name, version: 1)
+  end
+
+  def version_report_for(:multi_channel_association = name) do
+    CommandClassReport.new(command_class: name, version: 3)
+  end
+
+  def version_report_for(:supervision = name) do
+    CommandClassReport.new(command_class: name, version: 1)
+  end
+
+  def version_report_for(:multi_command = name) do
+    CommandClassReport.new(command_class: name, version: 1)
+  end
+
+  def version_report_for(_) do
+    {:error, :command_not_supported}
+  end
+end

--- a/test/grizzly/unsolicited_server/response_handler_test.exs
+++ b/test/grizzly/unsolicited_server/response_handler_test.exs
@@ -20,6 +20,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
     MultiChannelAssociationRemove,
     SupervisionGet,
     SwitchBinaryReport,
+    CommandClassGet,
     ZIPPacket
   }
 
@@ -194,6 +195,15 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
       assert [] =
                ResponseHandler.handle_response(make_response(mcar), associations_server: server)
     end
+  end
+
+  test "version get query" do
+    {:ok, version_get} = CommandClassGet.new(command_class: :association)
+
+    assert [{:send, version_report}] = ResponseHandler.handle_response(make_response(version_get))
+
+    assert version_report.name == :command_class_report
+    assert Command.param!(version_report, :version) == 3
   end
 
   defp make_response(command) do

--- a/test/grizzly_test.exs
+++ b/test/grizzly_test.exs
@@ -2,6 +2,7 @@ defmodule Grizzly.Test do
   use ExUnit.Case
 
   alias Grizzly.Report
+  alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.Commands.{SwitchBinaryGet, SwitchBinaryReport, ZIPPacket}
 
   describe "SwitchBinary Commands" do
@@ -66,5 +67,55 @@ defmodule Grizzly.Test do
 
     assert_receive {:grizzly, :binary_response,
                     <<0x23, 0x2, 0x80, 0x50, _seq_no, 0x0, 0x0, 0x25, 0x3, 0x0>>}
+  end
+
+  describe "version get" do
+    test "association" do
+      {:ok, report} =
+        Grizzly.send_command(:gateway, :version_command_class_get, command_class: :association)
+
+      assert Command.param!(report.command, :version) == 3
+    end
+
+    test "association group info" do
+      {:ok, report} =
+        Grizzly.send_command(:gateway, :version_command_class_get,
+          command_class: :association_group_info
+        )
+
+      assert Command.param!(report.command, :version) == 1
+    end
+
+    test "device reset locally" do
+      {:ok, report} =
+        Grizzly.send_command(:gateway, :version_command_class_get,
+          command_class: :device_reset_locally
+        )
+
+      assert Command.param!(report.command, :version) == 1
+    end
+
+    test "multi channel association" do
+      {:ok, report} =
+        Grizzly.send_command(:gateway, :version_command_class_get,
+          command_class: :multi_channel_association
+        )
+
+      assert Command.param!(report.command, :version) == 3
+    end
+
+    test "supervision" do
+      {:ok, report} =
+        Grizzly.send_command(:gateway, :version_command_class_get, command_class: :supervision)
+
+      assert Command.param!(report.command, :version) == 1
+    end
+
+    test "multi command" do
+      {:ok, report} =
+        Grizzly.send_command(:gateway, :version_command_class_get, command_class: :multi_command)
+
+      assert Command.param!(report.command, :version) == 1
+    end
   end
 end


### PR DESCRIPTION
There are two situations that we need to respond to extra commands:

1. From the Z-Wave PAN
2. From a user of Grizzly

For the first case the Z-Wave Z/IP packet will be forward to the
unsolicited destination server which will have to handle send back the
version command class report.

For the second case a user might call `Grizzly.send_command/4` to query
for a command class version.

Packets are only forward to the unsolicited destination server when the
come from the Z-Wave PAN network. For a user that calls `send_command`
the Z-Wave packet will never be forwarded to due this limitation (which
appears to be in place for security reasons). Since, the information for
the version reports are hardcoded information only we just respond to
callers of `send_command` directly without any Z-Wave commands being
sent. The abstraction still behaves like the normal `send_command` to
not break API expected functionality.