### PR TITLE
Add support S2ResynchronizationEvent command version 3

### DIFF
--- a/lib/grizzly/zwave/commands/s2_resynchronization_event.ex
+++ b/lib/grizzly/zwave/commands/s2_resynchronization_event.ex
@@ -26,7 +26,7 @@ defmodule Grizzly.ZWave.Commands.S2ResynchronizationEvent do
 
   @behaviour Grizzly.ZWave.Command
 
-  alias Grizzly.ZWave.Command
+  alias Grizzly.ZWave.{Command, NodeId}
   alias Grizzly.ZWave.CommandClasses.NetworkManagementInstallationMaintenance
 
   @impl Command
@@ -50,7 +50,9 @@ defmodule Grizzly.ZWave.Commands.S2ResynchronizationEvent do
   end
 
   @impl Command
-  def decode_params(<<node_id, reason>>) do
+  def decode_params(<<_node_id_8, reason, _node_id_16::binary>> = params) do
+    node_id = NodeId.parse(params, delimiter_size: 1)
+
     {:ok, [node_id: node_id, reason: reason]}
   end
 end

--- a/test/grizzly/zwave/commands/s2_resynchronization_event_test.exs
+++ b/test/grizzly/zwave/commands/s2_resynchronization_event_test.exs
@@ -21,4 +21,22 @@ defmodule Grizzly.ZWave.Commands.S2ResynchronizationEventTest do
     assert Keyword.get(params, :node_id) == 5
     assert Keyword.get(params, :reason) == 0
   end
+
+  test "parse version 3 - 8 bit node id" do
+    binary = <<0x04, 0x00, 0x00, 0x00>>
+
+    {:ok, params} = S2ResynchronizationEvent.decode_params(binary)
+
+    assert params[:node_id] == 0x04
+    assert params[:reason] == 0x00
+  end
+
+  test "parse version 3 - 16 bit node id" do
+    binary = <<0xFF, 0x00, 0x01, 0x00>>
+
+    {:ok, params} = S2ResynchronizationEvent.decode_params(binary)
+
+    assert params[:node_id] == 0x0100
+    assert params[:reason] == 0x00
+  end
 end


### PR DESCRIPTION
This adds the ability to parse extended node ids in the
S2ResynchronizationEvent command.
