### PR TITLE
Format IPv6 addresses in traces using standard port notation

### DIFF
--- a/lib/grizzly/transports/DTLS.ex
+++ b/lib/grizzly/transports/DTLS.ex
@@ -218,7 +218,7 @@ defmodule Grizzly.Transports.DTLS do
 
   defp maybe_write_trace(in_or_out, ip, port, binary) do
     ip_port_str = make_ip_port_str(ip, port)
-    grizzly_ip_port_string = "#{@grizzly_ip}:#{@grizzly_ip}"
+    grizzly_ip_port_string = "[#{@grizzly_ip}]:#{@grizzly_port}"
 
     case in_or_out do
       :incoming ->
@@ -234,10 +234,10 @@ defmodule Grizzly.Transports.DTLS do
   end
 
   defp make_ip_port_str(ip, port) when is_binary(ip) do
-    "#{ip}:#{port}"
+    "[#{ip}]:#{port}"
   end
 
   defp make_ip_port_str(ip, port) do
-    "#{:inet.ntoa(ip)}:#{port}"
+    "[#{:inet.ntoa(ip)}]:#{port}"
   end
 end


### PR DESCRIPTION
This also fixes a typo where the IP address was printed instead of the port.