### PR TITLE
Ignore extra 2 bytes in extended node id binary string

### DIFF
--- a/lib/grizzly/zwave/command_classes/network_management_inclusion.ex
+++ b/lib/grizzly/zwave/command_classes/network_management_inclusion.ex
@@ -200,5 +200,5 @@ defmodule Grizzly.ZWave.CommandClasses.NetworkManagementInclusion do
   @spec parse_node_remove_node_id(binary()) :: Grizzly.ZWave.node_id()
   def parse_node_remove_node_id(<<node_id>>), do: node_id
   def parse_node_remove_node_id(<<@remove_node_id_is_16_bit, node_id::16>>), do: node_id
-  def parse_node_remove_node_id(<<node_id, 0x00::16>>), do: node_id
+  def parse_node_remove_node_id(<<node_id, _ignored::16>>), do: node_id
 end


### PR DESCRIPTION
The specification only specifies this is some areas while not saying
much about these bytes in others. While all manual testing has shown
these bytes to be `<<0x00, 0x00>>` when there is an 8 bit node id, that
does not mean they will always be that way.

We know when the node id is an extended node id by the `0xFF` at the
byte index for the 8 bit node id.

By just ignoring these fields and we get a bit more flexibility to what
might come over the wire in those fields. Again, we will know to look at
those bytes if the `0xFF` byte is the right place, otherwise we can
safely ignore them and prevent any hard to track down match errors in
the future.
