### PR TITLE
Fix associations to reset to a map

### DIFF
--- a/lib/grizzly/associations.ex
+++ b/lib/grizzly/associations.ex
@@ -156,7 +156,7 @@ defmodule Grizzly.Associations do
 
   def handle_call(:delete_all, _from, state) do
     %State{file_path: path} = state
-    binary = :erlang.term_to_binary([])
+    binary = :erlang.term_to_binary(%{})
 
     :ok = File.write(path, binary)
 


### PR DESCRIPTION
The internal data structure for the associations is a map. When
deleting all the associations we were setting to an empty list which
would cause bugs later.