### PR TITLE
Turn off TLS warning when connecting to zipgateway

### DIFF
--- a/lib/grizzly/transports/DTLS.ex
+++ b/lib/grizzly/transports/DTLS.ex
@@ -202,7 +202,8 @@ defmodule Grizzly.Transports.DTLS do
           0x90, 0xAA>>}},
       {:cb_info, {:gen_udp, :udp, :udp_close, :udp_error}},
       :inet6,
-      {:ifaddr, ifaddr}
+      {:ifaddr, ifaddr},
+      {:log_level, :error}
     ]
   end
 


### PR DESCRIPTION
OTP 24 has a new warning for whenever `:verify_none` is specified. This
is the main way of connecting to `zipgateway` and it's a local
connection anyway. This turns down the TLS warning level to avoid seeing
that message in the logs.
