### PR TITLE
Set MultiChannelAssociation version to the correct one

### DIFF
--- a/lib/grizzly/version_reports.ex
+++ b/lib/grizzly/version_reports.ex
@@ -38,7 +38,7 @@ defmodule Grizzly.VersionReports do
   end
 
   def version_report_for(:multi_channel_association = name) do
-    VersionCommandClassReport.new(command_class: name, version: 3)
+    VersionCommandClassReport.new(command_class: name, version: 4)
   end
 
   def version_report_for(:supervision = name) do

--- a/test/grizzly_test.exs
+++ b/test/grizzly_test.exs
@@ -101,7 +101,7 @@ defmodule Grizzly.Test do
           command_class: :multi_channel_association
         )
 
-      assert Command.param!(report.command, :version) == 3
+      assert Command.param!(report.command, :version) == 4
     end
 
     test "supervision" do


### PR DESCRIPTION
Update the version report for multi-channel association to be the
correct version number.