### PR TITLE
Zip ND command class

### DIFF
--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -315,7 +315,14 @@ defmodule Grizzly.Commands.Table do
       {:rssi_get, {Commands.RssiGet, handler: {WaitReport, complete_report: :rssiReport}}},
       # Zwaveplus Info
       {:zwaveplus_info_get,
-       {Commands.ZwaveplusInfoGet, handler: {WaitReport, complete_report: :zwaveplus_info_report}}}
+       {Commands.ZwaveplusInfoGet, handler: {WaitReport, complete_report: :zwaveplus_info_report}}},
+      # Zip ND
+      {:zip_node_solicitation,
+       {Commands.ZipNodeSolicitation,
+        handler: {WaitReport, complete_report: :zip_node_advertisement}}},
+      {:zip_inverse_node_solicitation,
+       {Commands.ZipInverseNodeSolicitation,
+        handler: {WaitReport, complete_report: :zip_node_advertisement}}}
     ]
 
     defmacro __before_compile__(_) do

--- a/lib/grizzly/zwave/command_classes/zip_nd.ex
+++ b/lib/grizzly/zwave/command_classes/zip_nd.ex
@@ -1,0 +1,61 @@
+defmodule Grizzly.ZWave.CommandClasses.ZipND do
+  @moduledoc """
+  "ZipND" Command Class
+
+  Z/IP ND Command Class builds on the same principles as IPv6 ND and is inspired by the frame
+  formats.
+  """
+
+  @behaviour Grizzly.ZWave.CommandClass
+  alias Grizzly.ZWave.DecodeError
+
+  @type validity :: :information_ok | :information_obsolete | :information_not_found
+  # e.g. "0306:0709:0803:0405:0708:0905:0607:0809"
+  @type ipv6 :: String.t()
+
+  @impl true
+  def byte(), do: 0x58
+
+  @impl true
+  def name(), do: :zip_nd
+
+  @doc "Convert validity to byte"
+  @spec validity_to_byte(validity) :: byte
+  def validity_to_byte(:information_ok), do: 0x00
+  def validity_to_byte(:information_obsolete), do: 0x01
+  def validity_to_byte(:information_not_found), do: 0x02
+
+  @doc "Validity from byte"
+  @spec validity_from_byte(byte) :: {:ok, validity} | {:error, %DecodeError{}}
+  def validity_from_byte(0x00), do: {:ok, :information_ok}
+  def validity_from_byte(0x01), do: {:ok, :information_obsolete}
+  def validity_from_byte(0x02), do: {:ok, :information_not_found}
+  def validity_from_byte(byte), do: {:error, %DecodeError{value: byte, param: :validity}}
+
+  @doc "Decoce IPV6 address"
+  @spec decode_ipv6_address(binary) :: {:ok, ipv6} | {:error, %DecodeError{}}
+  def decode_ipv6_address(binary) do
+    quartets = for(<<quartet::size(16) <- binary>>, do: Integer.to_string(quartet, 16))
+
+    if Enum.count(quartets) == 8 do
+      ipv6_address =
+        quartets
+        |> Enum.map(&String.pad_leading(&1, 4, "0"))
+        |> Enum.join(":")
+
+      {:ok, ipv6_address}
+    else
+      {:error, %DecodeError{value: binary, param: :ipv6_address}}
+    end
+  end
+
+  @doc "Encode IPV6 address to binary"
+  @spec encode_ipv6_address(ipv6) :: binary
+  def encode_ipv6_address(ipv6) do
+    String.split(ipv6, ":")
+    |> Enum.reduce(<<>>, fn quartet, acc ->
+      bytes = Integer.parse(quartet, 16) |> elem(0)
+      acc <> <<bytes::size(16)>>
+    end)
+  end
+end

