### PR TITLE
Don't assume :signed_integer configuration format

### DIFF
--- a/lib/grizzly/zwave/commands/configuration_set.ex
+++ b/lib/grizzly/zwave/commands/configuration_set.ex
@@ -4,11 +4,12 @@ defmodule Grizzly.ZWave.Commands.ConfigurationSet do
 
   Params:
 
-    * `:size` - specifies the size of the configuration parameter
-      (required if not resetting to default)
-    * `:value` - the value of the parameter, can be set to `:default` to set
-      the parameter back to the factory default value (required)
     * `:param_number` - the configuration parameter number to set (required)
+    * `:value` - the value of the parameter, can be set to `:default` to set
+                 the parameter back to the factory default value (required)
+    * `:size` - specifies the size of the configuration parameter
+               (required if not resetting to default)
+    * `:format - one of :signed_integer, :unsigned_integer, :enumerated or :bit_field (defaults to :signed_integer)
 
 
   ## Size
@@ -21,6 +22,17 @@ defmodule Grizzly.ZWave.Commands.ConfigurationSet do
 
   If you want to factory reset a configuration parameter you can pass
   `:default` as the `:value` param
+
+  ## Format
+
+  The configuration value MUST be encoded according to the Format field advertised in the Configuration
+  Properties Report Command for the parameter number.
+
+  If the parameter format is “Unsigned integer”, normal binary integer encoding MUST be used.
+  If the parameter format is “Signed integer”, the binary encoding MUST use the two's complement representation.
+  If the parameter format is “Enumerated”, the parameter MUST be treated as an unsigned integer. A graphical configuration tool SHOULD present this parameter as a series of radio buttons.
+  If the parameter format is “Bit field” the parameter MUST be treated as a bit field where each individual
+  bit can be set or reset. A graphical configuration tool SHOULD present this parameter as a series of checkboxes.
   """
 
   @behaviour Grizzly.ZWave.Command
@@ -29,7 +41,10 @@ defmodule Grizzly.ZWave.Commands.ConfigurationSet do
   alias Grizzly.ZWave.CommandClasses.Configuration
 
   @type param ::
-          {:size, 1 | 2 | 4} | {:value, integer() | :default} | {:param_number, byte()}
+          {:size, 1 | 2 | 4}
+          | {:format, :signed_integer | :unsigned_integer | :enumerated | :bit_field}
+          | {:value, integer() | :default}
+          | {:param_number, byte()}
 
   @impl true
   @spec new([param()]) :: {:ok, Command.t()}
@@ -79,17 +94,34 @@ defmodule Grizzly.ZWave.Commands.ConfigurationSet do
   defp encode_value_set(command) do
     param_num = Command.param!(command, :param_number)
     size = Command.param!(command, :size)
+    format = Command.param(command, :format, :signed_integer)
     value = Command.param!(command, :value)
-    validate!(value, size)
+    validate!(value, size, format)
     value_bin = <<value::signed-integer-size(size)-unit(8)>>
 
     <<param_num, size>> <> value_bin
   end
 
-  defp validate!(value, 1) when value in -128..127, do: :ok
-  defp validate!(value, 2) when value in -32768..32767, do: :ok
-  defp validate!(value, 4) when value in -2_147_483_648..2_147_483_647, do: :ok
+  defp validate!(value, 1, :signed_integer) when value in -128..127, do: :ok
+  defp validate!(value, 2, :signed_integer) when value in -32768..32767, do: :ok
+  defp validate!(value, 4, :signed_integer) when value in -2_147_483_648..2_147_483_647, do: :ok
 
-  defp validate!(value, byte),
-    do: raise(ArgumentError, message: "Invalid parameter. #{value} will not fit in #{byte} bytes")
+  defp validate!(value, 1, format)
+       when format in [:unsigned_integer, :enumerated, :bit_field] and value in 0..255,
+       do: :ok
+
+  defp validate!(value, 2, format)
+       when format in [:unsigned_integer, :enumerated, :bit_field] and value in 0..65535,
+       do: :ok
+
+  defp validate!(value, 4, format)
+       when format in [:unsigned_integer, :enumerated, :bit_field] and value in 0..4_294_967_295,
+       do: :ok
+
+  defp validate!(value, byte, format),
+    do:
+      raise(ArgumentError,
+        message:
+          "Invalid parameter. #{value} with format #{inspect(format)} will not fit in #{byte} bytes"
+      )
 end

--- a/test/grizzly/zwave/commands/configuration_set_test.exs
+++ b/test/grizzly/zwave/commands/configuration_set_test.exs
@@ -14,59 +14,147 @@ defmodule Grizzly.ZWave.Commands.ConfigurationSetTest do
     end
   end
 
-  describe "encodes params correctly" do
+  describe "encodes params correctly with format signed_integer" do
     test "when default is set" do
       {:ok, configuration_set} = ConfigurationSet.new(value: :default, param_number: 15)
 
       assert <<0x0F, 0x81, 0x00>> == ConfigurationSet.encode_params(configuration_set)
     end
 
-    test "when a 1 byte neg value is set" do
+    test "when a 1 byte neg value is set - default signed_integer format" do
       {:ok, configuration_set} = ConfigurationSet.new(value: -126, param_number: 15, size: 1)
       assert <<0x0F, 0x01, 0x82>> == ConfigurationSet.encode_params(configuration_set)
     end
 
+    test "when a 1 byte neg value is set" do
+      {:ok, configuration_set} =
+        ConfigurationSet.new(value: -126, param_number: 15, size: 1, format: :signed_integer)
+
+      assert <<0x0F, 0x01, 0x82>> == ConfigurationSet.encode_params(configuration_set)
+    end
+
     test "when a 1 byte pos value is set" do
-      {:ok, configuration_set} = ConfigurationSet.new(value: 115, param_number: 15, size: 1)
+      {:ok, configuration_set} =
+        ConfigurationSet.new(value: 115, param_number: 15, size: 1, format: :signed_integer)
+
       assert <<0x0F, 0x01, 0x73>> == ConfigurationSet.encode_params(configuration_set)
     end
 
     test "when a 2 byte neg value is set" do
-      {:ok, command} = ConfigurationSet.new(value: -14313, param_number: 15, size: 2)
+      {:ok, command} =
+        ConfigurationSet.new(value: -14313, param_number: 15, size: 2, format: :signed_integer)
+
       assert <<0x0F, 0x02, 0xC8, 0x17>> == ConfigurationSet.encode_params(command)
     end
 
     test "when a 2 byte pos value is set" do
-      {:ok, command} = ConfigurationSet.new(value: 29463, param_number: 15, size: 2)
+      {:ok, command} =
+        ConfigurationSet.new(value: 29463, param_number: 15, size: 2, format: :signed_integer)
+
       assert <<0x0F, 0x02, 0x73, 0x17>> == ConfigurationSet.encode_params(command)
     end
 
     test "when a 4 byte neg value is set" do
-      {:ok, command} = ConfigurationSet.new(value: -3_664_127, param_number: 15, size: 4)
+      {:ok, command} =
+        ConfigurationSet.new(
+          value: -3_664_127,
+          param_number: 15,
+          size: 4,
+          format: :signed_integer
+        )
+
       assert <<0x0F, 0x04, 0xFF, 0xC8, 0x17, 0x01>> == ConfigurationSet.encode_params(command)
     end
 
     test "when a 4 byte pos value is set" do
-      {:ok, command} = ConfigurationSet.new(value: 7_542_529, param_number: 15, size: 4)
+      {:ok, command} =
+        ConfigurationSet.new(value: 7_542_529, param_number: 15, size: 4, format: :signed_integer)
+
       assert <<0x0F, 0x04, 0x00, 0x73, 0x17, 0x01>> == ConfigurationSet.encode_params(command)
     end
 
     test "when an illegal 3 byte value is set" do
-      {:ok, command} = ConfigurationSet.new(value: 7_542_529, param_number: 15, size: 3)
+      {:ok, command} =
+        ConfigurationSet.new(value: 7_542_529, param_number: 15, size: 3, format: :signed_integer)
 
       assert %ArgumentError{
                __exception__: true,
-               message: "Invalid parameter. 7542529 will not fit in 3 bytes"
+               message:
+                 "Invalid parameter. 7542529 with format :signed_integer will not fit in 3 bytes"
              } ==
                catch_error(ConfigurationSet.encode_params(command))
     end
 
     test "when an out-of-range byte value is set" do
-      {:ok, command} = ConfigurationSet.new(value: 128, param_number: 15, size: 1)
+      {:ok, command} =
+        ConfigurationSet.new(value: 128, param_number: 15, size: 1, format: :signed_integer)
 
       assert %ArgumentError{
                __exception__: true,
-               message: "Invalid parameter. 128 will not fit in 1 bytes"
+               message:
+                 "Invalid parameter. 128 with format :signed_integer will not fit in 1 bytes"
+             } ==
+               catch_error(ConfigurationSet.encode_params(command))
+    end
+  end
+
+  describe "encodes params correctly with format unsigned_integer" do
+    test "when a 1 byte neg value is set - default signed_integer format" do
+      {:ok, configuration_set} = ConfigurationSet.new(value: -126, param_number: 15, size: 1)
+      assert <<0x0F, 0x01, 0x82>> == ConfigurationSet.encode_params(configuration_set)
+    end
+
+    test "when a 1 byte neg value is set" do
+      {:ok, configuration_set} =
+        ConfigurationSet.new(value: 128, param_number: 15, size: 1, format: :unsigned_integer)
+
+      assert <<0x0F, 0x01, 0x80>> == ConfigurationSet.encode_params(configuration_set)
+    end
+
+    test "when a 2 byte pos value is set" do
+      {:ok, command} =
+        ConfigurationSet.new(value: 60000, param_number: 15, size: 2, format: :unsigned_integer)
+
+      assert <<0x0F, 0x02, 0xEA, 0x60>> == ConfigurationSet.encode_params(command)
+    end
+
+    test "when a 4 byte neg value is set" do
+      {:ok, command} =
+        ConfigurationSet.new(
+          value: 4_294_967_295,
+          param_number: 15,
+          size: 4,
+          format: :unsigned_integer
+        )
+
+      assert <<0x0F, 0x04, 0xFF, 0xFF, 0xFF, 0xFF>> == ConfigurationSet.encode_params(command)
+    end
+
+    test "when an illegal 3 byte value is set" do
+      {:ok, command} =
+        ConfigurationSet.new(
+          value: 4_294_967_296,
+          param_number: 15,
+          size: 3,
+          format: :unsigned_integer
+        )
+
+      assert %ArgumentError{
+               __exception__: true,
+               message:
+                 "Invalid parameter. 4294967296 with format :unsigned_integer will not fit in 3 bytes"
+             } ==
+               catch_error(ConfigurationSet.encode_params(command))
+    end
+
+    test "when an out-of-range byte value is set" do
+      {:ok, command} =
+        ConfigurationSet.new(value: 256, param_number: 15, size: 1, format: :unsigned_integer)
+
+      assert %ArgumentError{
+               __exception__: true,
+               message:
+                 "Invalid parameter. 256 with format :unsigned_integer will not fit in 1 bytes"
              } ==
                catch_error(ConfigurationSet.encode_params(command))
     end


### PR DESCRIPTION
and support the :signed_integer, :enumerated and :bit_field formats

SRH-696