### PR TITLE
Add long range provisioning list helper

### DIFF
--- a/lib/grizzly/network.ex
+++ b/lib/grizzly/network.ex
@@ -135,6 +135,20 @@ defmodule Grizzly.Network do
   end
 
   @doc """
+  Add a long range device to the provisioning list
+  """
+  @spec add_long_range_device(Grizzly.ZWave.DSK.t(), [opt()]) :: Grizzly.send_command_response()
+  def add_long_range_device(dsk, opts \\ []) do
+    extensions = [
+      bootstrapping_mode: :long_range,
+      smart_start_inclusion_setting: :pending,
+      advanced_joining: [:s2_unauthenticated, :s2_authenticated]
+    ]
+
+    set_node_provisioning(dsk, extensions, opts)
+  end
+
+  @doc """
   List all the nodes on the provisioning list
 
   Options


### PR DESCRIPTION
This helper function ensures the correct meta extensions are set for a
long range device to be correctly added to the node provisioning list.


Here's the log of the node joining the network after I used this function:

```

18:58:45.251 [debug] /usr/sbin/zipgateway: 185428 nm_fsm_post_event event: NM_EV_ADD_NODE_FOUND state: NM_WAITING_FOR_ADD

18:58:45.415 [debug] /usr/sbin/zipgateway: 185592 nm_fsm_post_event event: NM_EV_ADD_SLAVE state: NM_NODE_FOUND

18:58:45.416 [debug] /usr/sbin/zipgateway: 185593 Inclusion timeout (based on the network nodes) calculated is: 76217

18:58:45.422 [debug] /usr/sbin/zipgateway: 185594 nm_fsm_post_event event: NM_EV_ADD_PROTOCOL_DONE state: NM_WAIT_FOR_PROTOCOL

18:58:45.435 [debug] /usr/sbin/zipgateway: 185612 nm_fsm_post_event event: NM_EV_ADD_NODE_STATUS_DONE state: NM_WAIT_FOR_PROTOCOL

18:58:45.466 [debug] /usr/sbin/zipgateway: 185643 Probe machine is locked

18:58:45.467 [debug] /usr/sbin/zipgateway: 185643  nodeid=256 0x06
```

The key part is `nodeid=256` meaning the device was found and added to the network.