### PR TITLE
Support getting configuration parameter name

### DIFF
--- a/lib/grizzly/command_handlers/aggregate_report.ex
+++ b/lib/grizzly/command_handlers/aggregate_report.ex
@@ -40,15 +40,21 @@ defmodule Grizzly.CommandHandlers.AggregateReport do
 
     new_aggregate_values = Command.param!(command, aggregate_param)
 
-    %{state | aggregates: aggregates ++ new_aggregate_values}
+    %{state | aggregates: do_aggregate(aggregates, new_aggregate_values)}
   end
 
   defp prepare_aggregate_data(command, state) do
     %{aggregate_param: aggregate_param, aggregates: aggregates} = state
     final_values = Command.param!(command, aggregate_param)
 
-    Command.put_param(command, aggregate_param, aggregates ++ final_values)
+    Command.put_param(command, aggregate_param, do_aggregate(aggregates, final_values))
   end
+
+  defp do_aggregate(aggregates, new_aggregate_values) when is_list(aggregates),
+    do: aggregates ++ new_aggregate_values
+
+  defp do_aggregate(aggregates, new_aggregate_values) when is_binary(aggregates),
+    do: aggregates <> new_aggregate_values
 
   defp do_handle_command(command, state) do
     rtf = Command.param!(command, :reports_to_follow)

--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -38,6 +38,10 @@ defmodule Grizzly.Commands.Table do
       {:configuration_properties_get,
        {Commands.ConfigurationPropertiesGet,
         handler: {WaitReport, complete_report: :configuration_properties_report}}},
