### PR TITLE
fail node remove extended id

### DIFF
--- a/test/grizzly/zwave/command_classes/network_management_inclusion_test.exs
+++ b/test/grizzly/zwave/command_classes/network_management_inclusion_test.exs
@@ -127,4 +127,29 @@ defmodule Grizzly.ZWave.CommandClasses.NetworkManagementInclusionTest do
              }
     end
   end
+
+  describe "node remove node ids parsing" do
+    test "when version 1-3 - only 8 bit node ids" do
+      assert NetworkManagementInclusion.parse_node_remove_node_id(<<0x04>>) == 0x04
+    end
+
+    test "when version 4 - 8 bit node id provided" do
+      assert NetworkManagementInclusion.parse_node_remove_node_id(<<0x04, 0x00::16>>) == 0x04
+    end
+
+    test "when version 4 - 16 bit node id provided" do
+      assert NetworkManagementInclusion.parse_node_remove_node_id(<<0xFF, 0x01, 0x10>>) == 0x0110
+    end
+  end
+
+  describe "node remove node ids encoding for v4 command class" do
+    test "when version 4 - 8 bit node id provided" do
+      assert NetworkManagementInclusion.encode_node_remove_node_id_v4(0xA0) == <<0xA0, 0x00::16>>
+    end
+
+    test "when version 4 - 16 bit node id provided" do
+      assert NetworkManagementInclusion.encode_node_remove_node_id_v4(0xA030) ==
+               <<0xFF, 0xA0, 0x30>>
+    end
+  end
 end

--- a/test/grizzly/zwave/commands/failed_node_remove_test.exs
+++ b/test/grizzly/zwave/commands/failed_node_remove_test.exs
@@ -8,26 +8,54 @@ defmodule Grizzly.ZWave.Commands.FailedNodeRemoveTest do
     {:ok, _command} = FailedNodeRemove.new(params)
   end
 
-  test "encodes params correctly" do
-    params = [seq_number: 2, node_id: 4]
-    {:ok, command} = FailedNodeRemove.new(params)
-    expected_binary = <<0x02, 0x04>>
-    assert expected_binary == FailedNodeRemove.encode_params(command)
+  describe "encoding" do
+    test "version 1-3 - only 8 bit node ids" do
+      {:ok, command} = FailedNodeRemove.new(seq_number: 0x02, node_id: 0x04)
+
+      for v <- 1..3 do
+        assert FailedNodeRemove.encode_params(command, command_class_version: v) == <<0x02, 0x04>>
+      end
+    end
+
+    test "version 4 - with 8 bit node id" do
+      {:ok, command} = FailedNodeRemove.new(seq_number: 0x01, node_id: 0x04)
+
+      assert FailedNodeRemove.encode_params(command) == <<0x01, 0x04, 0x00, 0x00>>
+    end
+
+    test "version 4 - with 16 bit node id" do
+      {:ok, command} = FailedNodeRemove.new(seq_number: 0x01, node_id: 0x0401)
+
+      assert FailedNodeRemove.encode_params(command) == <<0x01, 0xFF, 0x04, 0x01>>
+    end
   end
 
   describe "decodes params correctly" do
-    test "NetworkManagementInclusion < v3" do
-      params_binary = <<0x02, 0x04>>
-      {:ok, params} = FailedNodeRemove.decode_params(params_binary)
-      assert Keyword.get(params, :seq_number) == 2
-      assert Keyword.get(params, :node_id) == 4
+    test "version 1-3 - no 16 bit node id support" do
+      expected_params = [seq_number: 0x01, node_id: 0x04]
+      {:ok, params} = FailedNodeRemove.decode_params(<<0x01, 0x04>>)
+
+      assert_params(expected_params, params)
     end
 
-    test "NetworkManagementInclusion < v4 (long range)" do
-      params_binary = <<0x02, 0x01, 0x00>>
-      {:ok, params} = FailedNodeRemove.decode_params(params_binary)
-      assert Keyword.get(params, :seq_number) == 2
-      assert Keyword.get(params, :node_id) == 256
+    test "version 4 - 8 bit node id" do
+      expected_params = [seq_number: 0x01, node_id: 0x04]
+      {:ok, params} = FailedNodeRemove.decode_params(<<0x01, 0x04, 0x00, 0x00>>)
+
+      assert_params(expected_params, params)
+    end
+
+    test "version 4 - 16 bit node id" do
+      expected_params = [seq_number: 0x01, node_id: 0x0411]
+      {:ok, params} = FailedNodeRemove.decode_params(<<0x01, 0xFF, 0x04, 0x11>>)
+
+      assert_params(expected_params, params)
+    end
+  end
+
+  defp assert_params(expected_params, params) do
+    for {param, value} <- expected_params do
+      assert params[param] == value
     end
   end
 end


### PR DESCRIPTION
- Add helpers for encoding and parsing node remove node ids
- Support v4 FailedNodeRemove

Closes: #480 