### PR TITLE
Thermostat setpoint supported, v1-3

### DIFF
--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -184,6 +184,9 @@ defmodule Grizzly.Commands.Table do
       {:thermostat_setpoint_get,
        {Commands.ThermostatSetpointGet,
         handler: {WaitReport, complete_report: :thermostat_setpoint_report}}},
+      {:thermostat_setpoint_supported_get,
+       {Commands.ThermostatSetpointSupportedGet,
+        handler: {WaitReport, complete_report: :thermostat_setpoint_supported_report}}},
       # Thermostat fan mode
       {:thermostat_fan_mode_set, {Commands.ThermostatFanModeSet, handler: AckResponse}},
       {:thermostat_fan_mode_get,

--- a/lib/grizzly/zwave/command_classes/thermostat_setpoint.ex
+++ b/lib/grizzly/zwave/command_classes/thermostat_setpoint.ex
@@ -8,7 +8,20 @@ defmodule Grizzly.ZWave.CommandClasses.ThermostatSetpoint do
   What type of commands does this command class support?
   """
 
-  @type type :: :na | :heating | :cooling | :furnace | :dry_air | :moist_air | :auto_changeover
+  @type type ::
+          :na
+          | :heating
+          | :cooling
+          | :furnace
+          | :dry_air
+          | :moist_air
+          | :auto_changeover
+          | :energy_save_heating
+          | :energy_save_cooling
+          | :away_heating
+          | :away_cooling
+          | :full_power
+
   @type scale :: :celsius | :fahrenheit
 
   @behaviour Grizzly.ZWave.CommandClass
@@ -29,6 +42,11 @@ defmodule Grizzly.ZWave.CommandClasses.ThermostatSetpoint do
   def encode_type(:dry_air), do: 0x08
   def encode_type(:moist_air), do: 0x09
   def encode_type(:auto_changeover), do: 0x0A
+  def encode_type(:energy_save_heating), do: 0x0B
+  def encode_type(:energy_save_cooling), do: 0x0C
+  def encode_type(:away_heating), do: 0x0D
+  def encode_type(:away_cooling), do: 0x0E
+  def encode_type(:full_power), do: 0x0F
 
   @spec decode_type(byte()) :: type()
   def decode_type(0x01), do: :heating
@@ -37,6 +55,11 @@ defmodule Grizzly.ZWave.CommandClasses.ThermostatSetpoint do
   def decode_type(0x08), do: :dry_air
   def decode_type(0x09), do: :moist_air
   def decode_type(0x0A), do: :auto_changeover
+  def decode_type(0x0B), do: :energy_save_heating
+  def decode_type(0x0C), do: :energy_save_cooling
+  def decode_type(0x0D), do: :away_heating
+  def decode_type(0x0E), do: :away_cooling
+  def decode_type(0x0F), do: :full_power
   def decode_type(_na_type), do: :na
 
   @spec encode_scale(scale) :: byte

--- a/lib/grizzly/zwave/commands/thermostat_setpoint_supported_get.ex
+++ b/lib/grizzly/zwave/commands/thermostat_setpoint_supported_get.ex
@@ -1,0 +1,36 @@
+defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedGet do
+  @moduledoc """
+  This module implements command THERMOSTAT_SETPOINT_SUPPORTED_GET of the
+  COMMAND_CLASS_THERMOSTAT_SETPOINT command class.
+
+  This command is used to query the supported setpoint types.
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.Command
+  alias Grizzly.ZWave.CommandClasses.ThermostatSetpoint
+
+  @impl Grizzly.ZWave.Command
+  @spec new([]) :: {:ok, Command.t()}
+  def new(_opts \\ []) do
+    command = %Command{
+      name: :thermostat_setpoint_supported_get,
+      command_byte: 0x04,
+      command_class: ThermostatSetpoint,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl Grizzly.ZWave.Command
+  def encode_params(_command) do
+    <<>>
+  end
+
+  @impl Grizzly.ZWave.Command
+  def decode_params(_binary) do
+    {:ok, []}
+  end
+end

--- a/lib/grizzly/zwave/commands/thermostat_setpoint_supported_report.ex
+++ b/lib/grizzly/zwave/commands/thermostat_setpoint_supported_report.ex
@@ -1,0 +1,90 @@
+defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReport do
+  @moduledoc """
+  This command is used to report the thermostat's supported setpoint types.
+
+  Params:
+
+    * `:setpoint_types` - A list of supported setpoint types. See `t:Grizzly.ZWave.CommandClasses.ThermostatSetpoint.type/0`.
+
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  use Bitwise, only_operators: true
+
+  alias Grizzly.ZWave.{Command, DecodeError}
+  alias Grizzly.ZWave.CommandClasses.ThermostatSetpoint
+
+  @type param :: {:setpoint_types, [{ThermostatSetpoint.type(), boolean()}]}
+
+  @impl Grizzly.ZWave.Command
+  @spec new([param()]) :: {:ok, Command.t()}
+  def new(params) do
+    command = %Command{
+      name: :thermostat_setpoint_supported_report,
+      command_byte: 0x05,
+      command_class: ThermostatSetpoint,
+      params: params,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl Grizzly.ZWave.Command
+  @spec encode_params(Command.t()) :: binary()
+  def encode_params(command) do
+    setpoint_types = Command.param!(command, :setpoint_types)
+
+    bit_masks =
+      for byte_index <- 1..2 do
+        for bit_index <- 7..0, into: <<>> do
+          setpoint_type = bitmask_field_to_setpoint_type(byte_index, bit_index)
+
+          if Keyword.get(setpoint_types, setpoint_type) == true,
+            do: <<1::size(1)>>,
+            else: <<0::size(1)>>
+        end
+      end
+
+    for bit_mask <- bit_masks, into: <<>>, do: bit_mask
+  end
+
+  @impl Grizzly.ZWave.Command
+  @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
+  def decode_params(<<first_bitmask::size(8)>>),
+    do: decode_params(<<first_bitmask, 0x0::size(8)>>)
+
+  def decode_params(bitmasks) do
+    bitmasks_as_indexed_list =
+      :erlang.binary_to_list(bitmasks) |> Enum.take(2) |> Enum.with_index(1)
+
+    setpoint_types =
+      Enum.flat_map(bitmasks_as_indexed_list, fn {bitmask_byte, byte_index} ->
+        for bit_index <- 0..7, into: [] do
+          {bitmask_field_to_setpoint_type(byte_index, bit_index),
+           (bitmask_byte &&& 1 <<< bit_index) !== 0}
+        end
+      end)
+      |> Keyword.drop([nil])
+
+    {:ok, [setpoint_types: setpoint_types]}
+  end
+
+  @spec bitmask_field_to_setpoint_type(pos_integer(), 0..7) ::
+          ThermostatSetpoint.type() | :reserved
+  defp bitmask_field_to_setpoint_type(byte_index, bit_index)
+
+  defp bitmask_field_to_setpoint_type(1, 1), do: :heating
+  defp bitmask_field_to_setpoint_type(1, 2), do: :cooling
+  defp bitmask_field_to_setpoint_type(1, 3), do: :furnace
+  defp bitmask_field_to_setpoint_type(1, 4), do: :dry_air
+  defp bitmask_field_to_setpoint_type(1, 5), do: :moist_air
+  defp bitmask_field_to_setpoint_type(1, 6), do: :auto_changeover
+  defp bitmask_field_to_setpoint_type(1, 7), do: :energy_save_heating
+  defp bitmask_field_to_setpoint_type(2, 0), do: :energy_save_cooling
+  defp bitmask_field_to_setpoint_type(2, 1), do: :away_heating
+  defp bitmask_field_to_setpoint_type(2, 2), do: :away_cooling
+  defp bitmask_field_to_setpoint_type(2, 3), do: :full_power
+  defp bitmask_field_to_setpoint_type(_, _), do: nil
+end

--- a/lib/grizzly/zwave/decoder.ex
+++ b/lib/grizzly/zwave/decoder.ex
@@ -227,6 +227,8 @@ defmodule Grizzly.ZWave.Decoder do
       {0x43, 0x01, Commands.ThermostatSetpointSet},
       {0x43, 0x02, Commands.ThermostatSetpointGet},
       {0x43, 0x03, Commands.ThermostatSetpointReport},
+      {0x43, 0x04, Commands.ThermostatSetpointSupportedGet},
+      {0x43, 0x05, Commands.ThermostatSetpointSupportedReport},
       # Thermostat fan mode
       {0x44, 0x01, Commands.ThermostatFanModeSet},
       {0x44, 0x02, Commands.ThermostatFanModeGet},

--- a/priv/templates/zwave.gen/command.ex
+++ b/priv/templates/zwave.gen/command.ex
@@ -15,7 +15,7 @@ defmodule <%= inspect command_module %> do
 
   @type param :: # give me some type specs for your params
 
-  @impl true
+  @impl Grizzly.ZWave.Command
   @spec new([param()]) :: {:ok, Command.t()}
   def new(params) do
     command = %Command{
@@ -29,13 +29,13 @@ defmodule <%= inspect command_module %> do
     {:ok, command}
   end
 
-  @impl true
+  @impl Grizzly.ZWave.Command
   @spec encode_params(Command.t()) :: binary()
   def encode_params(_command) do
     <<>>
   end
 
-  @impl true
+  @impl Grizzly.ZWave.Command
   @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
   def decode_params(_binary) do
     {:ok, []}

--- a/priv/templates/zwave.gen/command_class.ex
+++ b/priv/templates/zwave.gen/command_class.ex
@@ -7,9 +7,9 @@ defmodule <%= inspect command_class_module %> do
 
   @behaviour Grizzly.ZWave.CommandClass
 
-  @impl true
+  @impl Grizzly.ZWave.CommandClass
   def byte(), do: # add byte here
 
-  @impl true
+  @impl Grizzly.ZWave.CommandClass
   def name(), do: <%= inspect command_class_name %>
 end

--- a/test/grizzly/zwave/commands/thermostat_setpoint_supported_report_test.exs
+++ b/test/grizzly/zwave/commands/thermostat_setpoint_supported_report_test.exs
@@ -1,0 +1,197 @@
+defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReportTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave.Commands.ThermostatSetpointSupportedReport
+
+  test "creates the command and validates params" do
+    params = [
+      setpoint_types: [
+        heating: true,
+        cooling: true,
+        furnace: true,
+        dry_air: true,
+        moist_air: true,
+        auto_changeover: true,
+        energy_save_heating: true,
+        energy_save_cooling: true,
+        away_heating: true,
+        away_cooling: true,
+        full_power: true
+      ]
+    ]
+
+    {:ok, _command} = ThermostatSetpointSupportedReport.new(params)
+  end
+
+  test "encodes params correctly" do
+    # all the odd bits
+    params = [
+      setpoint_types: [
+        heating: true,
+        cooling: false,
+        furnace: true,
+        dry_air: false,
+        moist_air: true,
+        auto_changeover: false,
+        energy_save_heating: true,
+        energy_save_cooling: false,
+        away_heating: true,
+        away_cooling: false,
+        full_power: true
+      ]
+    ]
+
+    {:ok, command} = ThermostatSetpointSupportedReport.new(params)
+
+    ThermostatSetpointSupportedReport.encode_params(command)
+
+    assert <<0b10101010, 0b00001010>> == ThermostatSetpointSupportedReport.encode_params(command)
+
+    # all the even bits
+    params = [
+      setpoint_types: [
+        heating: false,
+        cooling: true,
+        furnace: false,
+        dry_air: true,
+        moist_air: false,
+        auto_changeover: true,
+        energy_save_heating: false,
+        energy_save_cooling: true,
+        away_heating: false,
+        away_cooling: true,
+        full_power: false
+      ]
+    ]
+
+    {:ok, command} = ThermostatSetpointSupportedReport.new(params)
+
+    ThermostatSetpointSupportedReport.encode_params(command)
+
+    assert <<0b01010100, 0b00000101>> == ThermostatSetpointSupportedReport.encode_params(command)
+
+    # just heating
+    params = [setpoint_types: [heating: true]]
+
+    {:ok, command} = ThermostatSetpointSupportedReport.new(params)
+
+    ThermostatSetpointSupportedReport.encode_params(command)
+
+    assert <<0b10, 0b0>> == ThermostatSetpointSupportedReport.encode_params(command)
+  end
+
+  describe "decodes params correctly" do
+    test "two bytes of bitmasks" do
+      # odd bits are set in both bitmasks
+      assert {:ok, setpoint_types: setpoint_types} =
+               ThermostatSetpointSupportedReport.decode_params(<<0b10101010, 0b10101010>>)
+
+      assert setpoint_types == [
+               heating: true,
+               cooling: false,
+               furnace: true,
+               dry_air: false,
+               moist_air: true,
+               auto_changeover: false,
+               energy_save_heating: true,
+               energy_save_cooling: false,
+               away_heating: true,
+               away_cooling: false,
+               full_power: true
+             ]
+
+      # even bits are set in both bitmasks
+      assert {:ok, setpoint_types: setpoint_types} =
+               ThermostatSetpointSupportedReport.decode_params(<<0b01010101, 0b01010101>>)
+
+      assert setpoint_types == [
+               heating: false,
+               cooling: true,
+               furnace: false,
+               dry_air: true,
+               moist_air: false,
+               auto_changeover: true,
+               energy_save_heating: false,
+               energy_save_cooling: true,
+               away_heating: false,
+               away_cooling: true,
+               full_power: false
+             ]
+
+      # all bits are set
+      assert {:ok, setpoint_types: setpoint_types} =
+               ThermostatSetpointSupportedReport.decode_params(<<0xFF, 0xFF>>)
+
+      assert setpoint_types == [
+               heating: true,
+               cooling: true,
+               furnace: true,
+               dry_air: true,
+               moist_air: true,
+               auto_changeover: true,
+               energy_save_heating: true,
+               energy_save_cooling: true,
+               away_heating: true,
+               away_cooling: true,
+               full_power: true
+             ]
+
+      # no bits are set
+      assert {:ok, setpoint_types: setpoint_types} =
+               ThermostatSetpointSupportedReport.decode_params(<<0x0, 0x0>>)
+
+      assert setpoint_types == [
+               heating: false,
+               cooling: false,
+               furnace: false,
+               dry_air: false,
+               moist_air: false,
+               auto_changeover: false,
+               energy_save_heating: false,
+               energy_save_cooling: false,
+               away_heating: false,
+               away_cooling: false,
+               full_power: false
+             ]
+    end
+
+    test "just one byte" do
+      assert {:ok, setpoint_types: setpoint_types} =
+               ThermostatSetpointSupportedReport.decode_params(<<0xFF>>)
+
+      assert setpoint_types == [
+               heating: true,
+               cooling: true,
+               furnace: true,
+               dry_air: true,
+               moist_air: true,
+               auto_changeover: true,
+               energy_save_heating: true,
+               energy_save_cooling: false,
+               away_heating: false,
+               away_cooling: false,
+               full_power: false
+             ]
+    end
+
+    test "extra bytes" do
+      # just one byte
+      assert {:ok, setpoint_types: setpoint_types} =
+               ThermostatSetpointSupportedReport.decode_params(<<0x00, 0x00, 0xFF>>)
+
+      assert setpoint_types == [
+               heating: false,
+               cooling: false,
+               furnace: false,
+               dry_air: false,
+               moist_air: false,
+               auto_changeover: false,
+               energy_save_heating: false,
+               energy_save_cooling: false,
+               away_heating: false,
+               away_cooling: false,
+               full_power: false
+             ]
+    end
+  end
+end


### PR DESCRIPTION
Turns out this supports v1-2 as well as v3. I was initially confused by Table 141 listing two different interpretations of the bitmask, but according to sections 4.114.1 and 4.114.2, v3 is backwards compatible with v1-2. As I understand it, "Interpretation B" is just a documented deviation from the spec that exists in some devices.