### PR TITLE
Handle timeout on DSK input during inclusion

### DIFF
--- a/lib/grizzly/inclusions/zwave_adapter.ex
+++ b/lib/grizzly/inclusions/zwave_adapter.ex
@@ -140,7 +140,7 @@ defmodule Grizzly.Inclusions.ZWaveAdapter do
 
   @impl Grizzly.Inclusions.NetworkAdapter
   def handle_timeout(state, _old_ref, adapter_state)
-      when state in [:node_adding, :waiting_s2_keys, :waiting_dsk] do
+      when state in [:node_adding, :waiting_s2_keys, :waiting_dsk, :dsk_input_set] do
     {:ok, new_state} = add_node_stop(adapter_state)
 
     {:node_add_stopping, new_state}


### PR DESCRIPTION
Else we get an error when timing out on providing a requested DSK PIN
```
18:49:24.914 [error] GenServer Grizzly.InclusionServer terminating
** (FunctionClauseError) no function clause matching in Grizzly.Inclusions.ZWaveAdapter.handle_timeout/3
    (grizzly 5.1.2) lib/grizzly/inclusions/zwave_adapter.ex:142: Grizzly.Inclusions.ZWaveAdapter.handle_timeout(:dsk_input_set, #Reference<0.3940735786.1738276865.248287>, %{command_ref: #Reference<0.3940735786.1738276865.249871>})
    (grizzly 5.1.2) lib/grizzly/inclusion_server.ex:234: Grizzly.InclusionServer.handle_info/2
    (stdlib 4.0.1) gen_server.erl:1120: :gen_server.try_dispatch/4
    (stdlib 4.0.1) gen_server.erl:1197: :gen_server.handle_msg/6
    (stdlib 4.0.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message: {:grizzly, :report, %Grizzly.Report{command: nil, command_ref: #Reference<0.3940735786.1738276865.248287>, node_id: 1, queued: false, queued_delay: 0, status: :complete, transmission_stats: [], type: :timeout}}
State: %{adapter: Grizzly.Inclusions.ZWaveAdapter, adapter_state: %{command_ref: #Reference<0.3940735786.1738276865.249871>}, dsk_requested_length: 2, handler: {Piston.InclusionHandler, [s2_keys: [:s2_access_control, :s2_authenticated, :s2_unauthenticated, :s0], s2_pin: nil]}, state: :dsk_input_set}
```