### PR TITLE
Inclusions tests should not be async

### DIFF
--- a/test/grizzly/inclusions_test.exs
+++ b/test/grizzly/inclusions_test.exs
@@ -1,5 +1,5 @@
 defmodule Grizzly.InclusionsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Grizzly.{Inclusions, Report}
   alias Grizzly.ZWave.Command


### PR DESCRIPTION
When inclusion is running, all commands will fail with `{:error, including}`.

This should fix some (if not all) of the flaky tests.
