### PR TITLE
Fix crash when zipgateway responds with queue full

### DIFF
--- a/lib/grizzly/commands/command.ex
+++ b/lib/grizzly/commands/command.ex
@@ -88,7 +88,7 @@ defmodule Grizzly.Commands.Command do
 
   @spec handle_zip_command(t(), ZWaveCommand.t()) ::
           {Report.t(), t()}
-          | {:error, :nack_response, t()}
+          | {:error, :nack_response | :queue_full, t()}
           | {:retry, t()}
           | {:continue, t()}
   def handle_zip_command(command, zip_command) do
@@ -101,6 +101,9 @@ defmodule Grizzly.Commands.Command do
 
       :nack_waiting ->
         handle_nack_waiting(command, zip_command)
+
+      :nack_queue_full ->
+        {:error, :queue_full, zip_command}
 
       flag when flag in [nil, :ack_request] ->
         do_handle_zip_command(command, zip_command)

--- a/lib/grizzly/commands/command_runner.ex
+++ b/lib/grizzly/commands/command_runner.ex
@@ -75,6 +75,9 @@ defmodule Grizzly.Commands.CommandRunner do
       {:error, :nack_response, new_command} ->
         {:stop, :normal, {:error, :nack_response}, new_command}
 
+      {:error, reason, new_command} ->
+        {:stop, :normal, {:error, reason}, new_command}
+
       {:retry, new_command} ->
         {:reply, :retry, new_command}
     end

--- a/test/grizzly/commands/command_runner_test.exs
+++ b/test/grizzly/commands/command_runner_test.exs
@@ -74,6 +74,17 @@ defmodule Grizzly.Commands.CommandRunnerTest do
     assert {:error, :nack_response} == CommandRunner.handle_zip_command(runner, nack_response)
   end
 
+  test "handles :nack_queue_full response" do
+    {:ok, command} = SwitchBinaryGet.new()
+    {:ok, runner} = CommandRunner.start_link(command, 1, retries: 0)
+
+    {:ok, nack_queue_full} =
+      ZIPPacket.new(seq_number: CommandRunner.seq_number(runner), flag: :nack_queue_full)
+
+    assert {:error, :queue_full} == CommandRunner.handle_zip_command(runner, nack_queue_full)
+    refute Process.alive?(runner)
+  end
+
   test "ignores nack_response not for command" do
     {:ok, command} = SwitchBinaryGet.new()
     {:ok, runner} = CommandRunner.start_link(command, 1)


### PR DESCRIPTION
When sending messages to a wake up device, while the device is sleeping
the command gets queued in zipgateway's mailbox. The mailbox can only
contain 2000 entries by all devices on a network. If a command is sent
and is queued into the mailbox but the mailbox has hit capacity the
command is dropped and the device will never receive it.

This fixes an issue were Grizzly was not matching on this error when
receiving a Z/IP Packet from zipgateway that contains the
`:nack_queue_full` flag.
