### PR TITLE
Bugfix: Typo For Celsius

### DIFF
--- a/lib/grizzly/zwave/command_classes/thermostat_setpoint.ex
+++ b/lib/grizzly/zwave/command_classes/thermostat_setpoint.ex
@@ -63,11 +63,11 @@ defmodule Grizzly.ZWave.CommandClasses.ThermostatSetpoint do
   def decode_type(_na_type), do: :na
 
   @spec encode_scale(scale) :: byte
-  def encode_scale(:celcius), do: 0x00
+  def encode_scale(:celsius), do: 0x00
   def encode_scale(:fahrenheit), do: 0x01
 
   @spec decode_scale(byte) :: {:ok, scale} | {:error, DecodeError.t()}
-  def decode_scale(0x00), do: {:ok, :celcius}
+  def decode_scale(0x00), do: {:ok, :celsius}
   def decode_scale(0x01), do: {:ok, :fahrenheit}
 
   def decode_scale(byte),

--- a/test/grizzly/zwave/commands/thermostat_setpoint_set_test.exs
+++ b/test/grizzly/zwave/commands/thermostat_setpoint_set_test.exs
@@ -4,7 +4,7 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSetTest do
   alias Grizzly.ZWave.Commands.ThermostatSetpointSet
 
   test "creates the command and validates params" do
-    params = [type: :heating, scale: :celcius, value: 75.5]
+    params = [type: :heating, scale: :celsius, value: 75.5]
     {:ok, _command} = ThermostatSetpointSet.new(params)
   end
 


### PR DESCRIPTION
While digging around I noticed spellings for both `celcius` and `celsius`. 

I don't know what this change impacts but I changed it to be consistent 😅 Can someone help test to make sure this doesn't break anything? 😆 