### PR TITLE
Allow for no parameter length in alarm reports

### DIFF
--- a/test/grizzly/zwave/commands/alarm_report_test.exs
+++ b/test/grizzly/zwave/commands/alarm_report_test.exs
@@ -130,6 +130,19 @@ defmodule Grizzly.ZWave.Commands.AlarmReportTest do
       assert Keyword.fetch!(params, :event_parameters) == []
     end
 
+    test "v2 no parameters or parameter length" do
+      binary = <<0x10, 0x25, 0x00, 0x00, 0x06, 0x06>>
+
+      {:ok, params} = AlarmReport.decode_params(binary)
+
+      assert Keyword.fetch!(params, :type) == 0x10
+      assert Keyword.fetch!(params, :level) == 0x25
+      assert Keyword.fetch!(params, :zwave_status) == :disabled
+      assert Keyword.fetch!(params, :zensor_net_node_id) == 0x00
+      assert Keyword.fetch!(params, :zwave_event) == :keypad_unlock_operation
+      assert Keyword.fetch!(params, :zwave_type) == :access_control
+    end
+
     test "v2 with event params" do
       binary = <<0x10, 0x25, 0x00, 0x00, 0x06, 0x06, 0x04, 0x63, 0x03, 0xFB, 0x01>>
 


### PR DESCRIPTION
Schalge 468ZP door locks send v2 alarms with no parameter length.