### PR TITLE
Update DSK

### DIFF
--- a/lib/grizzly/inclusions.ex
+++ b/lib/grizzly/inclusions.ex
@@ -168,7 +168,7 @@ defmodule Grizzly.Inclusions do
 
   alias Grizzly.Inclusions.InclusionRunnerSupervisor
   alias Grizzly.Inclusions.InclusionRunner
-  alias Grizzly.ZWave.Security
+  alias Grizzly.ZWave.{DSK, Security}
 
   @type opt ::
           {:controller_id, Grizzly.node_id()} | {:handler, pid() | module() | {module, keyword()}}
@@ -225,11 +225,12 @@ defmodule Grizzly.Inclusions do
   you can pass it as an argument like so:
 
   ```elixir
-  Grizzly.Inclusions.set_input_dsk(12345)
+  {:ok, dsk} = Grizzly.ZWave.DSK.parse("12345")
+  Grizzly.Inclusions.set_input_dsk(dsk)
   ```
   """
-  @spec set_input_dsk(non_neg_integer()) :: :ok
-  def set_input_dsk(input_dsk \\ 0) do
+  @spec set_input_dsk(DSK.t()) :: :ok
+  def set_input_dsk(input_dsk \\ DSK.new(<<>>)) do
     InclusionRunner.set_dsk(InclusionRunner, input_dsk)
   end
 

--- a/lib/grizzly/inclusions/inclusion_runner.ex
+++ b/lib/grizzly/inclusions/inclusion_runner.ex
@@ -6,7 +6,7 @@ defmodule Grizzly.Inclusions.InclusionRunner do
   alias Grizzly.{Connection, Inclusions, Options, SeqNumber, Report}
   alias Grizzly.Inclusions.InclusionRunner.Inclusion
   alias Grizzly.Connections.AsyncConnection
-  alias Grizzly.ZWave.{Security, Command}
+  alias Grizzly.ZWave.{Security, Command, DSK}
 
   @typedoc """
   At any given moment there can only be 1 `InclusionRunner` process going so
@@ -59,8 +59,8 @@ defmodule Grizzly.Inclusions.InclusionRunner do
     GenServer.call(runner, {:grant_keys, security_keys})
   end
 
-  @spec set_dsk(t(), non_neg_integer()) :: :ok
-  def set_dsk(runner \\ __MODULE__, dsk \\ 0) do
+  @spec set_dsk(t(), DSK.t()) :: :ok
+  def set_dsk(runner \\ __MODULE__, dsk \\ DSK.new("")) do
     GenServer.call(runner, {:set_dsk, dsk})
   end
 
@@ -172,9 +172,6 @@ defmodule Grizzly.Inclusions.InclusionRunner do
     seq_number = SeqNumber.get_and_inc()
 
     case Inclusion.next_command(inclusion, :dsk_set, seq_number, dsk: dsk) do
-      {:error, _} = error ->
-        {:reply, error, inclusion}
-
       {command, inclusion} ->
         :ok
 

--- a/lib/grizzly/inclusions/inclusion_runner/inclusion.ex
+++ b/lib/grizzly/inclusions/inclusion_runner/inclusion.ex
@@ -113,21 +113,15 @@ defmodule Grizzly.Inclusions.InclusionRunner.Inclusion do
   def next_command(inclusion, :dsk_set, seq_number, command_params) do
     dsk = Keyword.fetch!(command_params, :dsk)
 
-    if valid_pin?(dsk, inclusion.dsk_input_length) do
-      # The PIN could be 00000. It's actual byte size is 1 and so can fit in 2 bytes
-      # if this is the inclusion's (max) dsk input length.
-      {:ok, command} =
-        NodeAddDSKSet.new(
-          seq_number: seq_number,
-          accept: true,
-          input_dsk_length: inclusion.dsk_input_length,
-          input_dsk: dsk
-        )
+    {:ok, command} =
+      NodeAddDSKSet.new(
+        seq_number: seq_number,
+        accept: true,
+        input_dsk_length: inclusion.dsk_input_length,
+        input_dsk: dsk
+      )
 
-      {command, dsk_set(inclusion)}
-    else
-      {:error, :invalid_pin_or_dsk}
-    end
+    {command, dsk_set(inclusion)}
   end
 
   def next_command(inclusion, :learn_mode, seq_number, _) do
@@ -193,8 +187,4 @@ defmodule Grizzly.Inclusions.InclusionRunner.Inclusion do
   def learn_mode_stop(%__MODULE__{state: :learn_mode} = inclusion) do
     %__MODULE__{inclusion | state: :learn_mode_stop}
   end
