### PR TITLE
Handle illegal values from Z/IP Gateway in RSSI_REPORT

### DIFF
--- a/lib/grizzly/zwave/command_classes/network_management_installation_maintenance.ex
+++ b/lib/grizzly/zwave/command_classes/network_management_installation_maintenance.ex
@@ -89,7 +89,10 @@ defmodule Grizzly.ZWave.CommandClasses.NetworkManagementInstallationMaintenance 
   def rssi_from_byte(0x7D), do: {:ok, :rssi_below_sensitivity}
   def rssi_from_byte(0x7E), do: {:ok, :rssi_max_power_saturated}
   def rssi_from_byte(0x7F), do: {:ok, :rssi_not_available}
-  def rssi_from_byte(byte) when byte in 0xE0..0xA2, do: {:ok, byte - 256}
+  # 0 is reserved in the spec, but Z/IP Gateway sends it for the secondary long
+  # range channel when the primary long range channel is 0x7F / not available
+  def rssi_from_byte(0x00), do: {:ok, :rssi_not_available}
+  def rssi_from_byte(byte) when byte in 0xE0..0x80, do: {:ok, byte - 256}
   def rssi_from_byte(byte), do: {:error, %DecodeError{value: byte}}
 
   def repeaters_to_bytes(repeaters) do

--- a/test/grizzly/zwave/commands/rssi_report_test.exs
+++ b/test/grizzly/zwave/commands/rssi_report_test.exs
@@ -24,7 +24,7 @@ defmodule Grizzly.ZWave.Commands.RssiReportTest do
   test "ignore non-standard channel" do
     params_binary = <<0x7E, 0xA2, 0x9E>>
     {:ok, params} = RssiReport.decode_params(params_binary)
-    assert [:rssi_max_power_saturated, -94] == Keyword.get(params, :channels)
+    assert [:rssi_max_power_saturated, -94, -98] == Keyword.get(params, :channels)
   end
 
   test "encode version 4 - long range channels" do
@@ -59,5 +59,18 @@ defmodule Grizzly.ZWave.Commands.RssiReportTest do
     for {param, value} <- expected_params do
       assert params[param] == value
     end
+  end
+
+  test "handles z/ip gateway erroneously sending an illegal value for LR secondary" do
+    expected_params = [
+      channels: [-99, -102, -102],
+      long_range_primary_channel: :rssi_not_available,
+      long_range_secondary_channel: :rssi_not_available
+    ]
+
+    binary = <<0x9D, 0x9A, 0x9A, 0x7F, 0x00>>
+    {:ok, params} = RssiReport.decode_params(binary)
+
+    assert expected_params == params
   end
 end


### PR DESCRIPTION
This also fixes a bug wherein the Z-Wave spec says that valid RSSI values will be in the range `0xE0..0x80` (signed), but we were allowing only a subset `0xE0..0xA2`.

Fixes #702
