### PR TITLE
Ensure that the DSK binary is 128 bits; add test

### DIFF
--- a/lib/grizzly/zwave/commands/node_add_dsk_set.ex
+++ b/lib/grizzly/zwave/commands/node_add_dsk_set.ex
@@ -80,7 +80,7 @@ defmodule Grizzly.ZWave.Commands.NodeAddDSKSet do
     <<>>
   end
 
-  defp dsk_to_binary(%DSK{} = dsk, _dsk_length) do
-    dsk.raw
+  defp dsk_to_binary(%DSK{} = dsk, dsk_len) do
+    :binary.part(dsk.raw, 0, dsk_len)
   end
 end

--- a/lib/grizzly/zwave/dsk.ex
+++ b/lib/grizzly/zwave/dsk.ex
@@ -37,10 +37,18 @@ defmodule Grizzly.ZWave.DSK do
 
   @doc """
   Make a new DSK
+
+  If less than 16 bytes are passed in, the rest are initialized to zero.
+  Due to how DSKs are constructed, odd length binaries aren't allowed since
+  they should never be possible.
   """
   @spec new(binary()) :: t()
-  def new(dsk_binary) when byte_size(dsk_binary) <= 16 and is_even(byte_size(dsk_binary)) do
+  def new(dsk_binary) when byte_size(dsk_binary) == 16 do
     %__MODULE__{raw: dsk_binary}
+  end
+
+  def new(dsk_binary) when byte_size(dsk_binary) < 16 and is_even(byte_size(dsk_binary)) do
+    new(dsk_binary <> <<0::16>>)
   end
 
   @doc """
@@ -52,7 +60,7 @@ defmodule Grizzly.ZWave.DSK do
   end
 
   defp do_parse(<<>>, parts) when parts != <<>> and byte_size(parts) <= 16 do
-    {:ok, %__MODULE__{raw: parts}}
+    {:ok, new(parts)}
   end
 
   defp do_parse(<<sep, rest::binary>>, parts) when sep in [?-, ?\s] do

--- a/test/grizzly/zwave/dsk_test.exs
+++ b/test/grizzly/zwave/dsk_test.exs
@@ -7,9 +7,30 @@ defmodule Grizzly.ZWave.DSKTest do
   @dsk_string "33654-49908-42539-00289-58381-21884-63570-22247"
   @dsk_binary <<33654::16, 49908::16, 42539::16, 00289::16, 58381::16, 21884::16, 63570::16,
                 22247::16>>
-  @dsk_struct %DSK{raw: @dsk_binary}
+  @dsk_struct DSK.new(@dsk_binary)
 
   test "new/1" do
+    # Normal case
+    assert %DSK{raw: @dsk_binary} == DSK.new(@dsk_binary)
+
+    # 5-digit partial DSK case when handling PINs
+    assert %DSK{raw: <<12345::16, 0::112>>} == DSK.new(<<12345::16>>)
+
+    # Empty
+    assert %DSK{raw: <<0::128>>} == DSK.new(<<>>)
+
+    # Odd lengths in bytes
+    assert_raise FunctionClauseError, fn -> DSK.new(<<123::8>>) end
+    assert_raise FunctionClauseError, fn -> DSK.new(<<123::24>>) end
+    assert_raise FunctionClauseError, fn -> DSK.new(<<123::40>>) end
+    assert_raise FunctionClauseError, fn -> DSK.new(<<123::56>>) end
+    assert_raise FunctionClauseError, fn -> DSK.new(<<123::72>>) end
+    assert_raise FunctionClauseError, fn -> DSK.new(<<123::88>>) end
+    assert_raise FunctionClauseError, fn -> DSK.new(<<123::104>>) end
+    assert_raise FunctionClauseError, fn -> DSK.new(<<123::120>>) end
+
+    # Too long
+    assert_raise FunctionClauseError, fn -> DSK.new(<<123::144>>) end
   end
 
   test "parse/1" do
@@ -17,8 +38,8 @@ defmodule Grizzly.ZWave.DSKTest do
     assert {:ok, @dsk_struct} == DSK.parse(String.replace(@dsk_string, "-", " "))
     assert {:ok, @dsk_struct} == DSK.parse(String.replace(@dsk_string, "-", ""))
 
-    assert {:ok, %DSK{raw: <<12345::16>>}} == DSK.parse("12345")
-    assert {:ok, %DSK{raw: <<0::16>>}} == DSK.parse("00000")
+    assert {:ok, DSK.new(<<12345::16, 0::112>>)} == DSK.parse("12345")
+    assert {:ok, DSK.new(<<0::128>>)} == DSK.parse("00000")
 
     assert {:error, :invalid_dsk} == DSK.parse(@dsk_string <> "12345")
     assert {:error, :invalid_dsk} == DSK.parse("")


### PR DESCRIPTION
DSK.new/1 was untested. This fixes that.

The type spec for DSK.t() also requires that the binary be 128 bits
internally. This is nice since it means that DSK functions don't have to
worry about empty or short binaries. It, however, was not implemented
that way and binaries could be any even size between 0 and 16 bytes.
