### PR TITLE
Support more that just timeout errors on DTLS failures

### DIFF
--- a/lib/grizzly/connections/async_connection.ex
+++ b/lib/grizzly/connections/async_connection.ex
@@ -85,8 +85,8 @@ defmodule Grizzly.Connections.AsyncConnection do
            node_id: node_id
          }}
 
-      {:error, :timeout} ->
-        {:stop, :timeout}
+      {:error, reason} ->
+        {:stop, reason}
     end
   end
 

--- a/lib/grizzly/connections/supervisor.ex
+++ b/lib/grizzly/connections/supervisor.ex
@@ -54,8 +54,8 @@ defmodule Grizzly.Connections.Supervisor do
            connection_module.child_spec(node_id, command_opts)
          ) do
       {:ok, _} = ok -> ok
-      {:error, :timeout} = timeout_error -> timeout_error
       {:error, {:already_started, pid}} -> {:ok, pid}
+      {:error, _reason} = other_error -> other_error
     end
   end
 end

--- a/lib/grizzly/connections/sync_connection.ex
+++ b/lib/grizzly/connections/sync_connection.ex
@@ -75,8 +75,8 @@ defmodule Grizzly.Connections.SyncConnection do
            node_id: node_id_or_gateway
          }}
 
-      {:error, :timeout} ->
-        {:stop, :timeout}
+      {:error, reason} ->
+        {:stop, reason}
     end
   end
 

--- a/lib/grizzly/zipgateway/ready_checker.ex
+++ b/lib/grizzly/zipgateway/ready_checker.ex
@@ -28,9 +28,9 @@ defmodule Grizzly.ZIPGateway.ReadyChecker do
         :ok = apply(m, f, a)
         {:stop, :normal, on_ready}
 
-      {:error, :timeout} ->
+      {:error, _reason} ->
         # give a little breathing space
-        :timer.sleep(250)
+        :timer.sleep(500)
 
         # try again
         {:noreply, on_ready, {:continue, :try_connect}}


### PR DESCRIPTION
These are due to zipgateway not being ready and they're ok. The strategy
is to retry later. This fixes crashes coming from this code that look
like this:

```
18:22:03.081 [error] GenServer Grizzly.ZIPGateway.ReadyChecker terminating
** (CaseClauseError) no case clause matching: {:error, {{:case_clause, {:error, :eaddrnotavail}}, [{Grizzly.Connections.SyncConnection, :init, 1, [file: 'lib/grizzly/connections/sync_connection.ex', line: 69]}, {:gen_server, :init_it, 2, [file: 'gen_server.erl', line: 417]}, {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 385]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}]}}
    (grizzly 0.16.1) lib/grizzly/connections/supervisor.ex:52: Grizzly.Connections.Supervisor.do_start_connection/3
    (grizzly 0.16.1) lib/grizzly/zipgateway/ready_checker.ex:25: Grizzly.ZIPGateway.ReadyChecker.handle_continue/2
    (stdlib 3.13.2) gen_server.erl:680: :gen_server.try_dispatch/4
    (stdlib 3.13.2) gen_server.erl:431: :gen_server.loop/7
    (stdlib 3.13.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```

This additional error came up with the change to bind to the unsolicited
IP address. This IP address doesn't exist until zipgateway sets up the
tunnel. Previously, Erlang would use whatever IP address was available
at the time. This wasn't right, but it didn't crash with
`eaddrnotavail`. Presumably it timed out and the retry "just worked".