### PR TITLE
Stop and start zipgateway

### DIFF
--- a/lib/grizzly/zip_gateway.ex
+++ b/lib/grizzly/zip_gateway.ex
@@ -4,6 +4,7 @@ defmodule Grizzly.ZIPGateway do
   # helper functions for working with the Z/IP Gateway
 
   alias Grizzly.{Options, ZWave}
+  alias Grizzly.ZIPGateway
 
   # the host base is different for the LAN and PAN networks, we need to
   # probably handle this a little nicer
@@ -36,4 +37,23 @@ defmodule Grizzly.ZIPGateway do
   @spec node_id_from_ip(:inet.ip_address()) :: Grizzly.node_id()
   def node_id_from_ip({_, _, _, node_id}), do: node_id
   def node_id_from_ip({_, _, _, _, _, _, _, node_id}), do: node_id
+
+  @doc """
+  Stop Z/IP Gateway
+  """
+  @spec stop_zipgateway() :: :ok | {:error, :not_found}
+  def stop_zipgateway() do
+    Supervisor.terminate_child(ZIPGateway.Supervisor, MuonTrap.Daemon)
+  end
+
+  @doc """
+  Start Z/IP Gateway
+  """
+  @spec start_zipgateway() :: :ok | {:error, :not_found | :running | :restarting | term()}
+  def start_zipgateway() do
+    case Supervisor.restart_child(ZIPGateway.Supervisor, MuonTrap.Daemon) do
+      {:error, _reason} = error -> error
+      _ok -> :ok
+    end
+  end
 end


### PR DESCRIPTION
With some changes to the firmware update, and to support zipgateway
backup and restore functionality later, Grizzly needs to be able to
stop and start zipgateway before some of those process are started. The
reason for this is that Grizzly will call out to tooling that will
will need to attach to the same serial port as zipgateway does to run,
so these tools and zipgateway cannot run at the same time.

I have kept these functions internal to Grizzly, via moduledoc false,
since higher level functions will be provided to interact with these
processes in a more user friend way and abstracts the idea of stopping
and starting zipgateway.
