### PR TITLE
Ensure that required zipgateway files are written

### DIFF
--- a/lib/grizzly/zipgateway/supervisor.ex
+++ b/lib/grizzly/zipgateway/supervisor.ex
@@ -36,6 +36,7 @@ defmodule Grizzly.ZIPGateway.Supervisor do
     :ok =
       options
       |> Options.to_zipgateway_config(use_database?())
+      |> Config.ensure_files()
       |> Config.write(options.zipgateway_config_path)
 
     _ = System.cmd("modprobe", ["tun"])

--- a/test/grizzly/zipgateway/config_test.exs
+++ b/test/grizzly/zipgateway/config_test.exs
@@ -12,7 +12,7 @@ defmodule Grizzly.ZIPGateway.ConfigTest do
     ZipPrivKey=./ZIPR.key_1024.pem
     TunScript=./zipgateway.tun
     PVSStorageFile=/root/provisioning_list_store.dat
-    ProvisioningConfigFile=/etc/zipgateway_provisioning_list.cfg
+    ProvisioningConfigFile=/data/zipgateway_provisioning_list.cfg
     ZipLanGw6=::1
     ZipPSK=123456789012345678901234567890AA
     ExtraClasses= 133 89 90 142 108 143
@@ -35,7 +35,7 @@ defmodule Grizzly.ZIPGateway.ConfigTest do
     ZipPrivKey=./ZIPR.key_1024.pem
     TunScript=./zipgateway.tun
     PVSStorageFile=/root/provisioning_list_store.dat
-    ProvisioningConfigFile=/etc/zipgateway_provisioning_list.cfg
+    ProvisioningConfigFile=/data/zipgateway_provisioning_list.cfg
     ZipLanGw6=::1
     ZipPSK=123456789012345678901234567890AA
     ExtraClasses= 133 89 90 142 108 143
@@ -59,7 +59,7 @@ defmodule Grizzly.ZIPGateway.ConfigTest do
     ZipPrivKey=./ZIPR.key_1024.pem
     TunScript=./zipgateway.tun
     PVSStorageFile=/root/provisioning_list_store.dat
-    ProvisioningConfigFile=/etc/zipgateway_provisioning_list.cfg
+    ProvisioningConfigFile=/data/zipgateway_provisioning_list.cfg
     ZipLanGw6=::1
     ZipPSK=123456789012345678901234567890AA
     ZipProductID=1
@@ -86,7 +86,7 @@ defmodule Grizzly.ZIPGateway.ConfigTest do
     ZipPrivKey=./ZIPR.key_1024.pem
     TunScript=./zipgateway.tun
     PVSStorageFile=/root/provisioning_list_store.dat
-    ProvisioningConfigFile=/etc/zipgateway_provisioning_list.cfg
+    ProvisioningConfigFile=/data/zipgateway_provisioning_list.cfg
     ZipLanGw6=::1
     ZipPSK=123456789012345678901234567890AA
     ExtraClasses= 133 89 90 142 108 143


### PR DESCRIPTION
Various tools that are part of the `zipgateway` ecosystem require
particular files to exist and to be in a writable location.