### PR TITLE
Fix when invalid packets from from Z-Wave

### DIFF
--- a/lib/grizzly/connections/async_connection.ex
+++ b/lib/grizzly/connections/async_connection.ex
@@ -157,6 +157,11 @@ defmodule Grizzly.Connections.AsyncConnection do
       {:ok, transport_response} ->
         updated_state = handle_commands(transport_response.command, state)
         {:noreply, updated_state}
+
+      {:error, error} ->
+        error_message = Exception.message(error)
+        Logger.warn("[Grizzly] #{inspect(error_message)}")
+        {:noreply, state}
     end
   end
 

--- a/lib/grizzly/connections/sync_connection.ex
+++ b/lib/grizzly/connections/sync_connection.ex
@@ -138,6 +138,11 @@ defmodule Grizzly.Connections.SyncConnection do
       {:ok, transport_response} ->
         new_state = handle_commands(transport_response.command, state)
         {:noreply, new_state}
+
+      {:error, error} ->
+        error_message = Exception.message(error)
+        Logger.warn("[Grizzly] #{inspect(error_message)}")
+        {:noreply, state}
     end
   end
 

--- a/lib/grizzly/transports/DTLS.ex
+++ b/lib/grizzly/transports/DTLS.ex
@@ -59,6 +59,9 @@ defmodule Grizzly.Transports.DTLS do
            ip_address: ip,
            command: command
          }}
+
+      error ->
+        error
     end
   end
 
@@ -98,6 +101,9 @@ defmodule Grizzly.Transports.DTLS do
          %Response{
            command: command
          }}
+
+      error ->
+        error
     end
   end
 
@@ -124,6 +130,9 @@ defmodule Grizzly.Transports.DTLS do
 
       {:ok, command} ->
         {:ok, %Response{ip_address: ip, command: command}}
+
+      error ->
+        error
     end
   end
 

--- a/lib/grizzly/zwave/decode_error.ex
+++ b/lib/grizzly/zwave/decode_error.ex
@@ -7,6 +7,6 @@ defmodule Grizzly.ZWave.DecodeError do
   defexception [:value, :param, :command]
 
   def message(%{value: byte, param: param, command: command}) do
-    "unexpected value #{inspect(byte)} for param #{inspect(param)} when decoding binary for #{inspect(command)}"
+    "unexpected value #{inspect(byte, base: :hex)} for param #{inspect(param, base: :hex)} when decoding binary for #{inspect(command)}"
   end
 end

--- a/lib/grizzly/zwave/decoder.ex
+++ b/lib/grizzly/zwave/decoder.ex
@@ -3,7 +3,7 @@ defmodule Grizzly.ZWave.Decoder do
 
   defmodule Generate do
     @moduledoc false
-    alias Grizzly.ZWave.{Command, Commands, DecodeError}
+    alias Grizzly.ZWave.{Command, Commands, DecodeError, ZWaveError}
 
     @mappings [
       # {command_class_byte, command_byte, command_module}
@@ -325,6 +325,8 @@ defmodule Grizzly.ZWave.Decoder do
         # No Operation (0x00) - There is no command byte or args for this command, only the command class byte
         def from_binary(<<0x00>>), do: decode(Commands.NoOperation, [])
 
+        def from_binary(other), do: {:error, %ZWaveError{binary: other}}
+
         @spec command_module(byte, byte) :: {:ok, module} | {:error, :unsupported_command}
         unquote(command_module)
         def command_module(_cc_byte, _c_byte), do: {:error, :unsupported_command}
@@ -336,6 +338,9 @@ defmodule Grizzly.ZWave.Decoder do
 
             {:error, %DecodeError{}} = error ->
               error
+
+            %DecodeError{} = error ->
+              {:error, error}
           end
         end
       end

--- a/lib/grizzly/zwave/zwave_error.ex
+++ b/lib/grizzly/zwave/zwave_error.ex
@@ -1,0 +1,12 @@
+defmodule Grizzly.ZWave.ZWaveError do
+  @moduledoc """
+  Exception for when receiving unsupported Z-Wave binary
+  """
+  @type t :: %__MODULE__{binary: binary()}
+
+  defexception [:binary]
+
+  def message(%{binary: binary}) do
+    "unexpected Z-Wave binary #{inspect(binary)}"
+  end
+end

--- a/test/support/UDP.ex
+++ b/test/support/UDP.ex
@@ -47,6 +47,9 @@ defmodule GrizzlyTest.Transport.UDP do
       case ZWave.from_binary(binary) do
         {:ok, command} ->
           {:ok, %Response{ip_address: ip, command: command}}
+
+        {:error, _type} = error ->
+          error
       end
     end
   end

--- a/test/support/server.ex
+++ b/test/support/server.ex
@@ -91,6 +91,14 @@ defmodule GrizzlyTest.Server do
         400 ->
           :ok
 
+        500 ->
+          send_ack_response(state.socket, return_port, zip_packet)
+          send_garbage(state.socket, return_port, zip_packet)
+
+        501 ->
+          send_ack_response(state.socket, return_port, zip_packet)
+          send_command_not_to_spec(state.socket, return_port, zip_packet)
+
         _rest ->
           send_ack_response(state.socket, return_port, zip_packet)
           maybe_send_a_report(state.socket, return_port, zip_packet)
@@ -218,6 +226,17 @@ defmodule GrizzlyTest.Server do
     else
       :ok
     end
+  end
+
+  defp send_garbage(socket, port, _zip_packet) do
+    :gen_udp.send(socket, {0, 0, 0, 0}, port, <<0x12, 0x12>>)
+  end
+
+  defp send_command_not_to_spec(socket, port, _zip_packet) do
+    # Door lock report with invalid mode (0xAA)
+    command = <<98, 3, 0xAA, 0, 0, 0, 0>>
+
+    :gen_udp.send(socket, {0, 0, 0, 0}, port, command)
   end
 
   defp send_firmware_update_md_get_command(socket, port,


### PR DESCRIPTION
Sometimes Z-Wave will send out of spec information to us. Either by our
request or by some action in the Z-Wave network that we have setup to be
notified about. Originally this was designed to crash hard but as the
use case has grown it seems better to allow the sent command to time out
while logging that Grizzly wasn't able to parse the packet coming from
the Z-Wave network.

This prevents automations getting stuck hitting the same crash for a
device that does not follow spec, thus causing Grizzly to infinitely
crash.
