### PR TITLE
Fix RSSI encoding

### DIFF
--- a/lib/grizzly/zwave/command_classes/network_management_installation_maintenance.ex
+++ b/lib/grizzly/zwave/command_classes/network_management_installation_maintenance.ex
@@ -26,7 +26,7 @@ defmodule Grizzly.ZWave.CommandClasses.NetworkManagementInstallationMaintenance 
           | {:repeater?, boolean}
           | {:speed, speeds}
   @type rssi ::
-          :rssi_not_available | :rssi_max_power_saturated | :rssi_below_sensitivity | -94..-32
+          :rssi_not_available | :rssi_max_power_saturated | :rssi_below_sensitivity | -128..-32
 
   alias Grizzly.ZWave.DecodeError
   @behaviour Grizzly.ZWave.CommandClass
@@ -83,7 +83,7 @@ defmodule Grizzly.ZWave.CommandClasses.NetworkManagementInstallationMaintenance 
   def rssi_to_byte(:rssi_below_sensitivity), do: 0x7D
   def rssi_to_byte(:rssi_max_power_saturated), do: 0x7E
   def rssi_to_byte(:rssi_not_available), do: 0x7F
-  def rssi_to_byte(value) when value in -94..-32, do: 256 + value
+  def rssi_to_byte(value) when value in -128..-32, do: 256 + value
 
   @spec rssi_from_byte(byte) :: {:ok, rssi} | {:error, DecodeError.t()}
   def rssi_from_byte(0x7D), do: {:ok, :rssi_below_sensitivity}


### PR DESCRIPTION
In #705, we fixed the decoding of the full range of expected RSSI
values, but we missed re-encoding. This is normally not a problem
because Grizzly typically only decodes RSSI_REPORTs, but this will cause
calls to `Grizzly.Trace.dump/1` raise an error if an RSSI_REPORT with an
out-of-range value exists in the trace buffer.
