### PR TITLE
Add support for sending supervised commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,18 +72,6 @@ jobs:
       - run: mix compile
       - run: mix test
 
-  build_elixir_1_11_otp_23:
-    docker:
-      - image: hexpm/elixir:1.11.3-erlang-23.2.2-alpine-3.12.1
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
-      - run: mix deps.get
-      - run: mix compile
-      - run: mix test
-
 workflows:
   version: 2
   build_test:
@@ -91,4 +79,3 @@ workflows:
       - build_elixir_1_14_otp_25
       - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
-      - build_elixir_1_11_otp_23

--- a/lib/grizzly/command_handlers/supervision_report.ex
+++ b/lib/grizzly/command_handlers/supervision_report.ex
@@ -1,0 +1,62 @@
+defmodule Grizzly.CommandHandlers.SupervisionReport do
+  @moduledoc """
+  This handler is used for non-get commands sent with Supervision.
+  """
+  @behaviour Grizzly.CommandHandler
+
+  alias Grizzly.Report
+  alias Grizzly.ZWave.Command
+
+  @impl Grizzly.CommandHandler
+  def init(opts) do
+    state =
+      opts
+      |> Enum.into(%{})
+      |> Map.take([:command_ref, :node_id, :session_id, :waiter, :status_updates?])
+
+    {:ok, state}
+  end
+
+  @impl Grizzly.CommandHandler
+  def handle_ack(state), do: {:continue, state}
+
+  @impl Grizzly.CommandHandler
+  def handle_command(%Command{name: :supervision_report} = command, state) do
+    session_id = Command.param!(command, :session_id)
+    status = Command.param!(command, :status)
+    more_status_updates = Command.param!(command, :more_status_updates)
+
+    cond do
+      # ignore this report if the session ids do not match
+      session_id != state.session_id ->
+        {:continue, state}
+
+      # some devices erroneously set the more_status_updates field to true,
+      # so we'll consider success, fail, and no_support to be the final report
+      # even if more_status_updates is true
+      status in [:success, :fail, :no_support] or more_status_updates == :last_report ->
+        {:complete, command}
+
+      # more reports are coming
+      true ->
+        maybe_notify_waiter(command, state)
+        {:continue, state}
+    end
+  end
+
+  def handle_command(_command, state), do: {:continue, state}
+
+  defp maybe_notify_waiter(command, %{waiter: {waiter_pid, _}, status_updates?: true} = state)
+       when is_pid(waiter_pid) do
+    send(
+      waiter_pid,
+      {:grizzly, :report,
+       Report.new(:inflight, :supervision_status, state.node_id,
+         command: command,
+         command_ref: state.command_ref
+       )}
+    )
+  end
+
+  defp maybe_notify_waiter(_, _), do: :ok
+end

--- a/lib/grizzly/connections/command_list.ex
+++ b/lib/grizzly/connections/command_list.ex
@@ -180,6 +180,7 @@ defmodule Grizzly.Connections.CommandList do
     # only create a new reference if we are going to need it
     command_ref = Keyword.get_lazy(command_opts, :reference, fn -> make_ref() end)
     command_opts = Keyword.put_new(command_opts, :reference, command_ref)
+    command_opts = Keyword.put_new(command_opts, :waiter, waiter)
 
     case Commands.create_command(command, node_id, command_opts) do
       {:ok, command_runner} ->

--- a/lib/grizzly/connections/sync_connection.ex
+++ b/lib/grizzly/connections/sync_connection.ex
@@ -212,9 +212,9 @@ defmodule Grizzly.Connections.SyncConnection do
     %State{updated_state | keep_alive: KeepAlive.timer_restart(state.keep_alive)}
   end
 
-  defp do_send_command(command_runner, state, opts \\ []) do
+  defp do_send_command(command, state, opts \\ []) do
     %State{transport: transport} = state
-    binary = CommandRunner.encode_command(command_runner)
+    binary = CommandRunner.encode_command(command)
 
     Transport.send(transport, binary, opts)
   end

--- a/lib/grizzly/report.ex
+++ b/lib/grizzly/report.ex
@@ -159,6 +159,7 @@ defmodule Grizzly.Report do
           | :unsolicited
           | :queued_delay
           | :timeout
+          | :supervision_status
 
   @type status() :: :inflight | :complete
 

