### PR TITLE
Handle :nack_response when updating fw

### DIFF
--- a/lib/grizzly/firmware_updates/firmware_update_runner.ex
+++ b/lib/grizzly/firmware_updates/firmware_update_runner.ex
@@ -126,6 +126,14 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner do
     end
   end
 
+  def handle_info({:error, :nack_response}, firmware_update) do
+    Logger.info(
+      "[Grizzly] Received :nack_response while updating firmware of device #{firmware_update.device_id}. Ignoring it."
+    )
+
+    {:noreply, firmware_update}
+  end
+
   @impl true
   def terminate(:normal, firmware_update) do
     :ok = AsyncConnection.stop(firmware_update.device_id)


### PR DESCRIPTION
Fixes

`11:33:22.812 [error] GenServer Grizzly.FirmwareUpdates.FirmwareUpdateRunner terminating
** (FunctionClauseError) no function clause matching in Grizzly.FirmwareUpdates.FirmwareUpdateRunner.handle_info/2
    (grizzly 0.22.6) lib/grizzly/firmware_updates/firmware_update_runner.ex:119: Grizzly.FirmwareUpdates.FirmwareUpdateRunner.handle_info({:error, :nack_response}, %Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate{activation_may_be_delayed?: false, current_command_ref: #Reference<0.1726771937.2368733185.225652>, device_id: 58, firmware_id: 42400, firmware_target: 0, fragment_index: 549, fragments_wanted: 0, handler: Piston.FirmwareUpdateHandler, hardware_version: 2, image: %Grizzly.FirmwareUpdates.FirmwareUpdateRunner.Image{fragments: [<<235,`