### PR TITLE
Add support for virtual devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,36 @@ and you will need to pass in the location to your configuration like so:
 
 `zipgateway -c /path/to/zipgateway.cfg`
 
+### Virtual devices
+
+Grizzly provides a way to work with virtual devices. These devices should work
+as their hardware counterparts, however, the state of these devices are held in
+memory and managed by the Grizzly runtime.
+
+To add a new virtual device you can call the
+`Grizzly.VirtualDevices.add_device/1` function passing the a module that
+implements the `Grizzly.VirtualDevices.Device` behaviour.
+
+After adding the device you can call the `Grizzly.send_command/5` function to
+send the device a command.
+
+```elixir
+{:ok, virtual_device_id} = Grizzly.VirtualDevices.add_device(Grizzly.VirtualDevices.Thermostat)
+
+Grizzly.send_command(virtual_device_id, :thermostat_setpoint_get)
+```
+
+Virtual device ids are tuples where the first item is the atom `:virtual` and
+the second item an integer of the device id, for example:
+`{:virtual, device_id}`. Grizzly provides a guard and a helper function for any
+checking you might have to do:
+
+1. `Grizzly.is_virtual_device/1` (guard)
+1. `Grizzly.virtual_device/1` (function)
+
+Also, the documentation for functions in `Grizzly.Node` and `Grizzly.Network`
+should indicate if they work with virtual devices.
+
 ## Resources
 
 - [Z-Wave Specification Documentation](https://www.silabs.com/products/wireless/mesh-networking/z-wave/specification)

--- a/lib/grizzly/report.ex
+++ b/lib/grizzly/report.ex
@@ -117,7 +117,7 @@ defmodule Grizzly.Report do
   the example for illustration purposes
   """
 
-  alias Grizzly.ZWave
+  alias Grizzly.{VirtualDevices, ZWave}
   alias Grizzly.ZWave.Command
 
   @typedoc """
@@ -148,7 +148,7 @@ defmodule Grizzly.Report do
           transmission_stats: [transmission_stat()],
           queued_delay: non_neg_integer(),
           command_ref: reference() | nil,
-          node_id: ZWave.node_id(),
+          node_id: ZWave.node_id() | VirtualDevices.id(),
           queued: boolean()
         }
 
@@ -223,7 +223,7 @@ defmodule Grizzly.Report do
   @doc """
   Make a new `Grizzly.Report`
   """
-  @spec new(status(), type(), ZWave.node_id(), [opt()]) :: t()
+  @spec new(status(), type(), ZWave.node_id() | VirtualDevices.id(), [opt()]) :: t()
   def new(status, type, node_id, opts \\ []) do
     %__MODULE__{
       status: status,

--- a/lib/grizzly/supervisor.ex
+++ b/lib/grizzly/supervisor.ex
@@ -225,6 +225,9 @@ defmodule Grizzly.Supervisor do
 
       # Supervisor for running commands
       Grizzly.Commands.CommandRunnerSupervisor,
+
+      # Supervisor for virtual devices
+      Grizzly.VirtualDevicesSupervisor,
       {ReadyChecker, [status_reporter: options.status_reporter]}
     ]
     |> maybe_run_zipgateway_supervisor(options)

--- a/lib/grizzly/virtual_devices.ex
+++ b/lib/grizzly/virtual_devices.ex
@@ -1,0 +1,50 @@
+defmodule Grizzly.VirtualDevices do
+  @moduledoc """
+  Virtual devices
+
+  Virtual devices are in-memory devices that act like a Z-Wave device
+  """
+
+  alias Grizzly.VirtualDevices.{Device, DeviceServer, Network}
+  alias Grizzly.ZWave.Command
+
+  @typedoc """
+  Id for a virtual device
+  """
+  @type id() :: {:virtual, integer()}
+
+  @doc """
+  Add a new virtual device to the virtual device network
+
+  To add a virtual device you must supply a module that implements the
+  `Grizzly.VirtualDevices.Device` behaviour.
+  """
+  @spec add_device(Device.t()) :: {:ok, id()}
+  def add_device(device) do
+    Network.add_device(device)
+  end
+
+  @doc """
+  Send a Z-Wave command to a virtual device
+  """
+  @spec send_command(id(), Command.t()) :: Grizzly.send_command_response()
+  def send_command(node_id, command) do
+    DeviceServer.send_command(node_id, command)
+  end
+
+  @doc """
+  Remove a virtual device from the virtual device network
+  """
+  @spec remove_device(id()) :: :ok
+  def remove_device(virtual_device_id) do
+    Network.remove_device(virtual_device_id)
+  end
+
+  @doc """
+  List all the virtual devices on the virtual device network
+  """
+  @spec list_nodes() :: [id()]
+  def list_nodes() do
+    Network.list_nodes()
+  end
+end

