### PR TITLE
Fix trace dump crashes after including S2 devices

### DIFF
--- a/lib/grizzly/zwave/commands/node_add_dsk_report.ex
+++ b/lib/grizzly/zwave/commands/node_add_dsk_report.ex
@@ -51,10 +51,10 @@ defmodule Grizzly.ZWave.Commands.NodeAddDSKReport do
   def encode_params(command) do
     seq_number = Command.param!(command, :seq_number)
     input_dsk_length = Command.param!(command, :input_dsk_length)
-    dsk = Command.param!(command, :dsk)
-    {:ok, dsk} = DSK.parse(dsk)
 
-    <<seq_number, input_dsk_length>> <> dsk.raw
+    dsk = encode_dsk(Command.param!(command, :dsk))
+
+    <<seq_number, input_dsk_length>> <> dsk
   end
 
   @impl true
@@ -62,6 +62,9 @@ defmodule Grizzly.ZWave.Commands.NodeAddDSKReport do
   def decode_params(<<seq_number, _::size(4), input_dsk_length::size(4), dsk_bin::binary>>) do
     {:ok, [seq_number: seq_number, input_dsk_length: input_dsk_length, dsk: DSK.new(dsk_bin)]}
   end
+
+  defp encode_dsk(%DSK{raw: raw}), do: raw
+  defp encode_dsk(dsk_bin) when is_binary(dsk_bin), do: dsk_bin
 
   defp validate_seq_number(params) do
     case Keyword.get(params, :seq_number) do

--- a/lib/grizzly/zwave/commands/node_add_keys_set.ex
+++ b/lib/grizzly/zwave/commands/node_add_keys_set.ex
@@ -52,7 +52,7 @@ defmodule Grizzly.ZWave.Commands.NodeAddKeysSet do
      [
        seq_number: seq_number,
        csa: decode_csa(csa),
-       accepted: decode_accepted(accepted),
+       accept: decode_accepted(accepted),
        granted_keys: decode_granted_keys(granted_keys)
      ]}
   end

--- a/test/grizzly/trace/record_test.exs
+++ b/test/grizzly/trace/record_test.exs
@@ -16,4 +16,31 @@ defmodule Grizzly.Trace.RecordTest do
 
     assert expected_string == Record.to_string(record)
   end
+
+  test "decodes NodeAddDSKReport for S2 unauthenticated device without crashing" do
+    trace = %Grizzly.Trace.Record{
+      src: "[fd00:bbbb::1]:41230",
+      dest: "[fd00:aaaa::2]:41230",
+      binary:
+        <<35, 2, 0, 208, 42, 0, 0, 5, 132, 2, 4, 0, 52, 19, 123, 0, 110, 113, 215, 70, 212, 90,
+          35, 31, 65, 21, 237, 23, 121, 95, 97, 122>>,
+      timestamp: ~T[21:11:41.766545]
+    }
+
+    expected_string =
+      "21:11:41.766545 [fd00:bbbb::1]:41230 [fd00:aaaa::2]:41230 42  node_add_dsk_report <<123, 0, 110, 113, 215, 70, 212, 90, 35, 31, 65, 21, 237, 23, 121, 95, 97, 122>>"
+
+    assert expected_string == Record.to_string(trace)
+  end
+
+  test "encode NodeAddKeysSet without crashing" do
+    trace = %Grizzly.Trace.Record{
+      src: "[fd00:aaaa::2]:41230",
+      dest: "[fd00:bbbb::1]:41230",
+      binary: <<35, 2, 128, 80, 127, 0, 0, 52, 18, 127, 1, 1>>,
+      timestamp: ~T[21:11:41.673225]
+    }
+
+    Record.to_string(trace)
+  end
 end


### PR DESCRIPTION
`Grizzly.Trace.dump/1` would crash if you had recently included an S2 device due to errors encoding/decoding the `NODE_ADD_DSK_REPORT` and `NODE_ADD_KEYS_SET` commands.