### PR TITLE
Remove GenServer.terminate/2 to fix terminate crashes

### DIFF
--- a/lib/grizzly/connections/async_connection.ex
+++ b/lib/grizzly/connections/async_connection.ex
@@ -160,9 +160,6 @@ defmodule Grizzly.Connections.AsyncConnection do
     end
   end
 
-  @impl GenServer
-  def terminate(:normal, state), do: state
-
   defp handle_commands(%Command{name: :keep_alive}, state) do
     %State{state | keep_alive: KeepAlive.timer_restart(state.keep_alive)}
   end

--- a/lib/grizzly/connections/binary_connection.ex
+++ b/lib/grizzly/connections/binary_connection.ex
@@ -94,7 +94,4 @@ defmodule Grizzly.Connections.BinaryConnection do
         {:noreply, state}
     end
   end
-
-  @impl GenServer
-  def terminate(:normal, state), do: state
 end

--- a/lib/grizzly/connections/sync_connection.ex
+++ b/lib/grizzly/connections/sync_connection.ex
@@ -141,9 +141,6 @@ defmodule Grizzly.Connections.SyncConnection do
     end
   end
 
-  @impl GenServer
-  def terminate(:normal, state), do: state
-
   defp handle_commands(%Command{name: :keep_alive}, state) do
     %State{state | keep_alive: KeepAlive.timer_restart(state.keep_alive)}
   end

--- a/lib/grizzly/zipgateway/ready_checker.ex
+++ b/lib/grizzly/zipgateway/ready_checker.ex
@@ -36,7 +36,4 @@ defmodule Grizzly.ZIPGateway.ReadyChecker do
         {:noreply, on_ready, {:continue, :try_connect}}
     end
   end
-
-  @impl GenServer
-  def terminate(_, _state), do: :ok
 end


### PR DESCRIPTION
This removes all of the empty `GenServer.terminate/2` implementations
since they don't do any cleanup and the ones that only match `:normal`
obscure the reasons for abnormal crashes since they will raise.

Here's an example exception that was raised before this fix:

```
15:52:08.290 [error] GenServer {Grizzly.ConnectionRegistry, :gateway} terminating
** (FunctionClauseError) no function clause matching in Grizzly.Connections.SyncConnection.terminate/2
    (grizzly 0.15.11) lib/grizzly/connections/sync_connection.ex:145: Grizzly.Connections.SyncConnection.terminate({:function_clause, [{Grizzly.Transports.DTLS, :parse_response, [{:ssl, {:sslsocket, {:gen_udp, {{{64768, 43690, 0, 0, 0, 0, 0, 1}, 41230}, #Port<0.289>}, :dtls_gen_connection}, [#PID<0.4272.0>]}, [35, 2, 64, 0, 237, 0, 0]}, []], [file: 'lib/grizzly/transports/DTLS.ex', line: 34]}, {Grizzly.Connections.SyncConnection, :handle_info, 2, [file: 'lib/grizzly/connections/sync_connection.ex', line: 133]}, {:gen_server, :try_dispatch, 4, [file: 'gen_server.erl', line: 689]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 765]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}]}, %Grizzly.Connections.SyncConnection.State{commands: %Grizzly.Connections.CommandList{commands: [{#PID<0.4274.0>, {#PID<0.4273.0>, #Reference<0.2359165306.1828716545.148924>}, #Reference<0.2359165306.1828716545.148925>}], keep_alive_command: nil}, keep_alive: %Grizzly.Connections.KeepAlive{command_runner: nil, interval: 25000, last_send: nil, node_id: :gateway, owner: #PID<0.4271.0>, ref: #Reference<0.2359165306.1828716545.148934>}, node_id: :gateway, transport: %Grizzly.Transport{assigns: %{port: 41230, socket: {:sslsocket, {:gen_udp, {{{64768, 43690, 0, 0, 0, 0, 0, 1}, 41230}, #Port<0.289>}, :dtls_gen_connection}, [#PID<0.4272.0>]}}, impl: Grizzly.Transports.DTLS}})
```

After the fix, the `Grizzly.Transports.DTLS.parse_response/2` exception
is the one that's shown first in the error print. In fairness, you can
see the `parse_response/2` issue above, but it's harder to pick out when
skimming the logs.