### PR TITLE
Add support for a database file

### DIFF
--- a/lib/grizzly/supervisor.ex
+++ b/lib/grizzly/supervisor.ex
@@ -85,6 +85,12 @@ defmodule Grizzly.Supervisor do
      the unsolicited destination server.
   - `:unsolicited_data_path` - A path to the directory where the unsolicited
     server should persist data (defaults to `/root`)
+  - `:database_file` - `zipgateway` >= 7.14.2 uses an sqlite database to store
+    information about the Z-Wave network. This will default to
+    "/data/zipgateway.db".
+  - `:eeprom_file` - `zipgateway` < 7.14.2 uses an eeprom file to store
+    information about the Z-Wave network. This will default to
+    "/data/zipeeprom.dat".
 
   For the most part the defaults should work out of the box. However, the
   `serial_port` argument is the most likely argument that will need to be
@@ -110,6 +116,8 @@ defmodule Grizzly.Supervisor do
           | {:firmware_update_handler, Grizzly.handler()}
           | {:unsolicited_destination, {:inet.ip_address(), :inet.port_number()}}
           | {:unsolicited_data_path, Path.t()}
+          | {:eeprom_file, Path.t()}
+          | {:database_file, Path.t()}
 
   @doc """
   Start the Grizzly.Supervisor

--- a/test/grizzly/zipgateway/config_test.exs
+++ b/test/grizzly/zipgateway/config_test.exs
@@ -10,7 +10,6 @@ defmodule Grizzly.ZIPGateway.ConfigTest do
     ZipCaCert=./Portal.ca_x509.pem
     ZipCert=./ZIPR.x509_1024.pem
     ZipPrivKey=./ZIPR.key_1024.pem
-    Eepromfile=/root/zipeeprom.dat
     TunScript=./zipgateway.tun
     PVSStorageFile=/root/provisioning_list_store.dat
     ProvisioningConfigFile=/etc/zipgateway_provisioning_list.cfg
@@ -28,26 +27,49 @@ defmodule Grizzly.ZIPGateway.ConfigTest do
     assert output == Config.to_string(cfg)
   end
 
-  test "when options are added as string" do
+  test "with eeprom_file" do
     output = """
     ZipCaCert=./Portal.ca_x509.pem
     ZipCert=./ZIPR.x509_1024.pem
     ZipPrivKey=./ZIPR.key_1024.pem
-    Eepromfile=/root/zipeeprom.dat
     TunScript=./zipgateway.tun
     PVSStorageFile=/root/provisioning_list_store.dat
     ProvisioningConfigFile=/etc/zipgateway_provisioning_list.cfg
     ZipLanGw6=::1
     ZipPSK=123456789012345678901234567890AA
-    ZipProductID = 1
     ExtraClasses= 133 89 90 142 108 143
     ZipPanIp6=fd00:bbbb::1
     ZipLanIp6=fd00:aaaa::1
     ZipUnsolicitedDestinationIp6=fd00:aaaa::2
     ZipUnsolicitedDestinationPort=41230
+    Eepromfile=/data/zipeeprom.dat
     """
 
-    cfg = Config.new(%{product_id: 1})
+    cfg = Config.new(%{eeprom_file: "/data/zipeeprom.dat"})
+
+    assert output == Config.to_string(cfg)
+  end
+
+  test "when options are added as string" do
+    output = """
+    ZipCaCert=./Portal.ca_x509.pem
+    ZipCert=./ZIPR.x509_1024.pem
+    ZipPrivKey=./ZIPR.key_1024.pem
+    TunScript=./zipgateway.tun
+    PVSStorageFile=/root/provisioning_list_store.dat
+    ProvisioningConfigFile=/etc/zipgateway_provisioning_list.cfg
+    ZipLanGw6=::1
+    ZipPSK=123456789012345678901234567890AA
+    ZipProductID=1
+    ExtraClasses= 133 89 90 142 108 143
+    ZipPanIp6=fd00:bbbb::1
+    ZipLanIp6=fd00:aaaa::1
+    ZipUnsolicitedDestinationIp6=fd00:aaaa::2
+    ZipUnsolicitedDestinationPort=41230
+    ZipGwDatabase=/tmp/zipgateway.db
+    """
+
+    cfg = Config.new(%{product_id: 1, database_file: "/tmp/zipgateway.db"})
 
     assert output == Config.to_string(cfg)
   end
@@ -59,7 +81,6 @@ defmodule Grizzly.ZIPGateway.ConfigTest do
     ZipCaCert=./Portal.ca_x509.pem
     ZipCert=./ZIPR.x509_1024.pem
     ZipPrivKey=./ZIPR.key_1024.pem
-    Eepromfile=/root/zipeeprom.dat
     TunScript=./zipgateway.tun
     PVSStorageFile=/root/provisioning_list_store.dat
     ProvisioningConfigFile=/etc/zipgateway_provisioning_list.cfg


### PR DESCRIPTION
When using `zipgateway` version >= 7.14.2 it will rely on a database
 file to save network and Z-Wave information.
    
You can pass the file path to the `Grizzly.Supervisor` via the
`:database_file` option but this does default to `/data/zipgateway.db`.
    
When migrating to a version that is >= 7.14.2 `Grizzly` will try to run
the `zgw_eeprom_to_sqlite` utility that is packaged with `zipgateway`.
The expected location for this utility is
`/usr/bin/zgw_eeprom_to_sqlite`.
