### PR TITLE
Decode 0x01..0x63 as :on in Basic CC

### DIFF
--- a/lib/grizzly/zwave/commands/basic_report.ex
+++ b/lib/grizzly/zwave/commands/basic_report.ex
@@ -77,9 +77,9 @@ defmodule Grizzly.ZWave.Commands.BasicReport do
   defp encode_value(:off), do: 0x00
   defp encode_value(:unknown), do: 0xFE
 
-  defp encode_duration(secs) when is_number(secs) and secs in 0..127, do: secs
+  defp encode_duration(secs) when is_integer(secs) and secs in 0..127, do: secs
 
-  defp encode_duration(secs) when is_number(secs) and secs in 128..(126 * 60),
+  defp encode_duration(secs) when is_integer(secs) and secs in 128..(126 * 60),
     do: 0x80 + div(secs, 60)
 
   defp encode_duration(:unknown), do: 0xFE
@@ -88,6 +88,7 @@ defmodule Grizzly.ZWave.Commands.BasicReport do
   defp value_from_byte(0x00, _param), do: {:ok, :off}
   defp value_from_byte(0xFF, _param), do: {:ok, :on}
   defp value_from_byte(0xFE, _param), do: {:ok, :unknown}
+  defp value_from_byte(byte, _param) when byte in 0x01..0x63, do: {:ok, :on}
 
   defp value_from_byte(byte, param),
     do: {:error, %DecodeError{value: byte, param: param, command: :basic_report}}

--- a/lib/grizzly/zwave/commands/basic_set.ex
+++ b/lib/grizzly/zwave/commands/basic_set.ex
@@ -51,6 +51,7 @@ defmodule Grizzly.ZWave.Commands.BasicSet do
 
   defp value_from_byte(0x00), do: {:ok, :off}
   defp value_from_byte(0xFF), do: {:ok, :on}
+  defp value_from_byte(byte) when byte in 0x01..0x63, do: {:ok, :on}
 
   defp value_from_byte(byte),
     do: {:error, %DecodeError{value: byte, param: :value, command: :basic_set}}

--- a/test/grizzly/zwave/commands/basic_report_test.exs
+++ b/test/grizzly/zwave/commands/basic_report_test.exs
@@ -31,6 +31,9 @@ defmodule Grizzly.ZWave.Commands.BasicReportTest do
     binary_params = <<0xFF>>
     {:ok, params} = BasicReport.decode_params(binary_params)
     assert Keyword.get(params, :value) == :on
+    binary_params = <<0x63>>
+    {:ok, params} = BasicReport.decode_params(binary_params)
+    assert Keyword.get(params, :value) == :on
   end
 
   test "decodes v2 params correctly" do

--- a/test/grizzly/zwave/commands/basic_set_test.exs
+++ b/test/grizzly/zwave/commands/basic_set_test.exs
@@ -18,5 +18,8 @@ defmodule Grizzly.ZWave.Commands.BasicSetTest do
     binary_params = <<0xFF>>
     {:ok, params} = BasicSet.decode_params(binary_params)
     assert Keyword.get(params, :value) == :on
+    binary_params = <<0x01>>
+    {:ok, params} = BasicSet.decode_params(binary_params)
+    assert Keyword.get(params, :value) == :on
   end
 end


### PR DESCRIPTION
Only 0x00 and 0xFF were supported whereas the specs allow 0x01..0x63 to also mean :on