+      {:configuration_name_get,
+       {Commands.ConfigurationNameGet,
+        handler:
+          {AggregateReport, complete_report: :configuration_name_report, aggregate_param: :name}}},
       # Manufacturer specific
       {:manufacturer_specific_get,
        {Commands.ManufacturerSpecificGet,

--- a/lib/grizzly/zwave/commands/configuration_name_get.ex
+++ b/lib/grizzly/zwave/commands/configuration_name_get.ex
@@ -1,0 +1,44 @@
+defmodule Grizzly.ZWave.Commands.ConfigurationNameGet do
+  @moduledoc """
+  This command is used to get the name of a configuration parameter.
+
+  Params:
+
+    * `:param_number` - the requested configuration parameter
+
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.{Command, DecodeError}
+  alias Grizzly.ZWave.CommandClasses.Configuration
+
+  @type param :: {:param_number, byte}
+
+  @impl Grizzly.ZWave.Command
+  @spec new([param()]) :: {:ok, Command.t()}
+  def new(params) do
+    command = %Command{
+      name: :configuration_name_get,
+      command_byte: 0x0A,
+      command_class: Configuration,
+      params: params,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl Grizzly.ZWave.Command
+  @spec encode_params(Command.t()) :: binary()
+  def encode_params(command) do
+    param_number = Command.param!(command, :param_number)
+    <<param_number::size(16)>>
+  end
+
+  @impl Grizzly.ZWave.Command
+  @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
+  def decode_params(<<param_number::size(16)>>) do
+    {:ok, [param_number: param_number]}
+  end
+end

--- a/lib/grizzly/zwave/commands/configuration_name_report.ex
+++ b/lib/grizzly/zwave/commands/configuration_name_report.ex
@@ -1,0 +1,50 @@
+defmodule Grizzly.ZWave.Commands.ConfigurationNameReport do
+  @moduledoc """
+   This command is used to advertise the name of a configuration parameter.
+
+  Params:
+
+    * `:param_number` -  This field is used to specify which configuration parameter (required)
+
+    * `:name` -  This field is used to specify the name of the configuration parameter (required)
+
+    * `reports_to_follow` - This field is used to specify the number of reports to follow (optional)
+
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.{Command, DecodeError}
+  alias Grizzly.ZWave.CommandClasses.Configuration
+
+  @type param :: {:param_number, byte} | {:name, binary} | {:reports_to_follow, byte}
+
+  @impl Grizzly.ZWave.Command
+  @spec new([param()]) :: {:ok, Command.t()}
+  def new(params) do
+    command = %Command{
+      name: :configuration_name_report,
+      command_byte: 0x0B,
+      command_class: Configuration,
+      params: params,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl Grizzly.ZWave.Command
+  @spec encode_params(Command.t()) :: binary()
+  def encode_params(command) do
+    param_number = Command.param!(command, :param_number)
+    name = Command.param!(command, :name)
+    reports_to_follow = Command.param(command, :reports_to_follow, 0)
+    <<param_number::size(16), reports_to_follow, name::binary>>
+  end
+
+  @impl Grizzly.ZWave.Command
+  @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
+  def decode_params(<<param_number::size(16), reports_to_follow, name::binary>>) do
+    {:ok, [param_number: param_number, reports_to_follow: reports_to_follow, name: name]}
+  end
+end

--- a/lib/grizzly/zwave/decoder.ex
+++ b/lib/grizzly/zwave/decoder.ex
@@ -171,6 +171,8 @@ defmodule Grizzly.ZWave.Decoder do
       {0x70, 0x07, Commands.ConfigurationBulkSet},
       {0x70, 0x08, Commands.ConfigurationBulkGet},
       {0x70, 0x09, Commands.ConfigurationBulkReport},
+      {0x70, 0x0A, Commands.ConfigurationNameGet},
+      {0x70, 0x0B, Commands.ConfigurationNameReport},
       {0x70, 0x0E, Commands.ConfigurationPropertiesGet},
       {0x70, 0x0F, Commands.ConfigurationPropertiesReport},
       # Alarm

--- a/test/grizzly/zwave/commands/configuration_name_get_test.exs
+++ b/test/grizzly/zwave/commands/configuration_name_get_test.exs
@@ -1,0 +1,23 @@
+defmodule Grizzly.ZWave.Commands.ConfigurationNameGetTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave.Commands.ConfigurationNameGet
+
+  test "creates the command and validates params" do
+    params = [param_number: 2]
+    {:ok, _command} = ConfigurationNameGet.new(params)
+  end
+
+  test "encodes params correctly" do
+    params = [param_number: 2]
+    {:ok, command} = ConfigurationNameGet.new(params)
+    expected_params_binary = <<0x02::size(16)>>
+    assert expected_params_binary == ConfigurationNameGet.encode_params(command)
+  end
+
+  test "decodes params correctly" do
+    params_binary = <<0x02::size(16)>>
+    {:ok, params} = ConfigurationNameGet.decode_params(params_binary)
+    assert Keyword.get(params, :param_number) == 2
+  end
+end

--- a/test/grizzly/zwave/commands/configuration_name_report_test.exs
+++ b/test/grizzly/zwave/commands/configuration_name_report_test.exs
@@ -1,0 +1,24 @@
+defmodule Grizzly.ZWave.Commands.ConfigurationNameReportTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave.Commands.ConfigurationNameReport
+
+  test "creates the command and validates params" do
+    params = [param_number: 2, name: "something"]
+    {:ok, _command} = ConfigurationNameReport.new(params)
+  end
+
+  test "encodes params correctly" do
+    params = [param_number: 2, name: "something"]
+    {:ok, command} = ConfigurationNameReport.new(params)
+    expected_params_binary = <<0x02::size(16), 0x00>> <> "something"
+    assert expected_params_binary == ConfigurationNameReport.encode_params(command)
+  end
+
+  test "decodes params correctly" do
+    params_binary = <<0x02::size(16), 0x00>> <> "something"
+    {:ok, params} = ConfigurationNameReport.decode_params(params_binary)
+    assert Keyword.get(params, :param_number) == 2
+    assert Keyword.get(params, :name) == "something"
+  end
+end


### PR DESCRIPTION
```
iex(19)> Grizzly.send_command(56, :configuration_name_get, [param_number: 15])
{:ok,
 %Grizzly.Report{
   status: :complete,
   command: %Grizzly.ZWave.Command{
     name: :configuration_name_report,
     command_byte: 11,
     command_class: Grizzly.ZWave.CommandClasses.Configuration,
     params: [
       name: "Reset To Factory Defaults",
       param_number: 15,
       reports_to_follow: 0
     ],
     impl: Grizzly.ZWave.Commands.ConfigurationNameReport
   },
   transmission_stats: [],
   queued_delay: 0,
   command_ref: #Reference<0.1319199483.2911895553.38824>,
   node_id: 56,
   type: :command,
   queued: false
 }}
```