--- a/lib/grizzly/zwave/commands/zip_inverse_node_solicitation.ex
+++ b/lib/grizzly/zwave/commands/zip_inverse_node_solicitation.ex
@@ -1,0 +1,48 @@
+defmodule Grizzly.ZWave.Commands.ZipInverseNodeSolicitation do
+  @moduledoc """
+  Used to resolve a NodeID (link-layer address) of a Z-Wave node to an IPv6 address of that node in its actual Z-Wave HAN / IP subnet.
+
+  Params:
+
+    * `:node_id` - The NodeID that is to be resolved to an IPv6 address (required)
+
+    * `:local` - The flag indicates that the requester would like to receive the site-local address (a.k.a. ULA) even if a
+                 global address exists (required)
+
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.{Command, DecodeError}
+  alias Grizzly.ZWave.CommandClasses.ZipND
+
+  @type param :: {:node_id, byte} | {:local, boolean}
+
+  @impl true
+  @spec new([param()]) :: {:ok, Command.t()}
+  def new(params) do
+    command = %Command{
+      name: :zip_inverse_node_solicitation,
+      command_byte: 0x04,
+      command_class: ZipND,
+      params: params,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl true
+  @spec encode_params(Command.t()) :: binary()
+  def encode_params(command) do
+    node_id = Command.param!(command, :node_id)
+    local_bit = if Command.param!(command, :local), do: 0x01, else: 0x00
+    <<0x00::size(4), local_bit::size(1), 0x00::size(3), node_id>>
+  end
+
+  @impl true
+  @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
+  def decode_params(<<_reserved::size(4), local_bit::size(1), _also_reserved::size(3), node_id>>) do
+    {:ok, [node_id: node_id, local: local_bit == 0x01]}
+  end
+end

--- a/lib/grizzly/zwave/commands/zip_node_advertisement.ex
+++ b/lib/grizzly/zwave/commands/zip_node_advertisement.ex
@@ -1,0 +1,81 @@
+defmodule Grizzly.ZWave.Commands.ZipNodeAdvertisement do
+  @moduledoc """
+  Sent by a Z/IP Gateway in response to a unicast Zip Node
+  Solicitation or a unicast Zip Inverse Node Solicitation. The Zip Node Advertisement SHOULD advertise
+  valid information in both the IPv6 Address and NodeID fields if such information.
+
+  Params:
+
+    * `:node_id - The node id (required)
+
+    * `:local` - whether the requester asked for the site-local address (required)
+
+    * `:validity` - indicates the validity of the returned information (required)
+
+    * `:ipv6_address` - the IPv6 Address of the node (required)
+
+    * `:home_id` - Unique network address of the link layer network. All nodes in a Z-Wave network share the same Home ID (required)
+
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.{Command, DecodeError}
+  alias Grizzly.ZWave.CommandClasses.ZipND
+
+  @type param ::
+          {:node_id, byte}
+          | {:local, boolean}
+          | {:validity, ZipND.validity()}
+          | {:ipv6_address, ZipND.ipv6()}
+          | {:home_id, non_neg_integer}
+
+  @impl true
+  @spec new([param()]) :: {:ok, Command.t()}
+  def new(params) do
+    command = %Command{
+      name: :zip_node_advertisement,
+      command_byte: 0x01,
+      command_class: ZipND,
+      params: params,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl true
+  @spec encode_params(Command.t()) :: binary()
+  def encode_params(command) do
+    node_id = Command.param!(command, :node_id)
+    local_bit = if Command.param!(command, :local), do: 0x01, else: 0x00
+    validity_byte = Command.param!(command, :validity) |> ZipND.validity_to_byte()
+    ipv6_binary = Command.param!(command, :ipv6_address) |> ZipND.encode_ipv6_address()
+    home_id = Command.param!(command, :home_id)
+
+    <<0x00::size(5), local_bit::size(1), validity_byte::size(2), node_id>> <>
+      ipv6_binary <> <<home_id::integer-unsigned-size(4)-unit(8)>>
+  end
+
+  @impl true
+  @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
+  def decode_params(
+        <<_reserved::size(5), local_bit::size(1), validity_byte::size(2), node_id,
+          ipv6_binary::binary-size(16), home_id::integer-unsigned-size(4)-unit(8)>>
+      ) do
+    with {:ok, ipv6_address} <- ZipND.decode_ipv6_address(ipv6_binary),
+         {:ok, validity} <- ZipND.validity_from_byte(validity_byte) do
+      {:ok,
+       [
+         node_id: node_id,
+         validity: validity,
+         local: local_bit == 0x01,
+         ipv6_address: ipv6_address,
+         home_id: home_id
+       ]}
+    else
+      {:error, %DecodeError{} = error} ->
+        {:error, %DecodeError{error | command: :zip_node_advertisement}}
+    end
+  end
+end

--- a/lib/grizzly/zwave/commands/zip_node_solicitation.ex
+++ b/lib/grizzly/zwave/commands/zip_node_solicitation.ex
@@ -1,0 +1,51 @@
+defmodule Grizzly.ZWave.Commands.ZipNodeSolicitation do
+  @moduledoc """
+  This command is used to resolve an IPv6 address of a Z-Wave node to the NodeID
+  of that node.
+
+  Params:
+
+    * `:ipv6_address` - The IPv6 address of a node (required)
+
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.{Command, DecodeError}
+  alias Grizzly.ZWave.CommandClasses.ZipND
+
+  @type param :: {:ipv6_address, ZipND.ipv6()}
+
+  @impl true
+  @spec new([param()]) :: {:ok, Command.t()}
+  def new(params) do
+    command = %Command{
+      name: :zip_node_solicitation,
+      command_byte: 0x03,
+      command_class: ZipND,
+      params: params,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl true
+  @spec encode_params(Command.t()) :: binary()
+  def encode_params(command) do
+    ipv6_address_binary = Command.param!(command, :ipv6_address) |> ZipND.encode_ipv6_address()
+
+    <<0x00, 0x00>> <> ipv6_address_binary
+  end
+
+  @impl true
+  @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
+  def decode_params(<<_reserved, 0x00, ipv6_binary::binary-size(16)>>) do
+    with {:ok, ipv6_address} <- ZipND.decode_ipv6_address(ipv6_binary) do
+      {:ok, [ipv6_address: ipv6_address]}
+    else
+      {:error, %DecodeError{} = error} ->
+        {:error, %DecodeError{error | command: :zip_node_solicitation}}
+    end
+  end
+end

--- a/lib/grizzly/zwave/decoder.ex
+++ b/lib/grizzly/zwave/decoder.ex
@@ -221,6 +221,10 @@ defmodule Grizzly.ZWave.Decoder do
       # Thermostat operating state
       {0x42, 0x02, Commands.ThermostatOperatingStateGet},
       {0x42, 0x03, Commands.ThermostatOperatingStateReport},
+      # Zip ND
+      {0x58, 0x01, Commands.ZipNodeAdvertisement},
+      {0x58, 0x03, Commands.ZipNodeSolicitation},
+      {0x58, 0x04, Commands.ZipInverseNodeSolicitation},
       # Powerlevel
       {0x73, 0x01, Commands.PowerlevelSet},
       {0x73, 0x02, Commands.PowerlevelGet},

--- a/test/grizzly/zwave/commands/zip_inverse_node_solicitation_test.exs
+++ b/test/grizzly/zwave/commands/zip_inverse_node_solicitation_test.exs
@@ -1,0 +1,24 @@
+defmodule Grizzly.ZWave.Commands.ZipInverseNodeSolicitationTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave.Commands.ZipInverseNodeSolicitation
+
+  test "creates the command and validates params" do
+    params = [node_id: 2, local: true]
+    {:ok, _command} = ZipInverseNodeSolicitation.new(params)
+  end
+
+  test "encodes params correctly" do
+    params = [node_id: 2, local: true]
+    {:ok, command} = ZipInverseNodeSolicitation.new(params)
+    expected_binary = <<0x00::size(4), 0x01::size(1), 0x00::size(3), 0x02>>
+    assert expected_binary == ZipInverseNodeSolicitation.encode_params(command)
+  end
+
+  test "decodes params correctly" do
+    binary_params = <<0x00::size(4), 0x01::size(1), 0x00::size(3), 0x02>>
+    {:ok, params} = ZipInverseNodeSolicitation.decode_params(binary_params)
+    assert Keyword.get(params, :node_id) == 2
+    assert Keyword.get(params, :local) == true
+  end
+end

--- a/test/grizzly/zwave/commands/zip_node_advertisement_test.exs
+++ b/test/grizzly/zwave/commands/zip_node_advertisement_test.exs
@@ -1,0 +1,50 @@
+defmodule Grizzly.ZWave.Commands.ZipNodeAdvertisementTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave.Commands.ZipNodeAdvertisement
+
+  test "creates the command and validates params" do
+    params = [
+      node_id: 2,
+      local: true,
+      validity: :information_ok,
+      ipv6_address: "0306:0709:0803:0405:0708:0905:0607:0809",
+      home_id: 100
+    ]
+
+    {:ok, _command} = ZipNodeAdvertisement.new(params)
+  end
+
+  test "encodes params correctly" do
+    params = [
+      node_id: 2,
+      local: true,
+      validity: :information_ok,
+      ipv6_address: "0306:0709:0803:0405:0708:0905:0607:0809",
+      home_id: 100
+    ]
+
+    {:ok, command} = ZipNodeAdvertisement.new(params)
+
+    expected_binary =
+      <<0x00::size(5), 0x01::size(1), 0x00::size(2), 0x02>> <>
+        <<3, 6, 7, 9, 8, 3, 4, 5, 7, 8, 9, 5, 6, 7, 8, 9>> <>
+        <<100::integer-unsigned-size(4)-unit(8)>>
+
+    assert expected_binary == ZipNodeAdvertisement.encode_params(command)
+  end
+
+  test "decodes params correctly" do
+    binary_params =
+      <<0x00::size(5), 0x01::size(1), 0x00::size(2), 0x02>> <>
+        <<3, 6, 7, 9, 8, 3, 4, 5, 7, 8, 9, 5, 6, 7, 8, 9>> <>
+        <<100::integer-unsigned-size(4)-unit(8)>>
+
+    {:ok, params} = ZipNodeAdvertisement.decode_params(binary_params)
+    assert Keyword.get(params, :node_id) == 2
+    assert Keyword.get(params, :local) == true
+    assert Keyword.get(params, :validity) == :information_ok
+    assert Keyword.get(params, :ipv6_address) == "0306:0709:0803:0405:0708:0905:0607:0809"
+    assert Keyword.get(params, :home_id) == 100
+  end
+end

--- a/test/grizzly/zwave/commands/zip_node_solicitation_test.exs
+++ b/test/grizzly/zwave/commands/zip_node_solicitation_test.exs
@@ -1,0 +1,28 @@
+defmodule Grizzly.ZWave.Commands.ZipNodeSolicitationTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave.Commands.ZipNodeSolicitation
+
+  test "creates the command and validates params" do
+    params = [ipv6_address: "0306:0709:0803:0405:0708:0905:0607:0809"]
+
+    {:ok, _command} = ZipNodeSolicitation.new(params)
+  end
+
+  test "encodes params correctly" do
+    params = [ipv6_address: "0306:0709:0803:0405:0708:0905:0607:0809"]
+
+    {:ok, command} = ZipNodeSolicitation.new(params)
+
+    expected_binary = <<0x00, 0x00>> <> <<3, 6, 7, 9, 8, 3, 4, 5, 7, 8, 9, 5, 6, 7, 8, 9>>
+
+    assert expected_binary == ZipNodeSolicitation.encode_params(command)
+  end
+
+  test "decodes params correctly" do
+    binary_params = <<0x00, 0x00>> <> <<3, 6, 7, 9, 8, 3, 4, 5, 7, 8, 9, 5, 6, 7, 8, 9>>
+
+    {:ok, params} = ZipNodeSolicitation.decode_params(binary_params)
+    assert Keyword.get(params, :ipv6_address) == "0306:0709:0803:0405:0708:0905:0607:0809"
+  end
+end


### PR DESCRIPTION
I doubt the usefulness of implementing the Zip ND CC now that I have done so on my own initiative.
```
The Z/IP ND Commands are not intended for classic Z-Wave applications. Z/IP ND messages MUST
always be carried in UDP datagrams without Z/IP Packet encapsulation.
```
But here it is anyway. I implemented it the old-fashioned way for expediency.