### PR TITLE
Handle errors raised when writing trace dumps

### DIFF
--- a/lib/grizzly/trace/record.ex
+++ b/lib/grizzly/trace/record.ex
@@ -3,6 +3,8 @@ defmodule Grizzly.Trace.Record do
   Data structure for a single item in the trace log
   """
 
+  require Logger
+
   alias Grizzly.{Trace, ZWave}
   alias Grizzly.ZWave.Command
 
@@ -46,7 +48,7 @@ defmodule Grizzly.Trace.Record do
     %__MODULE__{timestamp: ts, src: src, dest: dest, binary: binary} = record
     {:ok, zip_packet} = ZWave.from_binary(binary)
 
-    "#{Time.to_string(ts)} #{src_dest_to_string(src)} #{src_dest_to_string(dest)} #{command_info_str(zip_packet)}"
+    "#{Time.to_string(ts)} #{src_dest_to_string(src)} #{src_dest_to_string(dest)} #{command_info_str(zip_packet, binary)}"
   end
 
   defp src_dest_to_string(nil) do
@@ -55,11 +57,11 @@ defmodule Grizzly.Trace.Record do
 
   defp src_dest_to_string(src_or_dest), do: src_or_dest
 
-  defp command_info_str(%Command{name: :keep_alive}) do
+  defp command_info_str(%Command{name: :keep_alive}, _binary) do
     "    keep_alive"
   end
 
-  defp command_info_str(zip_packet) do
+  defp command_info_str(zip_packet, binary) do
     seq_number = Command.param!(zip_packet, :seq_number)
     flag = Command.param!(zip_packet, :flag)
 
@@ -68,7 +70,7 @@ defmodule Grizzly.Trace.Record do
         command_info_empty_response(seq_number, flag)
 
       _ ->
-        command_info_with_encapsulated_command(seq_number, zip_packet)
+        command_info_with_encapsulated_command(seq_number, zip_packet, binary)
     end
   end
 
@@ -76,10 +78,29 @@ defmodule Grizzly.Trace.Record do
     "#{seq_number_to_str(seq_number)} #{flag}"
   end
 
-  defp command_info_with_encapsulated_command(seq_number, zip_packet) do
+  defp command_info_with_encapsulated_command(seq_number, zip_packet, binary) do
     command = Command.param!(zip_packet, :command)
 
     "#{seq_number_to_str(seq_number)} #{command.name} #{inspect(Command.encode_params(command))}"
+  rescue
+    err ->
+      Logger.error("""
+      [Grizzly.Trace] Expected an encapsulated command, but no command param was found.
+
+      This is probably a bug -- please report it along with the stack trace and, if
+      possible, the corresponding line in the trace file.
+
+      #{Exception.format(:error, err, __STACKTRACE__)}
+      """)
+
+      command_name =
+        try do
+          zip_packet.name
+        rescue
+          _ -> "UNKNOWN COMMAND"
+        end
+
+      "#{seq_number_to_str(seq_number)} ENCODING ERROR #{command_name} #{inspect(binary)}"
   end
 
   defp seq_number_to_str(seq_number) do


### PR DESCRIPTION
There is a bug in writing trace dumps when a command in the trace buffer
is not a Z/IP Packet encapsulated command. It's unclear what command(s)
are involved as the issue seems somewhat rare.

Until we can pin down the issue, this should prevent trace dumps from
crashing under the described circumstances and provide debugging
information for a future fix.
