### PR TITLE
Handle DTLS message change in OTP 23.2

### DIFF
--- a/lib/grizzly/transports/DTLS.ex
+++ b/lib/grizzly/transports/DTLS.ex
@@ -31,6 +31,7 @@ defmodule Grizzly.Transports.DTLS do
   end
 
   @impl Grizzly.Transport
+  # Erlang/OTP <= 23.1.x
   def parse_response(
         {:ssl, {:sslsocket, {:gen_udp, {_, {{ip, _}, _}}, :dtls_connection}, _}, bin_list},
         opts
@@ -47,6 +48,22 @@ defmodule Grizzly.Transports.DTLS do
            ip_address: ip,
            command: command
          }}
+    end
+  end
+
+  # Erlang/OTP >= 23.2
+  def parse_response(
+        {:ssl, {:sslsocket, {:gen_udp, {{ip, _}, _}, :dtls_gen_connection}, _}, bin_list},
+        opts
+      ) do
+    binary = :erlang.list_to_binary(bin_list)
+
+    case parse_zip_packet(binary, opts) do
+      {:ok, bin} when is_binary(bin) ->
+        {:ok, bin}
+
+      {:ok, command} ->
+        {:ok, %Response{ip_address: ip, command: command}}
     end
   end
 


### PR DESCRIPTION
I believe that [this commit](https://github.com/erlang/otp/commit/f61c4302a8a5e6185e05d0f97d1c7bbc0d2621fc) in OTP broke this. The commit talks about TLS/DTLS-1.3 and refactoring out the generic parts of TLS and DTLS with version 1.2 and before.