### PR TITLE
association group command list report fix

### DIFF
--- a/lib/grizzly/zwave/commands/association_group_command_list_report.ex
+++ b/lib/grizzly/zwave/commands/association_group_command_list_report.ex
@@ -73,7 +73,8 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupCommandListReport do
   end
 
   defp decode_commands(length, encoded_commands_list) do
-    byte_list = :erlang.binary_to_list(encoded_commands_list)
+    # Ignore extraneous bytes, e.g. trailing 0s
+    byte_list = :erlang.binary_to_list(encoded_commands_list) |> Enum.take(length)
 
     if Enum.count(byte_list) != length do
       Logger.warn("[Grizzly] Invalid length #{length} for list of commands")

--- a/test/grizzly/zwave/commands/association_group_command_list_report_test.exs
+++ b/test/grizzly/zwave/commands/association_group_command_list_report_test.exs
@@ -23,4 +23,13 @@ defmodule Grizzly.ZWave.Commands.AssociationGroupCommandListReportTest do
     assert Enum.count(commands) == 3
     assert Enum.all?([:basic_set, :basic_get, :battery_get], &(&1 in commands)) == true
   end
+
+  test "decodes params correctly in spite of extra byte" do
+    binary_params = <<0x02, 0x06, 0x20, 0x01, 0x20, 0x02, 0x80, 0x02, 0x00>>
+    {:ok, params} = AssociationGroupCommandListReport.decode_params(binary_params)
+    assert Keyword.get(params, :group_id) == 2
+    commands = Keyword.get(params, :commands)
+    assert Enum.count(commands) == 3
+    assert Enum.all?([:basic_set, :basic_get, :battery_get], &(&1 in commands)) == true
+  end
 end


### PR DESCRIPTION
Ignores bytes added by some devices beyond the advertized commands count