### PR TITLE
Support extended node ids in node list report

### DIFF
--- a/lib/grizzly/zwave/node_id_list.ex
+++ b/lib/grizzly/zwave/node_id_list.ex
@@ -1,0 +1,60 @@
+defmodule Grizzly.ZWave.NodeIdList do
+  @moduledoc false
+
+  @node_ids_list_len 29
+
+  @doc """
+  Parse a binary mask of node ids
+  """
+  @spec parse(binary()) :: [Grizzly.ZWave.node_id()]
+  def parse(node_ids) when byte_size(node_ids) == @node_ids_list_len do
+    unmask(node_ids, &node_id_modifier/2)
+  end
+
+  def parse(
+        <<node_ids::binary-size(@node_ids_list_len), extended_node_ids_list_len::16,
+          extended_node_ids_list::binary-size(extended_node_ids_list_len)>>
+      ) do
+    unmask(node_ids, &node_id_modifier/2) ++
+      unmask(extended_node_ids_list, &node_id_extended_modifier/2)
+  end
+
+  defp unmask(node_ids_bin, modifier) do
+    unmask(node_ids_bin, 0, [], modifier)
+  end
+
+  defp unmask(<<>>, _byte_offset, node_ids_list, _modifier) do
+    Enum.sort(node_ids_list)
+  end
+
+  defp unmask(<<masked_byte::binary-size(1), rest::binary>>, byte_offset, node_id_list, modifier) do
+    new_node_id_list = add_node_ids_in_byte(masked_byte, node_id_list, byte_offset, modifier)
+
+    unmask(rest, byte_offset + 1, new_node_id_list, modifier)
+  end
+
+  defp add_node_ids_in_byte(byte, node_id_list, byte_offset, modifier) do
+    <<eight::1, seven::1, six::1, five::1, four::1, three::1, two::1, one::1>> = byte
+
+    node_ids = [
+      {one, 1},
+      {two, 2},
+      {three, 3},
+      {four, 4},
+      {five, 5},
+      {six, 6},
+      {seven, 7},
+      {eight, 8}
+    ]
+
+    Enum.reduce(node_ids, node_id_list, fn
+      {0, _id}, ids -> ids
+      {1, id}, ids -> [modifier.(id, byte_offset) | ids]
+    end)
+  end
+
+  defp node_id_modifier(node_id, byte_offset), do: node_id + byte_offset * 8
+
+  defp node_id_extended_modifier(node_id, byte_offset),
+    do: node_id_modifier(node_id, byte_offset) + 255
+end

--- a/test/grizzly/zwave/node_id_list_test.exs
+++ b/test/grizzly/zwave/node_id_list_test.exs
@@ -1,0 +1,47 @@
+defmodule Grizzly.ZWave.NodeIdListTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave.NodeIdList
+
+  test "all 8 bit node id are able to parse" do
+    binary = make_binary(29, 0xFF)
+    list = Enum.to_list(1..232)
+
+    assert list == NodeIdList.parse(binary)
+  end
+
+  test "able to parse 16 bit node ids" do
+    eight_bit = make_binary(29, 0x00)
+    # another 29 more devices, since each node id is not 16 bits we us 58 as the
+    # length (29 * 2)
+    extended_ids_list_length = <<0x00, 29>>
+    extended_ids_binary = make_binary(29, 0xFF)
+
+    node_id_list_binary =
+      <<eight_bit::binary, extended_ids_list_length::binary, extended_ids_binary::binary>>
+
+    ## with extend node ids the first one is 256 and we add another 232 node ids
+    ## (including 256) so that is 488 is the highest node id for this test
+    expected_list = Enum.to_list(256..487)
+
+    assert expected_list == NodeIdList.parse(node_id_list_binary)
+  end
+
+  test "support both 16 bit nodes and a 8 bit node ids" do
+    eight_bit = make_binary(29, 0xFF)
+
+    extended_ids_list_length = <<0x00, 29>>
+    extended_ids_binary = make_binary(29, 0xFF)
+
+    node_id_list_binary =
+      <<eight_bit::binary, extended_ids_list_length::binary, extended_ids_binary::binary>>
+
+    expected_list = Enum.to_list(1..232) ++ Enum.to_list(256..487)
+
+    assert expected_list == NodeIdList.parse(node_id_list_binary)
+  end
+
+  def make_binary(number_of_bytes, byte) do
+    Enum.reduce(1..number_of_bytes, <<>>, fn _, bin -> <<bin::binary, byte>> end)
+  end
+end


### PR DESCRIPTION
This refactors our parsing of the node list binary. This type of code is
used in various places of Grizzly so providing an internal module to
reuse will provide useful. A follow up PR will made to update the parts
of code that would use this module.

This also handles parsing the node list binary bit mask for extended
node ids in support of Z-Wave long range.


Closes: #482 