--- a/lib/grizzly/virtual_devices/device.ex
+++ b/lib/grizzly/virtual_devices/device.ex
@@ -1,0 +1,23 @@
+defmodule Grizzly.VirtualDevices.Device do
+  @moduledoc """
+  Behaviour for implementing virtual device specifics
+  """
+
+  alias Grizzly.ZWave.{Command, DeviceClass}
+
+  @typedoc """
+  A module that implements this behaviour
+  """
+  @type t() :: module()
+
+  @doc """
+  Initialize the device
+  """
+  @callback init() :: {:ok, state :: term(), DeviceClass.t()} | {:error, term()}
+
+  @doc """
+  Handle a Z-Wave command
+  """
+  @callback handle_command(Command.t(), state :: term()) ::
+              {:ok, Command.t(), state :: term()} | {:error, term()}
+end

--- a/lib/grizzly/virtual_devices/device_server.ex
+++ b/lib/grizzly/virtual_devices/device_server.ex
@@ -1,0 +1,105 @@
+defmodule Grizzly.VirtualDevices.DeviceServer do
+  @moduledoc false
+
+  use GenServer
+
+  alias Grizzly.{Report, VirtualDevices}
+  alias Grizzly.VirtualDevices.Device
+  alias Grizzly.ZWave.Command
+  alias Grizzly.ZWave.Commands.NodeInfoCacheReport
+
+  @typedoc """
+  Initial arguments to the device server
+
+  * `:id` - the virtual device id, this is required
+  * `:device` - the virtual device implementation module that will handle the
+    specific commands, this is required
+  """
+  @type arg() ::
+          {:id, VirtualDevices.id()} | {:device, Device.t()}
+
+  def child_spec(args) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [args]},
+      restart: :transient
+    }
+  end
+
+  @doc """
+  Start the device server
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(args) do
+    id = Keyword.fetch!(args, :id)
+    GenServer.start_link(__MODULE__, args, name: name(id))
+  end
+
+  defp name(id) do
+    {:via, Registry, {Grizzly.VirtualDevicesRegistry, id}}
+  end
+
+  @doc """
+  Send a command to the virtual device
+  """
+  @spec send_command(VirtualDevices.id(), Command.t()) :: Grizzly.send_command_response()
+  def send_command(id, command) do
+    GenServer.call(name(id), {:send_command, command})
+  end
+
+  def stop(id) do
+    GenServer.stop(name(id))
+  end
+
+  @impl GenServer
+  def init(args) do
+    node_id = Keyword.fetch!(args, :id)
+    device_impl = Keyword.fetch!(args, :device)
+    {:ok, device_state, device_class} = device_impl.init()
+
+    {:ok,
+     %{
+       device_class: device_class,
+       device_state: device_state,
+       device: device_impl,
+       node_id: node_id
+     }}
+  end
+
+  @impl GenServer
+  def handle_call(
+        {:send_command, %Command{name: :node_info_cache_get} = node_info_get},
+        _from,
+        state
+      ) do
+    seq_number = Command.param!(node_info_get, :seq_number)
+
+    {:ok, node_info_report} =
+      NodeInfoCacheReport.new(
+        seq_number: seq_number,
+        status: :ok,
+        age: 1,
+        listening?: true,
+        command_classes: command_classes_for_device(state.device_class),
+        basic_device_class: state.device_class.basic_device_class,
+        specific_device_class: state.device_class.specific_device_class,
+        generic_device_class: state.device_class.generic_device_class
+      )
+
+    {:reply, build_report(node_info_report, state), state}
+  end
+
+  # helper function to transform a device class command class specification into
+  # a format that NodeInfoCacheReport expects
+  defp command_classes_for_device(device_class) do
+    [
+      non_secure_supported: device_class.command_classes.support,
+      non_secure_controlled: device_class.command_classes.control
+    ]
+  end
+
+  # helper function that builds the expected grizzly report
+  defp build_report(command, state) do
+    Report.new(:complete, :command, state.node_id, command: command)
+  end
+end

--- a/lib/grizzly/virtual_devices/devices_supervisor.ex
+++ b/lib/grizzly/virtual_devices/devices_supervisor.ex
@@ -1,0 +1,30 @@
+defmodule Grizzly.VirtualDevices.DevicesSupervisor do
+  @moduledoc false
+
+  use DynamicSupervisor
+
+  alias Grizzly.VirtualDevices
+  alias Grizzly.VirtualDevices.{Device, DeviceServer}
+
+  @doc """
+  Start the devices supervisor
+  """
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(args) do
+    DynamicSupervisor.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @doc """
+  Start the device server under this supervisor
+  """
+  @spec start_device(VirtualDevices.id(), Device.t()) :: DynamicSupervisor.on_start_child()
+  def start_device(device_id, device) do
+    spec = DeviceServer.child_spec(id: device_id, device: device)
+
+    DynamicSupervisor.start_child(__MODULE__, spec)
+  end
+
+  def init(_args) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/lib/grizzly/virtual_devices/network.ex
+++ b/lib/grizzly/virtual_devices/network.ex
@@ -1,0 +1,66 @@
+defmodule Grizzly.VirtualDevices.Network do
+  @moduledoc false
+
+  use GenServer
+
+  alias Grizzly.VirtualDevices
+  alias Grizzly.VirtualDevices.{DeviceServer, DevicesSupervisor}
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @doc """
+  Add a virtual device to the network
+  """
+  def add_device(device) do
+    GenServer.call(__MODULE__, {:add_device, device})
+  end
+
+  @doc """
+  List the virtual devices
+  """
+  @spec list_nodes() :: [VirtualDevices.id()]
+  def list_nodes() do
+    GenServer.call(__MODULE__, :list)
+  end
+
+  def remove_device(id) do
+    GenServer.call(__MODULE__, {:remove, id})
+  end
+
+  @impl GenServer
+  def init(_args) do
+    {:ok, %{network: %{}, current_id: 0}}
+  end
+
+  @impl GenServer
+  def handle_call({:add_device, device}, _from, state) do
+    id = state.current_id + 1
+
+    case DevicesSupervisor.start_device({:virtual, id}, device) do
+      {:ok, _pid} ->
+        updated_network = Map.put(state.network, id, device)
+
+        {:reply, {:ok, {:virtual, id}}, %{state | network: updated_network, current_id: id}}
+    end
+  end
+
+  def handle_call(:list, _from, state) do
+    list = Enum.map(state.network, fn {id, _} -> {:virtual, id} end)
+
+    {:reply, list, state}
+  end
+
+  def handle_call({:remove, {:virtual, id} = vid}, _from, state) do
+    case Map.get(state.network, id) do
+      nil ->
+        {:reply, :ok, state}
+
+      _device ->
+        :ok = DeviceServer.stop(vid)
+        new_networks = Map.delete(state.network, id)
+        {:reply, :ok, %{state | network: new_networks}}
+    end
+  end
+end

--- a/lib/grizzly/virtual_devices/thermostat.ex
+++ b/lib/grizzly/virtual_devices/thermostat.ex
@@ -1,0 +1,23 @@
+defmodule Grizzly.VirtualDevices.Thermostat do
+  @moduledoc """
+  Implementation of a virtual device for a thermostat
+  """
+
+  @behaviour Grizzly.VirtualDevices.Device
+
+  alias Grizzly.ZWave.DeviceClass
+
+  @impl Grizzly.VirtualDevices.Device
+  def init(), do: {:ok, %{}, DeviceClass.thermostat_hvac()}
+
+  @impl Grizzly.VirtualDevices.Device
+  def handle_command(_command, state) do
+    {:ok,
+     %Grizzly.ZWave.Command{
+       name: :name,
+       command_class: __MODULE__,
+       command_byte: 12,
+       impl: __MODULE__
+     }, state}
+  end
+end

--- a/lib/grizzly/virtual_devices_supervisor.ex
+++ b/lib/grizzly/virtual_devices_supervisor.ex
@@ -1,0 +1,26 @@
+defmodule Grizzly.VirtualDevicesSupervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  alias Grizzly.VirtualDevices.{DevicesSupervisor, Network}
+
+  @doc """
+  Start the VirtualDevices Supervisor
+  """
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(args) do
+    Supervisor.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @impl Supervisor
+  def init(_args) do
+    children = [
+      {Registry, [keys: :unique, name: Grizzly.VirtualDevicesRegistry]},
+      {Network, []},
+      {DevicesSupervisor, []}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/grizzly/zwave/device_class.ex
+++ b/lib/grizzly/zwave/device_class.ex
@@ -1,0 +1,54 @@
+defmodule Grizzly.ZWave.DeviceClass do
+  @moduledoc """
+  Z-Wave device classes
+
+  Z-Wave device classes allow grouping devices with the same functionality
+  together. Moreover, the device class specification for specific device classes
+  provide mandatory and recommended command class support.
+  """
+
+  alias Grizzly.ZWave.{DeviceClasses, CommandClasses}
+
+  @type command_class_spec() :: %{
+          support: [CommandClasses.command_class()],
+          control: [CommandClasses.command_class()]
+        }
+
+  @type t() :: %{
+          basic_device_class: DeviceClasses.basic_device_class(),
+          generic_device_class: DeviceClasses.generic_device_class(),
+          specific_device_class: DeviceClasses.specific_device_class(),
+          command_classes: command_class_spec()
+        }
+
+  @spec thermostat_hvac() :: t()
+  def thermostat_hvac() do
+    %{
+      basic_device_class: :routing_slave,
+      generic_device_class: :thermostat,
+      specific_device_class: :thermostat_general_v2,
+      command_classes: %{
+        support: [
+          :association,
+          :association_group_information,
+          :basic,
+          :batter,
+          :device_reset_locally,
+          :manufacturer_specific,
+          :power_level,
+          :security_2,
+          :supervision,
+          :thermostat_mode,
+          :thermostat_set_point,
+          :transport_service,
+          :version,
+          :wake_up,
+          :zwave_plus_info
+        ],
+        control: [
+          :wake_up
+        ]
+      }
+    }
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,47 @@ defmodule Grizzly.MixProject do
       logo: "./assets/grizzly-icon-yellow.png",
       source_ref: "v#{@version}",
       source_url: "https://github.com/smartrent/grizzly",
-      skip_undefined_reference_warnings_on: ["CHANGELOG.md"]
+      skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
+      groups_for_modules: [
+        Core: [
+          Grizzly.Supervisor,
+          Grizzly,
+          Grizzly.Inclusions,
+          Grizzly.Indicator,
+          Grizzly.Network,
+          Grizzly.Node,
+          Grizzly.Trace,
+          Grizzly.Trace.Record,
+          Grizzly.StatusReporter,
+          Grizzly.StatusReporter.Console,
+          Grizzly.Report
+        ],
+        "Grizzly Command Modules": [
+          Grizzly.SwitchBinary
+        ],
+        "Virtual Devices": [
+          Grizzly.VirtualDevices,
+          Grizzly.VirtualDevices.Device,
+          Grizzly.VirtualDevices.Thermostat
+        ],
+        ZWave: [
+          Grizzly.ZWave,
+          Grizzly.ZWave.CRC,
+          Grizzly.ZWave.DeviceClass,
+          Grizzly.ZWave.DeviceClasses,
+          Grizzly.ZWave.DSK,
+          Grizzly.ZWave.IconType,
+          Grizzly.ZWave.Notifications,
+          Grizzly.ZWave.QRCode,
+          Grizzly.ZWave.Security
+        ],
+        Transports: [
+          Grizzly.Transport,
+          Grizzly.Transport.Response,
+          Grizzly.Transports.DTLS,
+          Grizzly.Transports.UDP
+        ]
+      ]
     ]
   end
 

--- a/test/grizzly/virtual_devices_test.exs
+++ b/test/grizzly/virtual_devices_test.exs
@@ -1,0 +1,16 @@
+defmodule Grizzly.VirtualDeviceTest do
+  use Grizzly.VirtualDeviceCase, async: true
+
+  alias Grizzly.VirtualDevices
+  alias Grizzly.VirtualDevices.Thermostat
+
+  test "Adding devices to the network and getting them back" do
+    with_virtual_devices(Thermostat, fn ids ->
+      network_ids = VirtualDevices.list_nodes()
+
+      for nid <- network_ids do
+        assert nid in ids
+      end
+    end)
+  end
+end

--- a/test/grizzly_test.exs
+++ b/test/grizzly_test.exs
@@ -6,6 +6,7 @@ defmodule Grizzly.Test do
   alias Grizzly.ZWave.Commands.{SwitchBinaryGet, SwitchBinaryReport, ZIPPacket}
 
   import ExUnit.CaptureLog, only: [capture_log: 2]
+  import Grizzly, only: [is_virtual_device: 1]
 
   describe "SwitchBinary Commands" do
     @tag :integration
@@ -135,6 +136,25 @@ defmodule Grizzly.Test do
         Grizzly.send_command(:gateway, :version_command_class_get, command_class: :multi_command)
 
       assert Command.param!(report.command, :version) == 1
+    end
+  end
+
+  describe "checking if a device id is a virtual devices" do
+    test "when it is a virtual device" do
+      id = {:virtual, 100}
+
+      assert is_virtual_device(id)
+      assert Grizzly.virtual_device?(id)
+    end
+
+    test "when it is not a virtual device" do
+      refute is_virtual_device(100)
+      refute Grizzly.virtual_device?(100)
+    end
+
+    test "when it is the gateway" do
+      refute is_virtual_device(:gateway)
+      refute Grizzly.virtual_device?(:gateway)
     end
   end
 end

--- a/test/support/virtual_device_case.ex
+++ b/test/support/virtual_device_case.ex
@@ -1,0 +1,39 @@
+defmodule Grizzly.VirtualDeviceCase do
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import Grizzly.VirtualDeviceCase
+    end
+  end
+
+  alias Grizzly.VirtualDevices
+
+  def with_virtual_device(virtual_device_impl, test) do
+    {:ok, virtual_device_id} = VirtualDevices.add_device(virtual_device_impl)
+
+    test.(virtual_device_id)
+
+    :ok = VirtualDevices.remove_device(virtual_device_id)
+  end
+
+  def with_virtual_devices(virtual_device_impls, test) when is_list(virtual_device_impls) do
+    virtual_device_ids =
+      Enum.map(virtual_device_impls, fn impl ->
+        {:ok, id} = VirtualDevices.add_device(impl)
+
+        id
+      end)
+
+    test.(virtual_device_ids)
+
+    Enum.each(virtual_device_ids, fn id ->
+      :ok = VirtualDevices.remove_device(id)
+    end)
+  end
+
+  def with_virtual_devices(impl, test, number_of_devices \\ 5) when is_atom(impl) do
+    impls = Enum.map(1..number_of_devices, fn _ -> impl end)
+    with_virtual_devices(impls, test)
+  end
+end


### PR DESCRIPTION
Base support for virtual devices.

Since zip gateway does not provide a way for us to directly add virtual devices to the Z-Wave network, I added this feature to Grizzly.

The PR's goal is to setup the basic OTP infrastructure and modules needed for virtual devices. Two follow up PRs are next:

1. To finish the implementation of the thermostat
2. Provide some disk back options for virtual devices, so the devices stay in the virtual network over reboots.