-
-  defp valid_pin?(pin, num_bytes), do: pin >= 0 and pin < max_value(num_bytes)
-
-  defp max_value(num_bytes), do: 1 <<< (num_bytes * 8)
 end

--- a/lib/grizzly/zwave/command_classes/node_provisioning.ex
+++ b/lib/grizzly/zwave/command_classes/node_provisioning.ex
@@ -23,14 +23,31 @@ defmodule Grizzly.ZWave.CommandClasses.NodeProvisioning do
         extensions_bin <> MetaExtension.extension_to_binary(extension)
       end)
 
-  def optional_dsk_to_binary(no_dsk) when no_dsk in [nil, ""] do
-    {:ok, <<>>}
+  @doc """
+  Get the binary representation of the dsk
+
+  If the DSK is `nil` then this will return an empty binary.
+  """
+  @spec optional_dsk_to_binary(DSK.t() | nil) :: binary()
+  def optional_dsk_to_binary(nil) do
+    <<>>
   end
 
   def optional_dsk_to_binary(dsk) do
-    DSK.string_to_binary(dsk)
+    dsk.raw
   end
 
-  def optional_binary_to_dsk(<<>>), do: {:ok, ""}
-  def optional_binary_to_dsk(binary), do: DSK.binary_to_string(binary)
+  @doc """
+  Get the DSK from a raw binary
+
+  If the binary is empty this will return `{:ok, nil}`.
+  """
+  @spec optional_binary_to_dsk(binary()) :: DSK.t() | nil
+  def optional_binary_to_dsk(<<>>) do
+    nil
+  end
+
+  def optional_binary_to_dsk(binary) do
+    DSK.new(binary)
+  end
 end

--- a/lib/grizzly/zwave/commands/dsk_report.ex
+++ b/lib/grizzly/zwave/commands/dsk_report.ex
@@ -23,7 +23,7 @@ defmodule Grizzly.ZWave.Commands.DSKReport do
   @type param ::
           {:seq_number, ZWave.seq_number()}
           | {:add_mode, NetworkManagementBasicNode.add_mode()}
-          | {:dsk, DSK.dsk_string()}
+          | {:dsk, DSK.t()}
 
   @impl true
   @spec new([param()]) :: {:ok, Command.t()}
@@ -44,21 +44,15 @@ defmodule Grizzly.ZWave.Commands.DSKReport do
   def encode_params(command) do
     seq_number = Command.param!(command, :seq_number)
     add_mode = NetworkManagementBasicNode.add_mode_to_byte(Command.param!(command, :add_mode))
-    {:ok, dsk} = DSK.string_to_binary(Command.param!(command, :dsk))
+    dsk = Command.param!(command, :dsk)
 
-    <<seq_number, add_mode>> <> dsk
+    <<seq_number, add_mode>> <> dsk.raw
   end
 
   @impl true
   @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
   def decode_params(<<seq_number, _::size(7), add_mode_bit::size(1), dsk_binary::binary>>) do
-    case DSK.binary_to_string(dsk_binary) do
-      {:ok, dsk} ->
-        add_mode = NetworkManagementBasicNode.add_mode_from_bit(add_mode_bit)
-        {:ok, [seq_number: seq_number, add_mode: add_mode, dsk: dsk]}
-
-      {:error, _} ->
-        {:error, %DecodeError{value: dsk_binary, param: :dsk, command: :dsk_report}}
-    end
+    add_mode = NetworkManagementBasicNode.add_mode_from_bit(add_mode_bit)
+    {:ok, [seq_number: seq_number, add_mode: add_mode, dsk: DSK.new(dsk_binary)]}
   end
 end

--- a/lib/grizzly/zwave/commands/learn_mode_set_status.ex
+++ b/lib/grizzly/zwave/commands/learn_mode_set_status.ex
@@ -33,7 +33,7 @@ defmodule Grizzly.ZWave.Commands.LearnModeSetStatus do
           | {:new_node_id, Grizzly.Node.id()}
           | {:granted_keys, [Security.key()]}
           | {:kex_fail_type, Security.key_exchange_fail_type()}
-          | {:dsk, DSK.dsk_string()}
+          | {:dsk, DSK.t()}
 
   @impl true
   def new(params) do
@@ -63,10 +63,10 @@ defmodule Grizzly.ZWave.Commands.LearnModeSetStatus do
       kex_fail_type_byte =
         Command.param!(command, :kex_fail_type) |> Security.failed_type_to_byte()
 
-      {:ok, dsk_binary} = Command.param!(command, :dsk) |> DSK.string_to_binary()
+      dsk = Command.param!(command, :dsk)
 
       <<seq_number, status_byte, 0x00, new_node_id, granted_keys_byte, kex_fail_type_byte>> <>
