### PR TITLE
Rename parameter timeout in powerlevel commands

### DIFF
--- a/lib/grizzly/zwave/commands/powerlevel_report.ex
+++ b/lib/grizzly/zwave/commands/powerlevel_report.ex
@@ -6,7 +6,7 @@ defmodule Grizzly.ZWave.Commands.PowerlevelReport do
 
     * `:power_level` - This field indicates the power level value that the
       receiving node MUST set.
-    * `:timeout` - The time in seconds the node should keep the Power level
+    * `:reset_timeout` - The time in seconds the node should keep the Power level
       before resetting to normalPower level.
   """
 
@@ -15,7 +15,7 @@ defmodule Grizzly.ZWave.Commands.PowerlevelReport do
   alias Grizzly.ZWave.{Command, DecodeError}
   alias Grizzly.ZWave.CommandClasses.Powerlevel
 
-  @type param :: {:power_level, Powerlevel.power_level()} | {:timeout, non_neg_integer()}
+  @type param :: {:power_level, Powerlevel.power_level()} | {:reset_timeout, non_neg_integer()}
 
   @impl true
   @spec new([param()]) :: {:ok, Command.t()}
@@ -35,15 +35,15 @@ defmodule Grizzly.ZWave.Commands.PowerlevelReport do
   @spec encode_params(Command.t()) :: binary()
   def encode_params(command) do
     power_level_byte = Command.param!(command, :power_level) |> Powerlevel.power_level_to_byte()
-    timeout = Command.param!(command, :timeout)
-    <<power_level_byte, timeout>>
+    reset_timeout = Command.param!(command, :reset_timeout)
+    <<power_level_byte, reset_timeout>>
   end
 
   @impl true
   @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
-  def decode_params(<<power_level_byte, timeout>>) do
+  def decode_params(<<power_level_byte, reset_timeout>>) do
     with {:ok, power_level} <- Powerlevel.power_level_from_byte(power_level_byte) do
-      {:ok, [power_level: power_level, timeout: timeout]}
+      {:ok, [power_level: power_level, reset_timeout: reset_timeout]}
     else
       {:error, %DecodeError{} = error} ->
         %DecodeError{error | command: :powerlevel_report}

--- a/lib/grizzly/zwave/commands/powerlevel_set.ex
+++ b/lib/grizzly/zwave/commands/powerlevel_set.ex
@@ -8,7 +8,7 @@ defmodule Grizzly.ZWave.Commands.PowerlevelSet do
 
     * `:power_level` - This field indicates the power level value that the
       receiving node MUST set.
-    * `:timeout` - The time in seconds the node should keep the Power level
+    * `:reset_timeout` - The time in seconds the node should keep the Power level
       before resetting to normalPower level.
   """
 
@@ -17,7 +17,7 @@ defmodule Grizzly.ZWave.Commands.PowerlevelSet do
   alias Grizzly.ZWave.{Command, DecodeError}
   alias Grizzly.ZWave.CommandClasses.Powerlevel
 
-  @type param :: {:power_level, Powerlevel.power_level()} | {:timeout, non_neg_integer()}
+  @type param :: {:power_level, Powerlevel.power_level()} | {:reset_timeout, non_neg_integer()}
 
   @impl true
   @spec new([param()]) :: {:ok, Command.t()}
@@ -37,15 +37,15 @@ defmodule Grizzly.ZWave.Commands.PowerlevelSet do
   @spec encode_params(Command.t()) :: binary()
   def encode_params(command) do
     power_level_byte = Command.param!(command, :power_level) |> Powerlevel.power_level_to_byte()
-    timeout = Command.param!(command, :timeout)
-    <<power_level_byte, timeout>>
+    reset_timeout = Command.param!(command, :reset_timeout)
+    <<power_level_byte, reset_timeout>>
   end
 
   @impl true
   @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
-  def decode_params(<<power_level_byte, timeout>>) do
+  def decode_params(<<power_level_byte, reset_timeout>>) do
     with {:ok, power_level} <- Powerlevel.power_level_from_byte(power_level_byte) do
-      {:ok, [power_level: power_level, timeout: timeout]}
+      {:ok, [power_level: power_level, reset_timeout: reset_timeout]}
     else
       {:error, %DecodeError{} = error} ->
         %DecodeError{error | command: :powerlevel_set}

--- a/test/grizzly/zwave/commands/powerlevel_report_test.exs
+++ b/test/grizzly/zwave/commands/powerlevel_report_test.exs
@@ -4,12 +4,12 @@ defmodule Grizzly.ZWave.Commands.PowerlevelReportTest do
   alias Grizzly.ZWave.Commands.PowerlevelReport
 
   test "creates the command and validates params" do
-    params = [power_level: :normal_power, timeout: 10]
+    params = [power_level: :normal_power, reset_timeout: 10]
     {:ok, _command} = PowerlevelReport.new(params)
   end
 
   test "encodes params correctly" do
-    params = [power_level: :normal_power, timeout: 10]
+    params = [power_level: :normal_power, reset_timeout: 10]
     {:ok, command} = PowerlevelReport.new(params)
     expected_params_binary = <<0x00, 0x0A>>
     assert expected_params_binary == PowerlevelReport.encode_params(command)
@@ -19,6 +19,6 @@ defmodule Grizzly.ZWave.Commands.PowerlevelReportTest do
     params_binary = <<0x00, 0x0A>>
     {:ok, params} = PowerlevelReport.decode_params(params_binary)
     assert Keyword.get(params, :power_level) == :normal_power
-    assert Keyword.get(params, :timeout) == 10
+    assert Keyword.get(params, :reset_timeout) == 10
   end
 end

--- a/test/grizzly/zwave/commands/powerlevel_set_test.exs
+++ b/test/grizzly/zwave/commands/powerlevel_set_test.exs
@@ -4,12 +4,12 @@ defmodule Grizzly.ZWave.Commands.PowerlevelSetTest do
   alias Grizzly.ZWave.Commands.PowerlevelSet
 
   test "creates the command and validates params" do
-    params = [power_level: :normal_power, timeout: 10]
+    params = [power_level: :normal_power, reset_timeout: 10]
     {:ok, _command} = PowerlevelSet.new(params)
   end
 
   test "encodes params correctly" do
-    params = [power_level: :normal_power, timeout: 10]
+    params = [power_level: :normal_power, reset_timeout: 10]
     {:ok, command} = PowerlevelSet.new(params)
     expected_params_binary = <<0x00, 0x0A>>
     assert expected_params_binary == PowerlevelSet.encode_params(command)
@@ -19,6 +19,6 @@ defmodule Grizzly.ZWave.Commands.PowerlevelSetTest do
     params_binary = <<0x00, 0x0A>>
     {:ok, params} = PowerlevelSet.decode_params(params_binary)
     assert Keyword.get(params, :power_level) == :normal_power
-    assert Keyword.get(params, :timeout) == 10
+    assert Keyword.get(params, :reset_timeout) == 10
   end
 end


### PR DESCRIPTION
Renamed to reset_timeout because param timeout conflicts with command timeout option