### PR TITLE
Fix sending command class version get for non-extra cc

### DIFF
--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -305,7 +305,7 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
       {:ok, report} ->
         [{:send, report}]
 
-      {:error, _} ->
+      _ ->
         []
     end
   end

--- a/lib/grizzly/version_reports.ex
+++ b/lib/grizzly/version_reports.ex
@@ -9,11 +9,22 @@ defmodule Grizzly.VersionReports do
   alias Grizzly.ZWave.{Command, CommandClasses}
   alias Grizzly.ZWave.Commands.CommandClassReport
 
+  @extra_supported_commands [
+    :association,
+    :association_group_info,
+    :device_reset_locally,
+    :multi_channel_association,
+    :multi_command,
+    :supervision
+  ]
+
+  defguard is_extra_command(command) when command in @extra_supported_commands
+
   @doc """
   Get the version report for the command class
   """
   @spec version_report_for(CommandClasses.command_class()) ::
-          {:ok, Command.t()} | {:error, :command_not_supported}
+          {:ok, Command.t()} | :command_not_supported
   def version_report_for(:association = name) do
     CommandClassReport.new(command_class: name, version: 3)
   end
@@ -39,6 +50,6 @@ defmodule Grizzly.VersionReports do
   end
 
   def version_report_for(_) do
-    {:error, :command_not_supported}
+    :command_not_supported
   end
 end


### PR DESCRIPTION
When sending a command class version get command to the gateway, we have
to send it via the LAN if the command is not an extra supported command
class.