### PR TITLE
Reset tun/tap interface by marking it down

### DIFF
--- a/priv/zipgateway.tun
+++ b/priv/zipgateway.tun
@@ -9,6 +9,7 @@ ROUTING_PID="/tmp/zipgateway.routing.pid"
 
 case "$1" in
   up)
+    ip link set dev $TUNDEV down
     ip link set dev $TUNDEV up
     ip addr add fd00:aaaa::2 dev $TUNDEV
 
@@ -42,5 +43,6 @@ case "$1" in
     ;;
   down)
     ip -6 route del $HANPREFIX via $LANIP
+    ip link set dev $TUNDEV down
     ;;
 esac


### PR DESCRIPTION
Z/IP Gateway was failing to start up due to an issue with setting routes
on the tun/tap network interface. Setting the interface to down and
restarting the `zipgateway` process fixed this. In order to prevent this
from happening in the future, this updates the tunnel setup script to
bring the interface down first and then bring it up. Doing so should
clean up state in the Linux kernel and hopefully make setting up the
tun network more reliable. In theory, it also brings the network down if
requested to also remove routing table state.
