### PR TITLE
Make CentralSceneSupportedReport more forgiving

### DIFF
--- a/test/grizzly/zwave/commands/central_scene_supported_report_test.exs
+++ b/test/grizzly/zwave/commands/central_scene_supported_report_test.exs
@@ -109,5 +109,26 @@ defmodule Grizzly.ZWave.Commands.CentralSceneSupportedReportTest do
       assert Keyword.get(params, :bit_mask_bytes) == 1
       assert Keyword.get(params, :supported_key_attributes) == [[:key_pressed_1_time]]
     end
+
+    test "identical and superfluous" do
+      params_binary = <<2, 3, 31, 0, 0, 0>>
+
+      {:ok, params} = CentralSceneSupportedReport.decode_params(params_binary)
+
+      assert Keyword.get(params, :supported_scenes) == 2
+      assert Keyword.get(params, :slow_refresh_support) == false
+      assert Keyword.get(params, :identical) == true
+      assert Keyword.get(params, :bit_mask_bytes) == 1
+
+      assert Keyword.get(params, :supported_key_attributes) == [
+               [
+                 :key_pressed_3_times,
+                 :key_pressed_2_times,
+                 :key_held_down,
+                 :key_released,
+                 :key_pressed_1_time
+               ]
+             ]
+    end
   end
 end


### PR DESCRIPTION
Fixes CentralSceneSupportedReport params decode failures when identical is true but there are more than one set of per scene bit indices. In the case seen in the field, the superfulous ones are empty.

The problem was seen with  ZL-WS-100 (Switch) product_id=12339, product_type_id=17479, zw_mf_id=789