### PR TITLE
Add list mode param for AssociationGroupInfoReport

### DIFF
--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -161,11 +161,12 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
     end
   end
 
-  defp handle_command(%Command{name: :association_group_info_get}, _opts) do
+  defp handle_command(%Command{name: :association_group_info_get} = command, _opts) do
     {:ok, report} =
       AssociationGroupInfoReport.new(
         dynamic: false,
-        groups_info: [[group_id: 1, profile: :general_lifeline]]
+        groups_info: [[group_id: 1, profile: :general_lifeline]],
+        list_mode: Command.param(command, :all, false)
       )
 
     [{:send, report}]

--- a/lib/grizzly/zwave/commands/association_group_info_report.ex
+++ b/lib/grizzly/zwave/commands/association_group_info_report.ex
@@ -6,7 +6,12 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupInfoReport do
 
     * `:dynamic` - whether the group info is subject to be changed by the device
     * `:groups_info` - a list of group info
-
+    * `:list_mode` - a boolean if the report should be in list mode. In some
+      cases this needs to be forced, like if you are reporting one group but the
+      get query requested list mode. If you are reporting more than one group
+      then this parameter is optional as it will know that more than one group
+      can only be reported with list mode `true`. If you don't set this option
+      to `true` when reporting one group then this will default to `false`.
   """
 
   @behaviour Grizzly.ZWave.Command
@@ -15,9 +20,10 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupInfoReport do
   alias Grizzly.ZWave.CommandClasses.AssociationGroupInfo
 
   @type group_info() :: [group_id: byte(), profile: atom()]
-  @type param() :: {:groups_info, [group_info()]} | {:dynamic, boolean()}
+  @type param() ::
+          {:groups_info, [group_info()]} | {:dynamic, boolean() | {:list_mode, boolean()}}
 
-  @impl true
+  @impl Command
   @spec new([param()]) :: {:ok, Command.t()}
   def new(params) do
     command = %Command{
@@ -31,13 +37,13 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupInfoReport do
     {:ok, command}
   end
 
-  @impl true
+  @impl Command
   def encode_params(command) do
+    list_mode = get_list_mode(command)
     dynamic? = Command.param!(command, :dynamic)
     dynamic_bit = if dynamic?, do: 0x01, else: 0x00
     groups_info = Command.param!(command, :groups_info)
     group_count = Enum.count(groups_info)
-    list_mode_bit = if group_count == 1, do: 0x00, else: 0x01
 
     encoded_groups_info =
       for group_info <- groups_info, into: <<>> do
@@ -46,19 +52,20 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupInfoReport do
         <<group_id, 0x00>> <> encode_profile(Atom.to_string(profile)) <> <<0x00, 0x00, 0x00>>
       end
 
-    <<list_mode_bit::size(1), dynamic_bit::size(1), group_count::size(6)>> <> encoded_groups_info
+    <<list_mode::size(1), dynamic_bit::size(1), group_count::size(6)>> <> encoded_groups_info
   end
 
-  @impl true
+  @impl Command
   def decode_params(
-        <<_list_mode::size(1), dynamic_bit::size(1), group_count::size(6),
+        <<list_mode::size(1), dynamic_bit::size(1), group_count::size(6),
           encoded_groups_info::binary>>
       ) do
     dynamic? = dynamic_bit == 0x01
+    list_mode? = list_mode == 0x01
 
     case decode_groups_info(group_count, encoded_groups_info) do
       {:ok, groups_info} ->
-        {:ok, [dynamic: dynamic?, groups_info: groups_info]}
+        {:ok, [dynamic: dynamic?, groups_info: groups_info, list_mode: list_mode?]}
 
       {:error, %DecodeError{} = error} ->
         error
@@ -140,4 +147,14 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupInfoReport do
 
   defp encode_profile(<<"irrigation_channel_", key::binary>>),
     do: <<0x6B, elem(Integer.parse(key), 0)>>
+
+  defp get_list_mode(command) do
+    if Command.param(command, :list_mode, false) do
+      0x01
+    else
+      groups_info = Command.param!(command, :groups_info)
+
+      if length(groups_info) > 1, do: 0x01, else: 0x00
+    end
+  end
 end


### PR DESCRIPTION
In some cases we need to force the list mode bit to be set. This allows
us to do that but the fallback is to use derive this bit from the group
info param if this param is not set. This prevents a breaking change.