### PR TITLE
Fix typespec for `ThermostatSetpointReport` params

### DIFF
--- a/lib/grizzly/zwave/command_classes/thermostat_setpoint.ex
+++ b/lib/grizzly/zwave/command_classes/thermostat_setpoint.ex
@@ -24,6 +24,12 @@ defmodule Grizzly.ZWave.CommandClasses.ThermostatSetpoint do
 
   @type scale :: :c | :f
 
+  @typedoc "Shared parameters for ThermostatSetpointSet and ThermostatSetpointReport."
+  @type param ::
+          {:type, type()}
+          | {:scale, scale()}
+          | {:value, float()}
+
   @behaviour Grizzly.ZWave.CommandClass
 
   alias Grizzly.ZWave.DecodeError

--- a/lib/grizzly/zwave/command_classes/thermostat_setpoint.ex
+++ b/lib/grizzly/zwave/command_classes/thermostat_setpoint.ex
@@ -28,7 +28,7 @@ defmodule Grizzly.ZWave.CommandClasses.ThermostatSetpoint do
   @type param ::
           {:type, type()}
           | {:scale, scale()}
-          | {:value, float()}
+          | {:value, number()}
 
   @behaviour Grizzly.ZWave.CommandClass
 

--- a/lib/grizzly/zwave/commands/thermostat_setpoint_report.ex
+++ b/lib/grizzly/zwave/commands/thermostat_setpoint_report.ex
@@ -19,10 +19,8 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointReport do
   alias Grizzly.ZWave.{Command, DecodeError}
   alias Grizzly.ZWave.CommandClasses.ThermostatSetpoint
 
-  @type param :: {:type, ThermostatSetpoint.type()} | {:scale, ThermostatSetpoint.scale()}
-
-  @impl true
-  @spec new([param()]) :: {:ok, Command.t()}
+  @impl Command
+  @spec new([ThermostatSetpoint.param()]) :: {:ok, Command.t()}
   def new(params) do
     command = %Command{
       name: :thermostat_setpoint_report,
@@ -35,7 +33,7 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointReport do
     {:ok, command}
   end
 
-  @impl true
+  @impl Command
   def encode_params(command) do
     type = Command.param!(command, :type)
     scale_byte = Command.param!(command, :scale) |> ThermostatSetpoint.encode_scale()
@@ -59,7 +57,7 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointReport do
   defp encode_size(:na, _value), do: 1
   defp encode_size(_type, value), do: ceil(:math.log2(value) / 8)
 
-  @impl true
+  @impl Command
   def decode_params(
         <<_::size(4), type_byte::size(4), precision::size(3), scale_byte::size(2),
           byte_size::size(3), int_value::size(byte_size)-unit(8)>>

--- a/lib/grizzly/zwave/commands/thermostat_setpoint_set.ex
+++ b/lib/grizzly/zwave/commands/thermostat_setpoint_set.ex
@@ -18,13 +18,8 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSet do
   alias Grizzly.ZWave.{Command, DecodeError}
   alias Grizzly.ZWave.CommandClasses.ThermostatSetpoint
 
-  @type param ::
-          {:type, ThermostatSetpoint.type()}
-          | {:scale, ThermostatSetpoint.scale()}
-          | {:value, non_neg_integer()}
-
-  @impl true
-  @spec new([param()]) :: {:ok, Command.t()}
+  @impl Command
+  @spec new([ThermostatSetpoint.param()]) :: {:ok, Command.t()}
   def new(params) do
     command = %Command{
       name: :thermostat_setpoint_set,
@@ -37,7 +32,7 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSet do
     {:ok, command}
   end
 
-  @impl true
+  @impl Command
   def encode_params(command) do
     type_byte = Command.param!(command, :type) |> ThermostatSetpoint.encode_type()
 
@@ -52,7 +47,7 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSet do
       byte_size::size(3), int_value::size(byte_size)-unit(8)>>
   end
 
-  @impl true
+  @impl Command
   def decode_params(
         <<_::size(4), type_byte::size(4), precision::size(3), scale_byte::size(2),
           byte_size::size(3), int_value::size(byte_size)-unit(8)>>


### PR DESCRIPTION
`ThermostatSetpointReport.param()` was missing `{:value, integer()}`.