### PR TITLE
Fixes for priority route and statistics commands

### DIFF
--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -324,7 +324,7 @@ defmodule Grizzly.Commands.Table do
       {:clock_set, {Commands.ClockSet, handler: AckResponse}},
       # Network Management Installation Maintenance
       {:priority_route_get,
-       {Commands.PriorityRouteGet, handler: {WaitReport, complete_report: :priorityRouteReport}}},
+       {Commands.PriorityRouteGet, handler: {WaitReport, complete_report: :priority_route_report}}},
       {:statistics_get,
        {Commands.StatisticsGet, handler: {WaitReport, complete_report: :statistics_report}}},
       {:statistics_clear, {Commands.StatisticsGet, handler: AckResponse}},

--- a/lib/grizzly/zwave/commands/priority_route_report.ex
+++ b/lib/grizzly/zwave/commands/priority_route_report.ex
@@ -10,7 +10,7 @@ defmodule Grizzly.ZWave.Commands.PriorityRouteReport do
 
     * `:repeaters` - node ids of repeaters for the route (required)
 
-    * `:speed` - speed used for the route (required)
+    * `:speed` - speeds used for the route (required)
 
   """
 
@@ -23,7 +23,7 @@ defmodule Grizzly.ZWave.Commands.PriorityRouteReport do
           {:node_id, byte}
           | {:type, NetworkManagementInstallationMaintenance.route_type()}
           | {:repeaters, [byte]}
-          | {:speed, NetworkManagementInstallationMaintenance.speed()}
+          | {:speed, NetworkManagementInstallationMaintenance.speeds()}
 
   @impl true
   @spec new([param()]) :: {:ok, Command.t()}
@@ -52,22 +52,22 @@ defmodule Grizzly.ZWave.Commands.PriorityRouteReport do
       Command.param!(command, :repeaters)
       |> NetworkManagementInstallationMaintenance.repeaters_to_bytes()
 
-    speed_byte =
-      Command.param!(command, :speed) |> NetworkManagementInstallationMaintenance.speed_to_byte()
+    speeds_byte =
+      Command.param!(command, :speed) |> NetworkManagementInstallationMaintenance.speeds_to_byte()
 
-    <<node_id, type_byte>> <> repeater_bytes <> <<speed_byte>>
+    <<node_id, type_byte>> <> repeater_bytes <> <<speeds_byte>>
   end
 
   @impl true
   @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
   def decode_params(<<node_id, type_byte, repeater_bytes::binary-size(4), speed_byte>>) do
     with {:ok, type} <- NetworkManagementInstallationMaintenance.route_type_from_byte(type_byte),
-         {:ok, speed} <- NetworkManagementInstallationMaintenance.speed_from_byte(speed_byte) do
+         {:ok, speeds} <- NetworkManagementInstallationMaintenance.speeds_from_byte(speed_byte) do
       {:ok,
        [
          node_id: node_id,
          type: type,
-         speed: speed,
+         speed: speeds,
          repeaters: NetworkManagementInstallationMaintenance.repeaters_from_bytes(repeater_bytes)
        ]}
     else

--- a/test/grizzly/zwave/commands/priority_route_report_test.exs
+++ b/test/grizzly/zwave/commands/priority_route_report_test.exs
@@ -9,9 +9,9 @@ defmodule Grizzly.ZWave.Commands.PriorityRouteReportTest do
   end
 
   test "encodes params correctly" do
-    params = [node_id: 4, speed: :"100kbit/s", type: :last_working_route, repeaters: [5, 6]]
+    params = [node_id: 4, speed: [:"100kbit/s"], type: :last_working_route, repeaters: [5, 6]]
     {:ok, command} = PriorityRouteReport.new(params)
-    expected_binary = <<0x04, 0x01, 0x05, 0x06, 0x00, 0x00, 0x03>>
+    expected_binary = <<0x04, 0x01, 0x05, 0x06, 0x00, 0x00, 0x04>>
     assert expected_binary == PriorityRouteReport.encode_params(command)
   end
 
@@ -19,7 +19,7 @@ defmodule Grizzly.ZWave.Commands.PriorityRouteReportTest do
     params_binary = <<0x04, 0x01, 0x05, 0x06, 0x00, 0x00, 0x03>>
     {:ok, params} = PriorityRouteReport.decode_params(params_binary)
     assert Keyword.get(params, :node_id) == 4
-    assert Keyword.get(params, :speed) == :"100kbit/s"
+    assert Keyword.get(params, :speed) == [:"9.6kbit/s", :"40kbit/s"]
     assert Keyword.get(params, :type) == :last_working_route
     assert Keyword.get(params, :repeaters) == [5, 6]
   end

--- a/test/grizzly/zwave/commands/statistics_report_test.exs
+++ b/test/grizzly/zwave/commands/statistics_report_test.exs
@@ -8,8 +8,8 @@ defmodule Grizzly.ZWave.Commands.StatisticsReportTest do
       route_changes: 2,
       transmission_count: 10,
       neighbors: [
-        [node_id: 5, repeater?: true, speed: :"100kbit/s"],
-        [node_id: 6, repeater?: false, speed: :"40kbit/s"]
+        [node_id: 5, repeater?: true, speed: [:"100kbit/s"]],
+        [node_id: 6, repeater?: false, speed: [:"40kbit/s"]]
       ],
       packet_error_count: 5,
       sum_of_transmission_times: 12,
@@ -25,8 +25,8 @@ defmodule Grizzly.ZWave.Commands.StatisticsReportTest do
       route_changes: 2,
       transmission_count: 10,
       neighbors: [
-        [node_id: 5, repeater?: true, speed: :"100kbit/s"],
-        [node_id: 6, repeater?: false, speed: :"40kbit/s"]
+        [node_id: 5, repeater?: true, speed: [:"100kbit/s"]],
+        [node_id: 6, repeater?: false, speed: [:"40kbit/s"]]
       ],
       packet_error_count: 5,
       sum_of_transmission_times: 12,
@@ -40,7 +40,7 @@ defmodule Grizzly.ZWave.Commands.StatisticsReportTest do
 
     neighbors =
       <<0x02, 0x04>> <>
-        <<0x05, 0x01::size(1), 0x00::size(2), 0x03::size(5)>> <>
+        <<0x05, 0x01::size(1), 0x00::size(2), 0x04::size(5)>> <>
         <<0x06, 0x00::size(1), 0x00::size(2), 0x02::size(5)>>
 
     packet_error_count = <<0x03, 0x01, 0x05>>
@@ -85,9 +85,9 @@ defmodule Grizzly.ZWave.Commands.StatisticsReportTest do
     [n1, n2] = Keyword.get(statistics, :neighbors)
     assert Keyword.get(n1, :node_id) == 5
     assert Keyword.get(n1, :repeater?) == true
-    assert Keyword.get(n1, :speed) == :"100kbit/s"
+    assert Keyword.get(n1, :speed) == [:"9.6kbit/s", :"40kbit/s"]
     assert Keyword.get(n2, :node_id) == 6
     assert Keyword.get(n2, :repeater?) == false
-    assert Keyword.get(n2, :speed) == :reserved
+    assert Keyword.get(n2, :speed) == []
   end
 end


### PR DESCRIPTION
Fixed typo in command table for :priority_route_get
Speed byte is a mask encoding one or more speeds, not just one