### PR TITLE
Fix a bug that caused command discovery not to work

### DIFF
--- a/lib/grizzly.ex
+++ b/lib/grizzly.ex
@@ -259,7 +259,7 @@ defmodule Grizzly do
     Table.dump()
     |> Enum.filter(fn {_command, {command_module, _}} ->
       {:ok, command} = command_module.new([])
-      command.command_class.name() == command_class_name
+      command.command_class == command_class_name
     end)
     |> Enum.map(fn {command, _} -> command end)
   end

--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -81,7 +81,7 @@ defmodule Grizzly.Commands.Table do
       {:door_lock_operation_get,
        {Commands.DoorLockOperationGet,
         handler: {WaitReport, complete_report: :door_lock_operation_report}}},
-      {:door_lock_configuration_set, {Commands.DoorConfigurationSet, handler: AckResponse}},
+      {:door_lock_configuration_set, {Commands.DoorLockConfigurationSet, handler: AckResponse}},
       {:door_lock_configuration_get,
        {Commands.DoorLockConfigurationGet,
         handler: {WaitReport, complete_report: :door_lock_configuration_report}}},


### PR DESCRIPTION
The first issue was the `DoorConfiguration` command was suppose to be
`DoorLockConfiguration`.

The second issue was we were comparing the atom version of the name
against the module version of the name, thus all commands would be
filtered out and returned list of commands would always be empty.

Closes: #413 