### PR TITLE
Support extended node ids in failed node list report

### DIFF
--- a/lib/grizzly/zwave/commands/failed_node_list_report.ex
+++ b/lib/grizzly/zwave/commands/failed_node_list_report.ex
@@ -12,10 +12,10 @@ defmodule Grizzly.ZWave.Commands.FailedNodeListReport do
   @behaviour Grizzly.ZWave.Command
 
   alias Grizzly.ZWave
-  alias Grizzly.ZWave.{Command, DecodeError}
+  alias Grizzly.ZWave.{Command, DecodeError, NodeIdList}
   alias Grizzly.ZWave.CommandClasses.NetworkManagementProxy
 
-  @type param :: {:node_ids, [ZWave.node_id()]} | {:seq_number, ZWave.seq_number()}
+  @type param() :: {:node_ids, [ZWave.node_id()]} | {:seq_number, ZWave.seq_number()}
 
   @impl true
   def new(params) do
@@ -34,45 +34,14 @@ defmodule Grizzly.ZWave.Commands.FailedNodeListReport do
   def encode_params(command) do
     seq_number = Command.param!(command, :seq_number)
     node_ids = Command.param!(command, :node_ids)
-    node_id_bytes = node_ids_to_bytes(node_ids)
+    node_id_bytes = NodeIdList.to_binary(node_ids)
     <<seq_number>> <> node_id_bytes
   end
 
   @impl true
   @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
   def decode_params(<<seq_number, node_id_bytes::binary>>) do
-    node_ids = node_ids_from_bytes(node_id_bytes)
+    node_ids = NodeIdList.parse(node_id_bytes)
     {:ok, [seq_number: seq_number, node_ids: node_ids]}
-  end
-
-  defp node_ids_to_bytes(node_ids) do
-    bytes =
-      for byte_index <- 0..28 do
-        for bit_index <- 8..1, into: <<>> do
-          node_id = byte_index * 8 + bit_index
-          if node_id in node_ids, do: <<1::size(1)>>, else: <<0::size(1)>>
-        end
-      end
-
-    for byte <- bytes, into: <<>>, do: byte
-  end
-
-  defp node_ids_from_bytes(binary) do
-    :erlang.binary_to_list(binary)
-    |> Enum.with_index()
-    |> Enum.reduce(
-      [],
-      fn {byte, byte_index}, acc ->
-        bit_list = for <<(bit::size(1) <- <<byte>>)>>, do: bit
-
-        id_or_nil_list =
-          for bit_index <- 0..7 do
-            bit = Enum.at(bit_list, 7 - bit_index)
-            if bit == 1, do: byte_index * 8 + bit_index + 1, else: nil
-          end
-
-        acc ++ Enum.reject(id_or_nil_list, &(&1 == nil))
-      end
-    )
   end
 end

--- a/test/grizzly/zwave/commands/failed_node_list_report_test.exs
+++ b/test/grizzly/zwave/commands/failed_node_list_report_test.exs
@@ -9,12 +9,12 @@ defmodule Grizzly.ZWave.Commands.FailedNodeListReportTest do
   end
 
   test "encodes params correctly" do
-    params = [seq_number: 10, node_ids: [1, 2, 3, 9]]
+    params = [seq_number: 10, node_ids: [1, 2, 3, 9, 256]]
     {:ok, command} = FailedNodeListReport.new(params)
 
     expected_binary =
       <<0x0A, 7, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0>>
+        0, 0, 1, 1>>
 
     assert expected_binary == FailedNodeListReport.encode_params(command)
   end

--- a/test/grizzly/zwave/node_id_list_test.exs
+++ b/test/grizzly/zwave/node_id_list_test.exs
@@ -41,6 +41,42 @@ defmodule Grizzly.ZWave.NodeIdListTest do
     assert expected_list == NodeIdList.parse(node_id_list_binary)
   end
 
+  test "encode all 8 bit node ids (max 232) with no extended node ids" do
+    node_ids = Enum.to_list(1..232)
+    node_id_list = make_binary(29, 0xFF)
+
+    expected_binary = <<node_id_list::binary, 0x00, 0x00>>
+
+    assert expected_binary == NodeIdList.to_binary(node_ids)
+  end
+
+  test "encode all 8 bit node ids (max 232) with extended node ids turned off" do
+    node_ids = Enum.to_list(1..232)
+    expected_binary = make_binary(29, 0xFF)
+
+    assert expected_binary == NodeIdList.to_binary(node_ids, extended: false)
+  end
+
+  test "encode a bunch of extended node ids" do
+    node_ids = Enum.to_list(256..487)
+    extended = make_binary(29, 0xFF)
+    eight_bit = make_binary(29, 0x00)
+
+    expected_binary = <<eight_bit::binary, 0x00, 29, extended::binary>>
+
+    assert expected_binary == NodeIdList.to_binary(node_ids)
+  end
+
+  test "encode some 8 bit and 16 bit node ids" do
+    node_ids = [1, 25, 100, 56, 99, 230, 256, 264]
+
+    expected_bin =
+      <<0x1, 0x0, 0x0, 0x1, 0x0, 0x0, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0xC, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x20, 0x0, 0x2, 0x1, 0x1>>
+
+    assert expected_bin == NodeIdList.to_binary(node_ids)
+  end
+
   def make_binary(number_of_bytes, byte) do
     Enum.reduce(1..number_of_bytes, <<>>, fn _, bin -> <<bin::binary, byte>> end)
   end


### PR DESCRIPTION
This change proves support for parsing and encoding extended node ids
for failed node list report. This also moves the encoding logic to the
NodeIdList module to better provide code reuse for encoding node id
lists correctly. This logic is located in other parts of the code, so
follow up changes will update the other places in the code that can use
this encoding logic.


Closes: #489 