--- a/lib/grizzly/session_id.ex
+++ b/lib/grizzly/session_id.ex
@@ -1,0 +1,40 @@
+defmodule Grizzly.SessionId do
+  @moduledoc false
+
+  use GenServer
+
+  @type option :: {:seed, :rand.seed()}
+
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Returns a supervision session id for the given node.
+  """
+  @spec get_and_inc(GenServer.name(), Grizzly.node_id()) :: 0..31
+  def get_and_inc(name \\ __MODULE__, node_id) do
+    GenServer.call(name, {:get_and_inc, node_id})
+  end
+
+  @impl GenServer
+  def init(opts) do
+    _ =
+      if seed = Keyword.get(opts, :seed) do
+        :rand.seed(:default, seed)
+      end
+
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_call({:get_and_inc, node_id}, _from, state) do
+    number = Map.get_lazy(state, node_id, fn -> Enum.random(0..31) end)
+    next_state = Map.put(state, node_id, inc(number))
+    {:reply, number, next_state}
+  end
+
+  defp inc(31), do: 0
+  defp inc(n), do: n + 1
+end

--- a/lib/grizzly/supervisor.ex
+++ b/lib/grizzly/supervisor.ex
@@ -212,6 +212,7 @@ defmodule Grizzly.Supervisor do
       # sequence number counter that starts at a random number between
       # 0 and 0xFF (255)
       {Grizzly.SeqNumber, Enum.random(0..255)},
+      Grizzly.SessionId,
       Grizzly.Trace,
       {Registry, [keys: :duplicate, name: Grizzly.Events.Registry]},
       {Registry, [keys: :unique, name: Grizzly.ConnectionRegistry]},

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Grizzly.MixProject do
     [
       app: :grizzly,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/grizzly/command_handlers/supervision_report_test.exs
+++ b/test/grizzly/command_handlers/supervision_report_test.exs
@@ -1,0 +1,118 @@
+defmodule Grizzly.CommandHandlers.SupervisionReportTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.CommandHandlers.SupervisionReport, as: Handler
+  alias Grizzly.ZWave.Commands.SupervisionReport
+
+  setup do
+    ref = make_ref()
+
+    {:ok, state} =
+      Handler.init(
+        session_id: 1,
+        waiter: {self(), nil},
+        command_ref: ref,
+        node_id: 1,
+        status_updates?: false
+      )
+
+    %{state: state, command_ref: ref}
+  end
+
+  test "continues when receiving an ack", %{state: state} do
+    assert {:continue, ^state} = Handler.handle_ack(state)
+  end
+
+  test "continues when session id does not match", %{state: state} do
+    {:ok, command} =
+      SupervisionReport.new(
+        more_status_updates: :last_report,
+        status: :success,
+        duration: :unknown,
+        session_id: 10
+      )
+
+    assert {:continue, ^state} = Handler.handle_command(command, state)
+  end
+
+  test "continues when more_status_updates equals :more_reports", %{state: state} do
+    {:ok, command} =
+      SupervisionReport.new(
+        more_status_updates: :more_reports,
+        status: :working,
+        duration: :unknown,
+        session_id: 1
+      )
+
+    assert {:continue, ^state} = Handler.handle_command(command, state)
+  end
+
+  test "completes when more_status_updates equals :last_report", %{state: state} do
+    {:ok, command} =
+      SupervisionReport.new(
+        more_status_updates: :last_report,
+        status: :working,
+        duration: :unknown,
+        session_id: 1
+      )
+
+    assert {:complete, ^command} = Handler.handle_command(command, state)
+  end
+
+  test "sends non-final reports to command owner", %{state: state, command_ref: command_ref} do
+    state = %{state | status_updates?: true}
+
+    {:ok, update1} =
+      SupervisionReport.new(
+        more_status_updates: :more_reports,
+        status: :working,
+        duration: :unknown,
+        session_id: 1
+      )
+
+    assert {:continue, ^state} = Handler.handle_command(update1, state)
+
+    {:ok, update2} =
+      SupervisionReport.new(
+        more_status_updates: :more_reports,
+        status: :working,
+        duration: :unknown,
+        session_id: 1
+      )
+
+    assert {:continue, ^state} = Handler.handle_command(update2, state)
+
+    {:ok, final} =
+      SupervisionReport.new(
+        more_status_updates: :last_report,
+        status: :working,
+        duration: :unknown,
+        session_id: 1
+      )
+
+    assert {:complete, ^final} = Handler.handle_command(final, state)
+
+    assert_receive {:grizzly, :report,
+                    %Grizzly.Report{
+                      command: ^update1,
+                      command_ref: ^command_ref,
+                      queued: false,
+                      status: :inflight,
+                      type: :supervision_status,
+                      node_id: 1
+                    }}
+
+    assert_receive {:grizzly, :report,
+                    %Grizzly.Report{
+                      command: ^update2,
+                      command_ref: ^command_ref,
+                      queued: false,
+                      status: :inflight,
+                      type: :supervision_status,
+                      node_id: 1
+                    }}
+
+    # shouldn't be any other messages
+    refute_receive _
+  end
+end

--- a/test/grizzly/commands/command_test.exs
+++ b/test/grizzly/commands/command_test.exs
@@ -29,7 +29,8 @@ defmodule Grizzly.Commands.CommandTest do
       retries: 2,
       seq_number: grizzly_command.seq_number,
       ref: grizzly_command.ref,
-      node_id: 1
+      node_id: 1,
+      supervision?: false
     }
 
     assert expected_grizzly_command == grizzly_command

--- a/test/grizzly/session_id_test.exs
+++ b/test/grizzly/session_id_test.exs
@@ -1,0 +1,24 @@
+defmodule Grizzly.SessionIdTest do
+  use ExUnit.Case, async: true
+
+  setup do
+    pid = start_supervised!({Grizzly.SessionId, seed: 12345, name: __MODULE__})
+    %{pid: pid}
+  end
+
+  test "increments session ids per-node", %{pid: pid} do
+    assert 13 == Grizzly.SessionId.get_and_inc(pid, 2)
+    assert 14 == Grizzly.SessionId.get_and_inc(pid, 2)
+    assert 15 == Grizzly.SessionId.get_and_inc(pid, 2)
+    assert 22 == Grizzly.SessionId.get_and_inc(pid, 3)
+    assert 23 == Grizzly.SessionId.get_and_inc(pid, 3)
+    assert 25 == Grizzly.SessionId.get_and_inc(pid, 5)
+    assert 26 == Grizzly.SessionId.get_and_inc(pid, 5)
+    assert 27 == Grizzly.SessionId.get_and_inc(pid, 5)
+    assert 28 == Grizzly.SessionId.get_and_inc(pid, 5)
+    assert 29 == Grizzly.SessionId.get_and_inc(pid, 5)
+    assert 30 == Grizzly.SessionId.get_and_inc(pid, 5)
+    assert 31 == Grizzly.SessionId.get_and_inc(pid, 5)
+    assert 0 == Grizzly.SessionId.get_and_inc(pid, 5)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,5 +8,7 @@ config =
     _ -> [formatters: [ExUnit.CLIFormatter, JUnitFormatter]]
   end
 
+Logger.configure(level: :debug)
+
 ExUnit.configure(Keyword.merge(config, capture_log: true))
 ExUnit.start()


### PR DESCRIPTION
## Examples

### Supervision support for a command
```elixir
iex(5)> Grizzly.can_supervise_command?(:door_lock_operation_get)
false
iex(6)> Grizzly.can_supervise_command?(:door_lock_operation_set)
true
```

### Supervised command

```elixir
iex(2)> Grizzly.send_command(46, :user_code_set, [user_id: 5, user_code: "123456", user_id_status: :occupied], supervision?: true)
{:ok,
 %Grizzly.Report{
   status: :complete,
   command: %Grizzly.ZWave.Command{
     name: :supervision_report,
     command_byte: 2,
     command_class: Grizzly.ZWave.CommandClasses.Supervision,
     params: [
       more_status_updates: :last_report,
       session_id: 31,
       status: :success,
       duration: 0
     ],
     impl: Grizzly.ZWave.Commands.SupervisionReport
   },
   transmission_stats: [],
   queued_delay: 0,
   command_ref: #Reference<0.1484145361.3358588929.238507>,
   node_id: 46,
   type: :command,
   queued: false
 }}
```

### Supervised command with opt-in status updates

```elixir
iex(3)> Grizzly.send_command(46, :door_lock_operation_set, [mode: :secured], supervision?: true, status_updates?: true)
{:ok,
 %Grizzly.Report{
   status: :complete,
   command: %Grizzly.ZWave.Command{
     name: :supervision_report,
     command_byte: 2,
     command_class: Grizzly.ZWave.CommandClasses.Supervision,
     params: [
       more_status_updates: :last_report,
       session_id: 10,
       status: :success,
       duration: 0
     ],
     impl: Grizzly.ZWave.Commands.SupervisionReport
   },
   transmission_stats: [],
   queued_delay: 0,
   command_ref: #Reference<0.1752128792.3357802497.26772>,
   node_id: 46,
   type: :command,
   queued: false
 }}

iex(4)> flush
{:grizzly, :report,
 %Grizzly.Report{
   status: :inflight,
   command: %Grizzly.ZWave.Command{
     name: :supervision_report,
     command_byte: 2,
     command_class: Grizzly.ZWave.CommandClasses.Supervision,
     params: [
       more_status_updates: :more_reports,
       session_id: 10,
       status: :working,
       duration: 3
     ],
     impl: Grizzly.ZWave.Commands.SupervisionReport
   },
   transmission_stats: [],
   queued_delay: 0,
   command_ref: #Reference<0.1752128792.3357802497.26772>,
   node_id: 46,
   type: :supervision_status,
   queued: false
 }}
:ok
```