### PR TITLE
Isolate inclusion status from inclusion logic

### DIFF
--- a/lib/grizzly/inclusions.ex
+++ b/lib/grizzly/inclusions.ex
@@ -167,7 +167,24 @@ defmodule Grizzly.Inclusions do
   """
 
   alias Grizzly.InclusionServer
+  alias Grizzly.Inclusions.StatusServer
   alias Grizzly.ZWave.{DSK, Security}
+
+  @typedoc """
+  Status of the inclusion server
+  """
+  @type status() ::
+          :idle
+          | :node_adding
+          | :node_add_stopping
+          | :node_removing
+          | :node_remove_stopping
+          | :waiting_dsk
+          | :waiting_s2_keys
+          | :s2_keys_granted
+          | :dsk_input_set
+          | :learn_mode
+          | :learn_mode_stopping
 
   @typedoc """
   Options for inclusion
@@ -194,8 +211,12 @@ defmodule Grizzly.Inclusions do
     InclusionServer.remove_node(opts)
   end
 
+  @doc """
+  Get the current status of the inclusion process
+  """
+  @spec status() :: status()
   def status() do
-    InclusionServer.status()
+    StatusServer.get()
   end
 
   @doc """
@@ -283,6 +304,6 @@ defmodule Grizzly.Inclusions do
   """
   @spec inclusion_running?() :: boolean()
   def inclusion_running?() do
-    InclusionServer.status() != :idle
+    StatusServer.get() != :idle
   end
 end

--- a/lib/grizzly/inclusions/network_adapter.ex
+++ b/lib/grizzly/inclusions/network_adapter.ex
@@ -3,7 +3,7 @@ defmodule Grizzly.Inclusions.NetworkAdapter do
   Behaviour for inclusions to use to talk to the network
   """
 
-  alias Grizzly.{Inclusions, InclusionServer}
+  alias Grizzly.Inclusions
   alias Grizzly.ZWave.{DSK, Security}
 
   @typedoc """
@@ -68,6 +68,6 @@ defmodule Grizzly.Inclusions.NetworkAdapter do
 
   This function returns the new status of the inclusion server
   """
-  @callback handle_timeout(InclusionServer.status(), reference(), state()) ::
-              {InclusionServer.status(), state()}
+  @callback handle_timeout(Inclusions.status(), reference(), state()) ::
+              {Inclusions.status(), state()}
 end

--- a/lib/grizzly/inclusions/status_server.ex
+++ b/lib/grizzly/inclusions/status_server.ex
@@ -1,0 +1,52 @@
+defmodule Grizzly.Inclusions.StatusServer do
+  @moduledoc false
+
+  # Server for keeping track of the inclusion status.
+
+  # Separating this into it's own process allows for error isolation between the
+  # inclusion server and the status of the inclusion process. The reason for the
+  # isolation is if the inclusion server crashes for whatever reason the Z-Wave
+  # controller will be in an non-operable state and there would be no why for
+  # the runtime to know this. Therefore, the status is kept separate from the
+  # more complex code around managing the communication back and forth during
+  # an inclusion/exclusion of a Z-Wave device. The goal of this is to provide
+  # system recoverability after a crash during inclusion/exclusion.
+
+  use GenServer
+
+  alias Grizzly.Inclusions
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @doc """
+  Set the status of the inclusion process
+  """
+  @spec set(Inclusions.status()) :: :ok
+  def set(status) do
+    GenServer.call(__MODULE__, {:set, status})
+  end
+
+  @doc """
+  Get the status of the inclusion process
+  """
+  @spec get() :: Inclusions.status()
+  def get() do
+    GenServer.call(__MODULE__, :get)
+  end
+
+  @impl GenServer
+  def init(_args) do
+    {:ok, :idle}
+  end
+
+  @impl GenServer
+  def handle_call({:set, status}, _from, _old_status) do
+    {:reply, :ok, status}
+  end
+
+  def handle_call(:get, _from, status) do
+    {:reply, status, status}
+  end
+end

--- a/lib/grizzly/inclusions/supervisor.ex
+++ b/lib/grizzly/inclusions/supervisor.ex
@@ -1,0 +1,27 @@
+defmodule Grizzly.Inclusions.Supervisor do
+  @moduledoc false
+
+  # Supervisor to manage the life cycle of inclusion related processes
+
+  use Supervisor
+
+  alias Grizzly.Options
+
+  @doc """
+  Start the Inclusions supervisor
+  """
+  @spec start_link(Options.t()) :: Supervisor.on_start()
+  def start_link(options) do
+    Supervisor.start_link(__MODULE__, options, name: __MODULE__)
+  end
+
+  @impl Supervisor
+  def init(options) do
+    children = [
+      Grizzly.Inclusions.StatusServer,
+      {Grizzly.InclusionServer, options}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/grizzly/supervisor.ex
+++ b/lib/grizzly/supervisor.ex
@@ -225,7 +225,7 @@ defmodule Grizzly.Supervisor do
 
       # Supervisor for starting connections to Z-Wave nodes
       {Grizzly.Connections.Supervisor, options},
-      {Grizzly.InclusionServer, options},
+      {Grizzly.Inclusions.Supervisor, options},
 
       # Supervisor for updating firmware
       {Grizzly.FirmwareUpdates.FirmwareUpdateRunnerSupervisor, options},

--- a/test/grizzly/inclusions_test.exs
+++ b/test/grizzly/inclusions_test.exs
@@ -153,4 +153,30 @@ defmodule Grizzly.InclusionsTest do
 
     assert_receive %Grizzly.ZWave.Command{name: :node_add_status}, 1_500
   end
+
+  test "crashing inclusion should return server back into idle state" do
+    :ok = Inclusions.add_node()
+
+    inclusions_pid = Process.whereis(Grizzly.InclusionServer)
+
+    assert :node_adding = Inclusions.status()
+
+    Process.exit(inclusions_pid, :kill)
+    Process.sleep(500)
+
+    assert :idle == Inclusions.status()
+  end
+
+  test "crashing exclusion should return server back into idle state" do
+    :ok = Inclusions.remove_node()
+
+    inclusions_pid = Process.whereis(Grizzly.InclusionServer)
+
+    assert :node_removing = Inclusions.status()
+
+    Process.exit(inclusions_pid, :kill)
+    Process.sleep(500)
+
+    assert :idle == Inclusions.status()
+  end
 end

--- a/test/support/test_network_adpater.ex
+++ b/test/support/test_network_adpater.ex
@@ -149,6 +149,10 @@ defmodule GrizzlyTest.InclusionAdapter do
     {:grizzly, :report, Report.new(:complete, :command, 1, command: command)}
   end
 
+  defp cancel_timer(%{timer_ref: nil} = state) do
+    state
+  end
+
   defp cancel_timer(state) do
     Process.cancel_timer(state.timer_ref)
 


### PR DESCRIPTION
We isolate the inclusion status from the inclusion logic process in order
to restore the inclusion process back to a working state in case of
runtime errors in the main inclusion process.

This fixes a bug where the inclusion process would be restored back to
an idle state, but the Z-Wave controller is still in inclusion mode.
