### PR TITLE
Provide controller firmware upgrade info

### DIFF
--- a/lib/grizzly/firmware_updates/firmware_update_supervisor.ex
+++ b/lib/grizzly/firmware_updates/firmware_update_supervisor.ex
@@ -20,6 +20,16 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunnerSupervisor do
     DynamicSupervisor.start_child(__MODULE__, child_spec)
   end
 
+  @doc """
+  Get the controller firmware upgrade info.
+  Note: The FirmwareUpdateRunnerSupervisor runs the only process that has this information once the hub is fully started.
+  """
+  @spec controller_firmware_upgrade_info :: [Grizzly.ZwaveFirmware.firmware_info()]
+  def controller_firmware_upgrade_info() do
+    state = :sys.get_state(__MODULE__)
+    Map.get(state.args, :zwave_firmware, [])
+  end
+
   @impl DynamicSupervisor
   def init(grizzly_options) do
     # Only one firmware update runner can be running at a time

--- a/lib/grizzly/zwave_firmware.ex
+++ b/lib/grizzly/zwave_firmware.ex
@@ -5,6 +5,8 @@ defmodule Grizzly.ZwaveFirmware do
 
   require Logger
 
+  @type firmware_info :: %{chip_type: non_neg_integer(), version: String.t(), path: Path.t()}
+
   @doc """
   Update the firmware on the Z-Wave module if an update is available
   """


### PR DESCRIPTION
To support Hubview requesting hub z-wave firmware upgrades, Piston needs to be able to aks Grizzly about the potential firmware info upgrades.