### PR TITLE
Fix Elixir 1.14 deprecation warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ install_system_deps: &install_system_deps
       apk add build-base
 
 jobs:
-  build_elixir_1_13_otp_24:
+  build_elixir_1_14_otp_25:
     docker:
-      - image: hexpm/elixir:1.13.3-erlang-24.2.2-alpine-3.15.0
+      - image: hexpm/elixir:1.14.0-erlang-25.1-alpine-3.15.6
     <<: *defaults
     steps:
       - checkout
@@ -44,6 +44,18 @@ jobs:
           paths:
             - _build
             - deps
+
+  build_elixir_1_13_otp_24:
+    docker:
+      - image: hexpm/elixir:1.13.3-erlang-24.2.2-alpine-3.15.0
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix compile
+      - run: mix test
 
   build_elixir_1_12_otp_24:
     docker:
@@ -85,6 +97,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_14_otp_25
       - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23

--- a/lib/grizzly/zwave/command_classes/barrier_operator.ex
+++ b/lib/grizzly/zwave/command_classes/barrier_operator.ex
@@ -9,7 +9,7 @@ defmodule Grizzly.ZWave.CommandClasses.BarrierOperator do
 
   alias Grizzly.ZWave.DecodeError
 
-  use Bitwise
+  import Bitwise
 
   @type target_value :: :open | :close
   @type state :: :closed | 0x01..0x63 | :closing | :stopped | :opening | :open

--- a/lib/grizzly/zwave/command_classes/network_management_installation_maintenance.ex
+++ b/lib/grizzly/zwave/command_classes/network_management_installation_maintenance.ex
@@ -6,7 +6,7 @@ defmodule Grizzly.ZWave.CommandClasses.NetworkManagementInstallationMaintenance 
   data.
   """
 
-  use Bitwise, only_operators: true
+  import Bitwise
 
   @type route_type ::
           :no_route | :last_working_route | :next_to_last_working_route | :set_by_application

--- a/lib/grizzly/zwave/commands/thermostat_setpoint_supported_report.ex
+++ b/lib/grizzly/zwave/commands/thermostat_setpoint_supported_report.ex
@@ -10,7 +10,7 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReport do
 
   @behaviour Grizzly.ZWave.Command
 
-  use Bitwise, only_operators: true
+  import Bitwise
 
   alias Grizzly.ZWave.{Command, DecodeError}
   alias Grizzly.ZWave.CommandClasses.ThermostatSetpoint


### PR DESCRIPTION
- `use Bitwise` is deprecated in favor of `import Bitwise`.
- Added Elixir 1.14 / OTP 25 to CircleCI config