### PR TITLE
Validate command names in `Grizzly.Commands.Table`

### DIFF
--- a/lib/grizzly/virtual_devices.ex
+++ b/lib/grizzly/virtual_devices.ex
@@ -115,7 +115,7 @@ defmodule Grizzly.VirtualDevices do
   """
   @spec send_command(id(), Command.t()) ::
           {:ok, Grizzly.Report.t()} | {:error, :device_not_found | Grizzly.Report.t()}
-  def send_command(device_id, %Command{name: :node_info_cache_get} = node_info_get) do
+  def send_command(device_id, %Command{name: :node_info_cached_get} = node_info_get) do
     with_entry(device_id, &Reports.build_node_info_cache_report(&1, node_info_get))
   end
 

--- a/lib/grizzly/zwave/commands/node_info_cached_get.ex
+++ b/lib/grizzly/zwave/commands/node_info_cached_get.ex
@@ -57,7 +57,7 @@ defmodule Grizzly.ZWave.Commands.NodeInfoCachedGet do
     params = set_defaults(params)
     # TODO: validate params
     command = %Command{
-      name: :node_info_cache_get,
+      name: :node_info_cached_get,
       command_byte: 0x03,
       command_class: NetworkManagementProxy,
       params: params,
@@ -109,7 +109,7 @@ defmodule Grizzly.ZWave.Commands.NodeInfoCachedGet do
   def decode_max_age(n) when n > 0 and n < 15, do: {:ok, n}
 
   def decode_max_age(n),
-    do: {:error, %DecodeError{value: n, param: :max_age, command: :node_info_cache_get}}
+    do: {:error, %DecodeError{value: n, param: :max_age, command: :node_info_cached_get}}
 
   defp set_defaults(params) do
     Keyword.put_new(params, :max_age, 10)

--- a/test/grizzly/zwave/commands/node_info_cached_get_test.exs
+++ b/test/grizzly/zwave/commands/node_info_cached_get_test.exs
@@ -12,7 +12,7 @@ defmodule Grizzly.ZWave.Commands.NodeInfoCachedGetTest do
   test "ensure correct name" do
     {:ok, cmd} = NodeInfoCachedGet.new()
 
-    assert cmd.name == :node_info_cache_get
+    assert cmd.name == :node_info_cached_get
   end
 
   describe "encoding" do


### PR DESCRIPTION
Several commands had names that did not match the command name in the
command returned from the implementation's `new/1` function. Several
other commands were pointing to the wrong implementation module and
never would have worked properly.

This adds simple validation to `Grizzly.Commands.Table` to ensure that
(outside of a few exceptions) the command name in the table matches the
command name in the implementation module.
