### PR TITLE
Virtual devices cleanup

### DIFF
--- a/lib/grizzly/virtual_devices/device.ex
+++ b/lib/grizzly/virtual_devices/device.ex
@@ -24,6 +24,11 @@ defmodule Grizzly.VirtualDevices.Device do
   @callback device_spec([device_opt()]) :: DeviceClass.t()
 
   @doc """
+  Set the virtual device's id once added to the (virtual) Z-Wave network.
+  """
+  @callback set_device_id(pid(), Grizzly.VirtualDevices.id()) :: :ok
+
+  @doc """
   Handle a Z-Wave command
 
   When handling a command you can reply, notify, or do nothing.

--- a/test/grizzly/virtual_devices/thermostat_test.exs
+++ b/test/grizzly/virtual_devices/thermostat_test.exs
@@ -6,7 +6,16 @@ defmodule Grizzly.VirtualDevices.ThermostatTest do
   alias Grizzly.ZWave.Command
 
   test "get thermostat node info" do
-    start_supervised({Thermostat, []})
+    {:ok, pid} = start_supervised({Thermostat, []})
+
+    device_id =
+      Grizzly.VirtualDevices.add_device(
+        Thermostat,
+        module: Thermostat,
+        server: pid
+      )
+
+    Thermostat.set_device_id(pid, device_id)
 
     [device_id] = Grizzly.VirtualDevices.list_nodes()
 
@@ -16,7 +25,16 @@ defmodule Grizzly.VirtualDevices.ThermostatTest do
   end
 
   test "get thermostat manufacture info" do
-    start_supervised({Thermostat, []})
+    {:ok, pid} = start_supervised({Thermostat, []})
+
+    device_id =
+      Grizzly.VirtualDevices.add_device(
+        Thermostat,
+        module: Thermostat,
+        server: pid
+      )
+
+    Thermostat.set_device_id(pid, device_id)
 
     [device_id] = Grizzly.VirtualDevices.list_nodes()
 
@@ -30,7 +48,16 @@ defmodule Grizzly.VirtualDevices.ThermostatTest do
   end
 
   test "getting a command class version" do
-    start_supervised({Thermostat, []})
+    {:ok, pid} = start_supervised({Thermostat, []})
+
+    device_id =
+      Grizzly.VirtualDevices.add_device(
+        Thermostat,
+        module: Thermostat,
+        server: pid
+      )
+
+    Thermostat.set_device_id(pid, device_id)
 
     [device_id] = Grizzly.VirtualDevices.list_nodes()
 
@@ -46,8 +73,16 @@ defmodule Grizzly.VirtualDevices.ThermostatTest do
 
   describe "thermostat setpoints" do
     test "get cooling setpoint" do
-      start_supervised({Thermostat, []})
+      {:ok, pid} = start_supervised({Thermostat, []})
 
+      device_id =
+        Grizzly.VirtualDevices.add_device(
+          Thermostat,
+          module: Thermostat,
+          server: pid
+        )
+
+      Thermostat.set_device_id(pid, device_id)
       [device_id] = Grizzly.VirtualDevices.list_nodes()
 
       assert {:ok, %Report{type: :command, command: command}} =
@@ -60,8 +95,16 @@ defmodule Grizzly.VirtualDevices.ThermostatTest do
     end
 
     test "get heating setpoint" do
-      start_supervised({Thermostat, []})
+      {:ok, pid} = start_supervised({Thermostat, []})
 
+      device_id =
+        Grizzly.VirtualDevices.add_device(
+          Thermostat,
+          module: Thermostat,
+          server: pid
+        )
+
+      Thermostat.set_device_id(pid, device_id)
       [device_id] = Grizzly.VirtualDevices.list_nodes()
 
       assert {:ok, %Report{type: :command, command: command}} =
@@ -74,8 +117,16 @@ defmodule Grizzly.VirtualDevices.ThermostatTest do
     end
 
     test "set heating setpoint" do
-      start_supervised({Thermostat, []})
+      {:ok, pid} = start_supervised({Thermostat, []})
 
+      device_id =
+        Grizzly.VirtualDevices.add_device(
+          Thermostat,
+          module: Thermostat,
+          server: pid
+        )
+
+      Thermostat.set_device_id(pid, device_id)
       [device_id] = Grizzly.VirtualDevices.list_nodes()
 
       assert {:ok, %Report{type: :ack_response}} =
@@ -94,7 +145,16 @@ defmodule Grizzly.VirtualDevices.ThermostatTest do
 
   describe "sensor multilevel" do
     test "supported get" do
-      start_supervised({Thermostat, []})
+      {:ok, pid} = start_supervised({Thermostat, []})
+
+      device_id =
+        Grizzly.VirtualDevices.add_device(
+          Thermostat,
+          module: Thermostat,
+          server: pid
+        )
+
+      Thermostat.set_device_id(pid, device_id)
       [device_id] = Grizzly.VirtualDevices.list_nodes()
 
       {:ok, %Report{type: :command, command: command}} =

--- a/test/grizzly/virtual_devices_test.exs
+++ b/test/grizzly/virtual_devices_test.exs
@@ -106,8 +106,16 @@ defmodule Grizzly.VirtualDeviceTest do
   end
 
   test "receives notification for sensor report" do
-    {:ok, _pid} =
-      start_supervised({TemperatureSensor, report_interval: 1_000, force_report: true})
+    {:ok, pid} = start_supervised({TemperatureSensor, report_interval: 1_000, force_report: true})
+
+    device_id =
+      Grizzly.VirtualDevices.add_device(
+        Thermostat,
+        module: Thermostat,
+        server: pid
+      )
+
+    Thermostat.set_device_id(pid, device_id)
 
     Messages.subscribe(:sensor_multilevel_report)
     on_exit(fn -> Messages.unsubscribe(:sensor_multilevel_report) end)


### PR DESCRIPTION
Allow for virtual devices to be started before Grizzly itself starts.

Virtual devices will be started and supervised in platform support libraries/applications (e.g. parakeet_support), which start before either Piston or Grizzly. The virtual device servers (pids) will be passed to Piston to carry out the inclusion process . The inclusion process is started by Piston adding a virtual device in Grizzly and then handling the inclusion callback.

All this to say that virtual devices must not add themselves to the virtual network when they start.