### PR TITLE
Fix to handling timeout of node removing

### DIFF
--- a/lib/grizzly/inclusions/zwave_adapter.ex
+++ b/lib/grizzly/inclusions/zwave_adapter.ex
@@ -146,7 +146,7 @@ defmodule Grizzly.Inclusions.ZWaveAdapter do
     {:node_add_stopping, new_state}
   end
 
-  def handle_timeout(:node_removing, command_ref, %{command_ref: command_ref} = state) do
+  def handle_timeout(:node_removing, _command_ref, state) do
     {:ok, new_state} = remove_node_stop(state)
 
     {:node_remove_stopping, new_state}


### PR DESCRIPTION
I am not certain about this fix because I don't understand why handling node_removing timeouts matches on command references while other handle_timeouts don't. 