-        dsk_binary
+        dsk.raw
     end
   end
 
@@ -88,7 +88,7 @@ defmodule Grizzly.ZWave.Commands.LearnModeSetStatus do
     kex_fail_type = Security.failed_type_from_byte(kex_fail_type_byte)
 
     with {:ok, status} <- decode_status(status_byte),
-         {:ok, dsk} <- DSK.binary_to_string(dsk_binary) do
+         dsk <- DSK.new(dsk_binary) do
       {:ok,
        [
          seq_number: seq_number,
@@ -101,9 +101,6 @@ defmodule Grizzly.ZWave.Commands.LearnModeSetStatus do
     else
       {:error, %DecodeError{}} = error ->
         error
-
-      {:error, dsk_error} when dsk_error in [:dsk_too_long, :dsk_too_short] ->
-        {:error, %DecodeError{value: dsk_binary, param: :dsk, command: :learn_mode_set_status}}
     end
   end
 

--- a/lib/grizzly/zwave/commands/node_add_status.ex
+++ b/lib/grizzly/zwave/commands/node_add_status.ex
@@ -17,11 +17,12 @@ defmodule Grizzly.ZWave.Commands.NodeAddStatus do
        used only if the device was included securely
     * `:granted_keys` - the security keys granted during S2 inclusion (optional)
     * `:kex_fail_type` - the error that occurred in the S2 bootstrapping (optional)
+    * `:input_dsk` - the device DSK
 
   """
   @behaviour Grizzly.ZWave.Command
 
-  alias Grizzly.ZWave.{Command, CommandClasses, Security}
+  alias Grizzly.ZWave.{Command, CommandClasses, DSK, Security}
   alias Grizzly.ZWave.CommandClasses.NetworkManagementInclusion
 
   @type status :: :done | :failed | :security_failed
@@ -42,6 +43,7 @@ defmodule Grizzly.ZWave.Commands.NodeAddStatus do
           | {:command_classes, [tagged_command_classes]}
           | {:granted_keys, [Security.key()]}
           | {:kex_fail_type, Security.key_exchange_fail_type()}
+          | {:input_dsk, DSK.t()}
 
   @impl true
   @spec new([param]) :: {:ok, Command.t()}
@@ -194,6 +196,7 @@ defmodule Grizzly.ZWave.Commands.NodeAddStatus do
        ) do
     keys_granted = Security.byte_to_keys(keys_granted_byte)
     kex_failed_type = Security.failed_type_from_byte(kex_failed_type_byte)
+    dsk = DSK.new(dsk)
 
     params ++ [keys_granted: keys_granted, kex_failed_type: kex_failed_type, input_dsk: dsk]
   end

--- a/lib/grizzly/zwave/commands/node_provisioning_delete.ex
+++ b/lib/grizzly/zwave/commands/node_provisioning_delete.ex
@@ -21,7 +21,7 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningDelete do
   alias Grizzly.ZWave.{Command, DecodeError, DSK}
   alias Grizzly.ZWave.CommandClasses.NodeProvisioning
 
-  @type param :: {:seq_number, ZWave.seq_number()} | {:dsk, DSK.dsk_string()}
+  @type param :: {:seq_number, ZWave.seq_number()} | {:dsk, DSK.t()}
 
   @impl true
   @spec new([param()]) :: {:ok, Command.t()}
@@ -41,20 +41,14 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningDelete do
   @spec encode_params(Command.t()) :: binary()
   def encode_params(command) do
     seq_number = Command.param!(command, :seq_number)
-    {:ok, dsk_bin} = DSK.string_to_binary(Command.param!(command, :dsk))
+    dsk = Command.param!(command, :dsk)
 
-    <<seq_number, byte_size(dsk_bin)>> <> dsk_bin
+    <<seq_number, byte_size(dsk.raw)>> <> dsk.raw
   end
 
   @impl true
   @spec decode_params(binary) :: {:ok, [param()]} | {:error, DecodeError.t()}
   def decode_params(<<seq_number, _, dsk_bin::binary>>) do
-    case DSK.binary_to_string(dsk_bin) do
-      {:ok, dsk} ->
-        {:ok, [seq_number: seq_number, dsk: dsk]}
-
-      {:error, _} ->
-        {:error, %DecodeError{value: dsk_bin, param: :dsk, command: :node_provisioning_delete}}
-    end
+    {:ok, [seq_number: seq_number, dsk: DSK.new(dsk_bin)]}
   end
 end

--- a/lib/grizzly/zwave/commands/node_provisioning_report.ex
+++ b/lib/grizzly/zwave/commands/node_provisioning_report.ex
@@ -19,7 +19,7 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningReport do
 
   @type param ::
           {:seq_number, Grizzly.ZWave.seq_number()}
-          | {:dsk, DSK.dsk_string()}
+          | {:dsk, DSK.t()}
           | {:meta_extensions, [MetaExtension.t()]}
 
   @impl true
@@ -40,7 +40,7 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningReport do
   @spec encode_params(Command.t()) :: binary()
   def encode_params(command) do
     seq_number = Command.param!(command, :seq_number)
-    {:ok, dsk_binary} = NodeProvisioning.optional_dsk_to_binary(Command.param!(command, :dsk))
+    dsk_binary = NodeProvisioning.optional_dsk_to_binary(Command.param!(command, :dsk))
     dsk_byte_size = byte_size(dsk_binary)
     meta_extensions = Command.param!(command, :meta_extensions)
 
@@ -53,18 +53,15 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningReport do
         <<seq_number, _::size(3), dsk_byte_size::size(5),
           dsk_binary::size(dsk_byte_size)-unit(8)-binary, meta_extensions_binary::binary>>
       ) do
-    with {:ok, dsk_string} <- NodeProvisioning.optional_binary_to_dsk(dsk_binary),
+    with dsk = NodeProvisioning.optional_binary_to_dsk(dsk_binary),
          {:ok, meta_extensions} <- MetaExtension.extensions_from_binary(meta_extensions_binary) do
       {:ok,
        [
          seq_number: seq_number,
-         dsk: dsk_string,
+         dsk: dsk,
          meta_extensions: meta_extensions
        ]}
     else
-      {:error, reason} when reason in [:dsk_too_short, :dsk_too_long] ->
-        {:error, %DecodeError{value: dsk_binary, param: :dsk, command: :node_provisioning_report}}
-
       {:error, _other} ->
         {:error,
          %DecodeError{
@@ -76,7 +73,7 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningReport do
   end
 
   defp params_with_defaults(params) do
-    defaults = [meta_extensions: [], dsk: ""]
+    defaults = [meta_extensions: [], dsk: nil]
     Keyword.merge(defaults, params)
   end
 end

--- a/lib/grizzly/zwave/commands/node_provisioning_set.ex
+++ b/lib/grizzly/zwave/commands/node_provisioning_set.ex
@@ -21,7 +21,7 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningSet do
 
   @type param ::
           {:seq_number, Grizzly.ZWave.seq_number()}
-          | {:dsk, DSK.dsk_string()}
+          | {:dsk, DSK.t()}
           | {:meta_extensions, [MetaExtension.t()]}
 
   @impl true
@@ -43,11 +43,11 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningSet do
   def encode_params(command) do
     seq_number = Command.param!(command, :seq_number)
     meta_extensions = Command.param!(command, :meta_extensions)
-    {:ok, dsk_binary} = DSK.string_to_binary(Command.param!(command, :dsk))
-    dsk_byte_size = byte_size(dsk_binary)
+    dsk = Command.param!(command, :dsk)
+    dsk_byte_size = byte_size(dsk.raw)
 
     <<seq_number, 0x00::size(3), dsk_byte_size::size(5)>> <>
-      dsk_binary <> NodeProvisioning.encode_meta_extensions(meta_extensions)
+      dsk.raw <> NodeProvisioning.encode_meta_extensions(meta_extensions)
   end
 
   @impl true

--- a/test/grizzly/inclusions/inclusion_runner_test.exs
+++ b/test/grizzly/inclusions/inclusion_runner_test.exs
@@ -2,7 +2,7 @@ defmodule Grizzly.Inclusions.InclusionRunnerTest do
   use ExUnit.Case
 
   alias Grizzly.Inclusions.InclusionRunner
-  alias Grizzly.ZWave.Command
+  alias Grizzly.ZWave.{Command, DSK}
   alias GrizzlyTest.Utils
 
   defmodule TestHandler do
@@ -139,7 +139,9 @@ defmodule Grizzly.Inclusions.InclusionRunnerTest do
     assert next_report.command.name == :node_add_dsk_report
     assert Command.param!(next_report.command, :input_dsk_length) == 2
 
-    :ok = InclusionRunner.set_dsk(runner, 12345)
+    {:ok, dsk} = DSK.parse("12345")
+
+    :ok = InclusionRunner.set_dsk(runner, dsk)
 
     assert_receive {:grizzly, :report, last_report}, 1000
 

--- a/test/grizzly/zwave/commands/dsk_report_test.exs
+++ b/test/grizzly/zwave/commands/dsk_report_test.exs
@@ -1,13 +1,17 @@
 defmodule Grizzly.ZWave.Commands.DSKReportTest do
   use ExUnit.Case, async: true
 
-  alias Grizzly.ZWave.Command
+  alias Grizzly.ZWave.{Command, DSK}
   alias Grizzly.ZWave.Commands.DSKReport
 
+  @dsk_string "50285-18819-09924-30691-15973-33711-04005-03623"
+
   test "creates the command and validates params" do
+    {:ok, dsk} = DSK.parse(@dsk_string)
+
     params = [
       seq_number: 0x01,
-      dsk: "50285-18819-09924-30691-15973-33711-04005-03623",
+      dsk: dsk,
       add_mode: :learn
     ]
 
@@ -15,9 +19,11 @@ defmodule Grizzly.ZWave.Commands.DSKReportTest do
   end
 
   test "encodes params correctly" do
+    {:ok, dsk} = DSK.parse(@dsk_string)
+
     params = [
       seq_number: 0x01,
-      dsk: "50285-18819-09924-30691-15973-33711-04005-03623",
+      dsk: dsk,
       add_mode: :learn
     ]
 
@@ -30,6 +36,8 @@ defmodule Grizzly.ZWave.Commands.DSKReportTest do
   end
 
   test "decodes params correctly" do
+    {:ok, dsk} = DSK.parse(@dsk_string)
+
     binary =
       <<0x01, 0x00, 196, 109, 73, 131, 38, 196, 119, 227, 62, 101, 131, 175, 15, 165, 14, 39>>
 
@@ -37,6 +45,7 @@ defmodule Grizzly.ZWave.Commands.DSKReportTest do
 
     assert Keyword.get(params, :seq_number) == 0x01
     assert Keyword.get(params, :add_mode) == :learn
-    assert Keyword.get(params, :dsk) == "50285-18819-09924-30691-15973-33711-04005-03623"
+
+    assert Keyword.get(params, :dsk) == dsk
   end
 end

--- a/test/grizzly/zwave/commands/learn_mode_set_status_test.exs
+++ b/test/grizzly/zwave/commands/learn_mode_set_status_test.exs
@@ -2,6 +2,7 @@ defmodule Grizzly.ZWave.Commands.LearnModeSetStatusTest do
   use ExUnit.Case, async: true
 
   alias Grizzly.ZWave.Commands.LearnModeSetStatus
+  alias GrizzlyTest.Utils
 
   describe "creates the command and validates params" do
     test "v1" do
@@ -21,7 +22,7 @@ defmodule Grizzly.ZWave.Commands.LearnModeSetStatusTest do
         new_node_id: 10,
         granted_keys: [:s2_authenticated],
         kex_fail_type: :none,
-        dsk: "00000-11111-22222-33333-44444-55555-66666-77777"
+        dsk: Utils.mkdsk()
       ]
 
       {:ok, _command} = LearnModeSetStatus.new(params)
@@ -48,7 +49,7 @@ defmodule Grizzly.ZWave.Commands.LearnModeSetStatusTest do
         new_node_id: 10,
         granted_keys: [:s2_authenticated],
         kex_fail_type: :none,
-        dsk: "50285-18819-09924-30691-15973-33711-04005-03623"
+        dsk: Utils.mkdsk()
       ]
 
       {:ok, command} = LearnModeSetStatus.new(params)
@@ -80,7 +81,7 @@ defmodule Grizzly.ZWave.Commands.LearnModeSetStatusTest do
       assert Keyword.get(params, :status) == :done
       assert Keyword.get(params, :new_node_id) == 10
       assert Keyword.get(params, :granted_keys) == [:s2_authenticated]
-      assert Keyword.get(params, :dsk) == "50285-18819-09924-30691-15973-33711-04005-03623"
+      assert Keyword.get(params, :dsk) == Utils.mkdsk()
     end
   end
 end

--- a/test/grizzly/zwave/commands/node_add_dsk_set_test.exs
+++ b/test/grizzly/zwave/commands/node_add_dsk_set_test.exs
@@ -1,23 +1,27 @@
 defmodule Grizzly.ZWave.Commands.NodeAddDSKSetTest do
   use ExUnit.Case, async: true
 
+  alias Grizzly.ZWave.DSK
   alias Grizzly.ZWave.Commands.NodeAddDSKSet
 
   test "creates the command and validates params" do
-    params = [seq_number: 1, accept: true, input_dsk_length: 2, input_dsk: 46411]
+    {:ok, dsk} = DSK.parse("46411")
+    params = [seq_number: 1, accept: true, input_dsk_length: 2, input_dsk: dsk]
     {:ok, _command} = NodeAddDSKSet.new(params)
   end
 
   describe "encodes params correctly" do
     test "encodes full bytes" do
-      params = [seq_number: 1, accept: true, input_dsk_length: 2, input_dsk: 46411]
+      {:ok, dsk} = DSK.parse("46411")
+      params = [seq_number: 1, accept: true, input_dsk_length: 2, input_dsk: dsk]
       {:ok, command} = NodeAddDSKSet.new(params)
       expected_binary = <<0x01, 0x01::size(1), 0x00::size(3), 0x02::size(4), 0xB5, 0x4B>>
       assert expected_binary == NodeAddDSKSet.encode_params(command)
     end
 
     test "encodes padded byte" do
-      params = [seq_number: 1, accept: true, input_dsk_length: 2, input_dsk: 159]
+      {:ok, dsk} = DSK.parse("00159")
+      params = [seq_number: 1, accept: true, input_dsk_length: 2, input_dsk: dsk]
       {:ok, command} = NodeAddDSKSet.new(params)
       expected_binary = <<0x01, 0x01::size(1), 0x00::size(3), 0x02::size(4), 0x00, 0x9F>>
       assert expected_binary == NodeAddDSKSet.encode_params(command)
@@ -26,21 +30,23 @@ defmodule Grizzly.ZWave.Commands.NodeAddDSKSetTest do
 
   describe "decodes params correctly" do
     test "decodes full bytes" do
+      {:ok, expected_dsk} = DSK.parse("46411")
       binary_params = <<0x01, 0x01::size(1), 0x00::size(3), 0x02::size(4), 0xB5, 0x4B>>
       {:ok, params} = NodeAddDSKSet.decode_params(binary_params)
       assert Keyword.get(params, :seq_number) == 1
       assert Keyword.get(params, :accept) == true
       assert Keyword.get(params, :input_dsk_length) == 2
-      assert Keyword.get(params, :input_dsk) == 46411
+      assert Keyword.get(params, :input_dsk) == expected_dsk
     end
 
     test "decodes padded bytes" do
+      {:ok, expected_dsk} = DSK.parse("00159")
       binary_params = <<0x01, 0x01::size(1), 0x00::size(3), 0x02::size(4), 0x00, 0x9F>>
       {:ok, params} = NodeAddDSKSet.decode_params(binary_params)
       assert Keyword.get(params, :seq_number) == 1
       assert Keyword.get(params, :accept) == true
       assert Keyword.get(params, :input_dsk_length) == 2
-      assert Keyword.get(params, :input_dsk) == 159
+      assert Keyword.get(params, :input_dsk) == expected_dsk
     end
   end
 end

--- a/test/grizzly/zwave/commands/node_provisioning_delete_test.exs
+++ b/test/grizzly/zwave/commands/node_provisioning_delete_test.exs
@@ -2,14 +2,15 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningDeleteTest do
   use ExUnit.Case, async: true
 
   alias Grizzly.ZWave.Commands.NodeProvisioningDelete
+  alias GrizzlyTest.Utils
 
   test "creates the command and validates params" do
-    params = [seq_number: 0x01, dsk: "50285-18819-09924-30691-15973-33711-04005-03623"]
+    params = [seq_number: 0x01, dsk: Utils.mkdsk()]
     {:ok, _command} = NodeProvisioningDelete.new(params)
   end
 
   test "encodes params correctly" do
-    params = [seq_number: 0x01, dsk: "50285-18819-09924-30691-15973-33711-04005-03623"]
+    params = [seq_number: 0x01, dsk: Utils.mkdsk()]
     {:ok, command} = NodeProvisioningDelete.new(params)
 
     expected_binary =
@@ -24,6 +25,6 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningDeleteTest do
 
     {:ok, params} = NodeProvisioningDelete.decode_params(binary_params)
     assert Keyword.get(params, :seq_number) == 1
-    assert Keyword.get(params, :dsk) == "50285-18819-09924-30691-15973-33711-04005-03623"
+    assert Keyword.get(params, :dsk) == Utils.mkdsk()
   end
 end

--- a/test/grizzly/zwave/commands/node_provisioning_get_test.exs
+++ b/test/grizzly/zwave/commands/node_provisioning_get_test.exs
@@ -2,14 +2,15 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningGetTest do
   use ExUnit.Case, async: true
 
   alias Grizzly.ZWave.Commands.NodeProvisioningGet
+  alias GrizzlyTest.Utils
 
   test "creates the command and validates params" do
-    params = [seq_number: 0x01, dsk: "50285-18819-09924-30691-15973-33711-04005-03623"]
+    params = [seq_number: 0x01, dsk: Utils.mkdsk()]
     {:ok, _command} = NodeProvisioningGet.new(params)
   end
 
   test "encodes params correctly" do
-    params = [seq_number: 0x01, dsk: "50285-18819-09924-30691-15973-33711-04005-03623"]
+    params = [seq_number: 0x01, dsk: Utils.mkdsk()]
     {:ok, command} = NodeProvisioningGet.new(params)
 
     expected_binary =
@@ -24,6 +25,6 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningGetTest do
 
     {:ok, params} = NodeProvisioningGet.decode_params(binary_params)
     assert Keyword.get(params, :seq_number) == 1
-    assert Keyword.get(params, :dsk) == "50285-18819-09924-30691-15973-33711-04005-03623"
+    assert Keyword.get(params, :dsk) == Utils.mkdsk()
   end
 end

--- a/test/grizzly/zwave/commands/node_provisioning_list_iteration_report_test.exs
+++ b/test/grizzly/zwave/commands/node_provisioning_list_iteration_report_test.exs
@@ -2,6 +2,7 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningListIterationReportTest do
   use ExUnit.Case, async: true
 
   alias Grizzly.ZWave.Commands.NodeProvisioningListIterationReport
+  alias GrizzlyTest.Utils
 
   test "creates the command and validates params" do
     params = [
@@ -18,7 +19,7 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningListIterationReportTest do
     params = [
       seq_number: 0x01,
       remaining_count: 2,
-      dsk: "50285-18819-09924-30691-15973-33711-04005-03623",
+      dsk: Utils.mkdsk(),
       meta_extensions: []
     ]
 
@@ -39,7 +40,7 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningListIterationReportTest do
     {:ok, params} = NodeProvisioningListIterationReport.decode_params(binary_params)
     assert Keyword.get(params, :seq_number) == 1
     assert Keyword.get(params, :remaining_count) == 2
-    assert Keyword.get(params, :dsk) == "50285-18819-09924-30691-15973-33711-04005-03623"
+    assert Keyword.get(params, :dsk) == Utils.mkdsk()
     assert Keyword.get(params, :meta_extensions) == []
   end
 end

--- a/test/grizzly/zwave/commands/node_provisioning_report_test.exs
+++ b/test/grizzly/zwave/commands/node_provisioning_report_test.exs
@@ -2,11 +2,12 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningReportTest do
   use ExUnit.Case, async: true
 
   alias Grizzly.ZWave.Commands.NodeProvisioningReport
+  alias GrizzlyTest.Utils
 
   test "creates the command and validates params" do
     params = [
       seq_number: 0x01,
-      dsk: "50285-18819-09924-30691-15973-33711-04005-03623",
+      dsk: Utils.mkdsk(),
       meta_extensions: []
     ]
 
@@ -16,7 +17,7 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningReportTest do
   test "encodes params correctly" do
     params = [
       seq_number: 0x01,
-      dsk: "50285-18819-09924-30691-15973-33711-04005-03623",
+      dsk: Utils.mkdsk(),
       meta_extensions: []
     ]
 
@@ -28,10 +29,9 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningReportTest do
     assert expected_binary == NodeProvisioningReport.encode_params(command)
   end
 
-  test "encodes params correctly with empty dsk" do
+  test "encodes params correctly with no DSK" do
     params = [
       seq_number: 0x01,
-      dsk: "",
       meta_extensions: []
     ]
 
@@ -48,7 +48,7 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningReportTest do
 
     {:ok, params} = NodeProvisioningReport.decode_params(binary_params)
     assert Keyword.get(params, :seq_number) == 1
-    assert Keyword.get(params, :dsk) == "50285-18819-09924-30691-15973-33711-04005-03623"
+    assert Keyword.get(params, :dsk) == Utils.mkdsk()
     assert Keyword.get(params, :meta_extensions) == []
   end
 
@@ -57,7 +57,7 @@ defmodule Grizzly.ZWave.Commands.NodeProvisioningReportTest do
 
     {:ok, params} = NodeProvisioningReport.decode_params(binary_params)
     assert Keyword.get(params, :seq_number) == 1
-    assert Keyword.get(params, :dsk) == ""
+    assert Keyword.get(params, :dsk) == nil
     assert Keyword.get(params, :meta_extensions) == []
   end
 end

--- a/test/grizzly/zwave/commands/smart_start_join_started_test.exs
+++ b/test/grizzly/zwave/commands/smart_start_join_started_test.exs
@@ -2,11 +2,12 @@ defmodule Grizzly.ZWave.Commands.SmartStartJoinStartedTest do
   use ExUnit.Case, async: true
 
   alias Grizzly.ZWave.Commands.SmartStartJoinStarted
+  alias GrizzlyTest.Utils
 
   test "creates the command and validates params" do
     params = [
       seq_number: 0x01,
-      dsk: "50285-18819-09924-30691-15973-33711-04005-03623"
+      dsk: Utils.mkdsk()
     ]
 
     {:ok, _command} = SmartStartJoinStarted.new(params)
@@ -15,7 +16,7 @@ defmodule Grizzly.ZWave.Commands.SmartStartJoinStartedTest do
   test "encodes params correctly" do
     params = [
       seq_number: 0x01,
-      dsk: "50285-18819-09924-30691-15973-33711-04005-03623"
+      dsk: Utils.mkdsk()
     ]
 
     {:ok, command} = SmartStartJoinStarted.new(params)
@@ -32,6 +33,6 @@ defmodule Grizzly.ZWave.Commands.SmartStartJoinStartedTest do
 
     {:ok, params} = SmartStartJoinStarted.decode_params(binary_params)
     assert Keyword.get(params, :seq_number) == 1
-    assert Keyword.get(params, :dsk) == "50285-18819-09924-30691-15973-33711-04005-03623"
+    assert Keyword.get(params, :dsk) == Utils.mkdsk()
   end
 end

--- a/test/grizzly/zwave/dsk_test.exs
+++ b/test/grizzly/zwave/dsk_test.exs
@@ -1,0 +1,40 @@
+defmodule Grizzly.ZWave.DSKTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave.DSK
+  doctest DSK
+
+  @dsk_string "33654-49908-42539-00289-58381-21884-63570-22247"
+  @dsk_binary <<33654::16, 49908::16, 42539::16, 00289::16, 58381::16, 21884::16, 63570::16,
+                22247::16>>
+  @dsk_struct %DSK{raw: @dsk_binary}
+
+  test "new/1" do
+  end
+
+  test "parse/1" do
+    assert {:ok, @dsk_struct} == DSK.parse(@dsk_string)
+    assert {:ok, @dsk_struct} == DSK.parse(String.replace(@dsk_string, "-", " "))
+    assert {:ok, @dsk_struct} == DSK.parse(String.replace(@dsk_string, "-", ""))
+
+    assert {:ok, %DSK{raw: <<12345::16>>}} == DSK.parse("12345")
+    assert {:ok, %DSK{raw: <<0::16>>}} == DSK.parse("00000")
+
+    assert {:error, :invalid_dsk} == DSK.parse(@dsk_string <> "12345")
+    assert {:error, :invalid_dsk} == DSK.parse("")
+    assert {:error, :invalid_dsk} == DSK.parse("70000")
+    assert {:error, :invalid_dsk} == DSK.parse("12ABC")
+    assert {:error, :invalid_dsk} == DSK.parse("1234")
+    assert {:error, :invalid_dsk} == DSK.parse("123")
+    assert {:error, :invalid_dsk} == DSK.parse("12")
+    assert {:error, :invalid_dsk} == DSK.parse("1")
+  end
+
+  test "to_string/1" do
+    assert DSK.to_string(@dsk_struct) == @dsk_string
+  end
+
+  test "inspecting a DSK" do
+    assert inspect(@dsk_struct) == "#DSK<" <> @dsk_string <> ">"
+  end
+end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -2,6 +2,7 @@ defmodule GrizzlyTest.Utils do
   @moduledoc false
 
   alias Grizzly.Options
+  alias Grizzly.ZWave.DSK
 
   @spec default_options_args() :: [Grizzly.Supervisor.arg()]
   def default_options_args() do
@@ -17,5 +18,13 @@ defmodule GrizzlyTest.Utils do
   def default_options() do
     default_options_args()
     |> Options.new()
+  end
+
+  @spec mkdsk() :: DSK.t()
+  def mkdsk() do
+    dsk_string = "50285-18819-09924-30691-15973-33711-04005-03623"
+    {:ok, dsk} = DSK.parse(dsk_string)
+
+    dsk
   end
 end


### PR DESCRIPTION
The old implementation of the DSK support was lacking some useful
features. These updates allow better handle the various edge cases
with DSK inputs.

This changes `Grizzly.Inclusions.set_input_dsk/1` to take the new
`Grizzly.ZWave.DSK.t()`. Also, setting and getting node provisionings
will now use the `DSK.t()`. These are breaking changes but the new
abstraction provides better handling of DSKs.

To see an example of the change effecting setting the DSK during S2 inclusion:
https://github.com/smartrent/grizzly/compare/dsk-updates?expand=1#diff-7630ee3c7687384efe4cfc02f9d42a0654ca79b45a0d704a2e787010f85a8a10R228-R229