### PR TITLE
Validate signed configuration parameter values

### DIFF
--- a/lib/grizzly/zwave/commands/configuration_set.ex
+++ b/lib/grizzly/zwave/commands/configuration_set.ex
@@ -80,8 +80,16 @@ defmodule Grizzly.ZWave.Commands.ConfigurationSet do
     param_num = Command.param!(command, :param_number)
     size = Command.param!(command, :size)
     value = Command.param!(command, :value)
+    validate!(value, size)
     value_bin = <<value::signed-integer-size(size)-unit(8)>>
 
     <<param_num, size>> <> value_bin
   end
+
+  defp validate!(value, 1) when value in -128..127, do: :ok
+  defp validate!(value, 2) when value in -32768..32767, do: :ok
+  defp validate!(value, 4) when value in -2_147_483_648..2_147_483_647, do: :ok
+
+  defp validate!(value, byte),
+    do: raise(ArgumentError, message: "Invalid parameter. #{value} will not fit in #{byte} bytes")
 end

--- a/test/grizzly/zwave/commands/configuration_set_test.exs
+++ b/test/grizzly/zwave/commands/configuration_set_test.exs
@@ -41,14 +41,34 @@ defmodule Grizzly.ZWave.Commands.ConfigurationSetTest do
       assert <<0x0F, 0x02, 0x73, 0x17>> == ConfigurationSet.encode_params(command)
     end
 
-    test "when a 3 byte neg value is set" do
-      {:ok, command} = ConfigurationSet.new(value: -3_664_127, param_number: 15, size: 3)
-      assert <<0x0F, 0x03, 0xC8, 0x17, 0x01>> == ConfigurationSet.encode_params(command)
+    test "when a 4 byte neg value is set" do
+      {:ok, command} = ConfigurationSet.new(value: -3_664_127, param_number: 15, size: 4)
+      assert <<0x0F, 0x04, 0xFF, 0xC8, 0x17, 0x01>> == ConfigurationSet.encode_params(command)
     end
 
-    test "when a 3 byte pos value is set" do
+    test "when a 4 byte pos value is set" do
+      {:ok, command} = ConfigurationSet.new(value: 7_542_529, param_number: 15, size: 4)
+      assert <<0x0F, 0x04, 0x00, 0x73, 0x17, 0x01>> == ConfigurationSet.encode_params(command)
+    end
+
+    test "when an illegal 3 byte value is set" do
       {:ok, command} = ConfigurationSet.new(value: 7_542_529, param_number: 15, size: 3)
-      assert <<0x0F, 0x03, 0x73, 0x17, 0x01>> == ConfigurationSet.encode_params(command)
+
+      assert %ArgumentError{
+               __exception__: true,
+               message: "Invalid parameter. 7542529 will not fit in 3 bytes"
+             } ==
+               catch_error(ConfigurationSet.encode_params(command))
+    end
+
+    test "when an out-of-range byte value is set" do
+      {:ok, command} = ConfigurationSet.new(value: 128, param_number: 15, size: 1)
+
+      assert %ArgumentError{
+               __exception__: true,
+               message: "Invalid parameter. 128 will not fit in 1 bytes"
+             } ==
+               catch_error(ConfigurationSet.encode_params(command))
     end
   end
 


### PR DESCRIPTION
Configuration parameter values are now checked against allowed ranges given their byte sizes when set.

Also, only byte sizes 1,2 and 4 are now allowed, as per the Z-Wave specs.