### PR TITLE
Partial fixes to canceling secure inclusion

### DIFF
--- a/lib/grizzly/inclusions/inclusion_runner/inclusion.ex
+++ b/lib/grizzly/inclusions/inclusion_runner/inclusion.ex
@@ -167,8 +167,18 @@ defmodule Grizzly.Inclusions.InclusionRunner.Inclusion do
     %__MODULE__{inclusion | state: :keys_requested}
   end
 
+  def keys_requested(%__MODULE__{state: state} = inclusion)
+      when state in [:node_adding_stop, :learn_mode_stop] do
+    %__MODULE__{inclusion | state: :learn_mode_stop}
+  end
+
   def keys_granted(%__MODULE__{state: :keys_requested} = inclusion) do
     %__MODULE__{inclusion | state: :keys_granted}
+  end
+
+  def keys_granted(%__MODULE__{state: state} = inclusion)
+      when state in [:node_adding_stop, :learn_mode_stop] do
+    %__MODULE__{inclusion | state: :learn_mode_stop}
   end
 
   def dsk_requested(%__MODULE__{state: :keys_granted} = inclusion, opts) do
@@ -176,8 +186,18 @@ defmodule Grizzly.Inclusions.InclusionRunner.Inclusion do
     %__MODULE__{inclusion | state: :dsk_requested, dsk_input_length: dsk_input_length}
   end
 
+  def dsk_requested(%__MODULE__{state: state} = inclusion, _opts)
+      when state in [:node_adding_stop, :learn_mode_stop] do
+    %__MODULE__{inclusion | state: :learn_mode_stop}
+  end
+
   def dsk_set(%__MODULE__{state: :dsk_requested} = inclusion) do
     %__MODULE__{inclusion | state: :dsk_set}
+  end
+
+  def dsk_set(%__MODULE__{state: state} = inclusion)
+      when state in [:node_adding_stop, :learn_mode_stop] do
+    %__MODULE__{inclusion | state: :learn_mode_stop}
   end
 
   def learn_mode(%__MODULE__{state: :started} = inclusion) do

--- a/lib/grizzly/zwave/commands/node_add_dsk_set.ex
+++ b/lib/grizzly/zwave/commands/node_add_dsk_set.ex
@@ -76,6 +76,8 @@ defmodule Grizzly.ZWave.Commands.NodeAddDSKSet do
     <<>>
   end
 
+  defp dsk_to_binary(_dsk, nil), do: <<>>
+
   defp dsk_to_binary(0, dsk_len) when dsk_len == 0 do
     <<>>
   end


### PR DESCRIPTION
Start the inclusion of a secure device and cancel inclusion before DSK PIN is requested