### PR TITLE
Fix warning for helper modules

### DIFF
--- a/lib/grizzly.ex
+++ b/lib/grizzly.ex
@@ -148,12 +148,19 @@ defmodule Grizzly do
   end
 
   def send_command(node_id, command_name, args, opts) do
+    :ok = maybe_log_warning(command_name)
+
+    send_command_no_warn(node_id, command_name, args, opts)
+  end
+
+  # This is only to be used by Grizzly as it migrates into the higher
+  # level helper modules, for example Grizzly.SwitchBinary.
+  @doc false
+  def send_command_no_warn(node_id, command_name, args, opts) do
     # always open a connection. If the connection is already opened this
     # will not establish a new connection
     including? = Inclusions.inclusion_running?()
     updating_firmware? = FirmwareUpdates.firmware_update_running?()
-
-    :ok = maybe_log_warning(command_name)
 
     with false <- including? or updating_firmware?,
          {command_module, default_opts} <- Table.lookup(command_name),

--- a/lib/grizzly/switch_binary.ex
+++ b/lib/grizzly/switch_binary.ex
@@ -41,7 +41,7 @@ defmodule Grizzly.SwitchBinary do
           | {:queued, reference(), non_neg_integer()}
           | {:error, :timeout | :including | :updating_firmware | :nack_response | any()}
   def get(node_id, command_opts \\ []) do
-    case Grizzly.send_command(node_id, :switch_binary_get, [], command_opts) do
+    case Grizzly.send_command_no_warn(node_id, :switch_binary_get, [], command_opts) do
       {:ok, %{type: :command} = report} ->
         target_value = Command.param!(report.command, :target_value)
         duration = Command.param(report.command, :duration)
@@ -83,7 +83,7 @@ defmodule Grizzly.SwitchBinary do
     duration = Keyword.get(opts, :duration)
     send_opts = Keyword.drop(opts, [:duration])
 
-    case Grizzly.send_command(
+    case Grizzly.send_command_no_warn(
            node_id,
            :switch_binary_set,
            [target_value: target_value, duration: duration],


### PR DESCRIPTION
As we move more commands into the higher level modules we should not log
the warning to use the higher level modules for those commands. This
adds a project level private function to do this until we have migrated
over.