### PR TITLE
Fix when FailedNodeListReport does not contain extended node ids

### DIFF
--- a/lib/grizzly/zwave/node_id_list.ex
+++ b/lib/grizzly/zwave/node_id_list.ex
@@ -16,6 +16,10 @@ defmodule Grizzly.ZWave.NodeIdList do
     unmask(node_ids, &node_id_modifier/2)
   end
 
+  def parse(<<node_ids::binary-size(@node_ids_list_len), 0x00::16, _rest::binary>>) do
+    unmask(node_ids, &node_id_modifier/2)
+  end
+
   def parse(
         <<node_ids::binary-size(@node_ids_list_len), extended_node_ids_list_len::16,
           extended_node_ids_list::binary-size(extended_node_ids_list_len)>>

--- a/test/grizzly/zwave/commands/failed_node_list_report_test.exs
+++ b/test/grizzly/zwave/commands/failed_node_list_report_test.exs
@@ -28,4 +28,14 @@ defmodule Grizzly.ZWave.Commands.FailedNodeListReportTest do
     assert Keyword.get(params, :seq_number) == 10
     assert Keyword.get(params, :node_ids) == [1, 2, 3, 9]
   end
+
+  test "decodes params version 4 with empty extended node ids" do
+    binary =
+      <<0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0>>
+
+    {:ok, params} = FailedNodeListReport.decode_params(binary)
+
+    assert params[:node_ids] == [38]
+  end
 end


### PR DESCRIPTION
Adds a match for when the extended node id list length byte is set to 0.
