### PR TITLE
Improve InclusionServer crash recovery from non-idle status

### DIFF
--- a/lib/grizzly/inclusions/status_server.ex
+++ b/lib/grizzly/inclusions/status_server.ex
@@ -14,6 +14,8 @@ defmodule Grizzly.Inclusions.StatusServer do
 
   use GenServer
 
+  require Logger
+
   alias Grizzly.Inclusions
 
   def start_link(args) do
@@ -42,7 +44,8 @@ defmodule Grizzly.Inclusions.StatusServer do
   end
 
   @impl GenServer
-  def handle_call({:set, status}, _from, _old_status) do
+  def handle_call({:set, status}, _from, old_status) do
+    Logger.debug("[Grizzly.Inclusions.StatusServer] #{old_status} -> #{status}")
     {:reply, :ok, status}
   end
 

--- a/lib/grizzly/zwave/command_classes/network_management_inclusion.ex
+++ b/lib/grizzly/zwave/command_classes/network_management_inclusion.ex
@@ -129,6 +129,10 @@ defmodule Grizzly.ZWave.CommandClasses.NetworkManagementInclusion do
     |> parse_additional_node_info(more_info, command_class_length)
   end
 
+  defp parse_additional_node_info(node_info, additional_info, command_class_length)
+       when command_class_length <= 0 or byte_size(additional_info) == 0,
+       do: node_info
+
   defp parse_additional_node_info(node_info, additional_info, command_class_length) do
     <<command_classes_bin::binary-size(command_class_length), more_info::binary>> =
       additional_info


### PR DESCRIPTION
`Grizzly.InclusionServer` was failing to recover properly after a crash.

The expected behavior is that `InclusionServer` cancels any active add/remove/learn mode (as reported by `Grizzly.Inclusions.StatusServer`) when it starts. For some reason, the command to do this always seems to time out on the first attempt, but the `InclusionServer` was never retrying.

This introduces the following changes in behavior:

- `InclusionServer`'s init recovery will run even when `StatusServer` reports that inclusion mode is already being canceled
- If a command to cancel inclusion mode times out, it will be repeated

These changes provide the quickest recovery path. However, if the issue persists in other cases, it may make sense for `StatusServer` to implement its own internal timeout based on the inclusion timeouts defined in the Z-Wave spec.

---

### How to reproduce

```elixir
iex> Grizzly.InclusionServer.add_node(handler: self())
iex> Process.exit(GenServer.whereis(Grizzly.InclusionServer), :kill)
```