### PR TITLE
Normalize a Leviton dimmers incorrect value report

### DIFF
--- a/lib/grizzly/zwave/commands/switch_multilevel_report.ex
+++ b/lib/grizzly/zwave/commands/switch_multilevel_report.ex
@@ -91,6 +91,8 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelReport do
   # deprecated
   # 99 means 100% hardware level
   defp value_from_byte(0xFF), do: {:ok, 99}
+  # Leviton DZ1KD-1BZ dimmer
+  defp value_from_byte(100), do: {:ok, 99}
 
   defp value_from_byte(byte),
     do: {:error, %DecodeError{value: byte, param: :value, command: :switch_multilevel_report}}

--- a/test/grizzly/zwave/commands/switch_multilevel_report_test.exs
+++ b/test/grizzly/zwave/commands/switch_multilevel_report_test.exs
@@ -34,4 +34,13 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelReportTest do
     assert Keyword.get(params, :value) == 0x32
     assert Keyword.get(params, :duration) == 0x0A
   end
+
+  test "decodes Leviton DZ1KD-1BZ dimmer" do
+    binary_params = <<100, 100>>
+    {:ok, params} = SwitchMultilevelReport.decode_params(binary_params)
+
+    # Fix the 100% report to 99
+    assert Keyword.get(params, :value) == 99
+    assert Keyword.get(params, :duration) == 100
+  end
 end


### PR DESCRIPTION
A Leviton DZ1KD-1BZ dimmer reports 100 for 100% on. According to the
Z-Wave spec, this really should be 99. The decoder crashes with the
following, though:

```
** (MatchError) no match of right hand side value: {:error, %Grizzly.ZWave.DecodeError{value: 100, param: :value, command: :switch_multilevel_report}}
    (grizzly 6.4.0) lib/grizzly/zwave/commands/zip_packet.ex:83: Grizzly.ZWave.Commands.ZIPPacket.decode_params/1
    (grizzly 6.4.0) lib/grizzly/zwave/decoder.ex:1: Grizzly.ZWave.Decoder.decode/2
    (grizzly 6.4.0) lib/grizzly/transports/DTLS.ex:129: Grizzly.Transports.DTLS.handle_ssl_message_with_ip/4
    (grizzly 6.4.0) lib/grizzly/connections/sync_connection.ex:133: Grizzly.Connections.SyncConnection.handle_info/2
    (stdlib 4.3) gen_server.erl:1123: :gen_server.try_dispatch/4
    (stdlib 4.3) gen_server.erl:1200: :gen_server.handle_msg/6
    (stdlib 4.3) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message: {:ssl, {:sslsocket, {:gen_udp, {{{64768, 48059, 0, 0, 0, 0, 0, 32}, 41230}, #Port<0.640>}, :dtls_gen_connection}, [#PID<0.31297.0>]}, [35, 2, 128, 192, 165, 0, 0, 5, 132, 2, 0, 0, 38, 3, 100, 100, 0]}
State: %Grizzly.Connections.SyncConnection.State{transport: %Grizzly.Transport{assigns: %{ip_address: {64768, 48059, 0, 0, 0, 0, 0, 32}, port: 41230, socket: {:sslsocket, {:gen_udp, {{{64768, 48059, 0, 0, 0, 0, 0, 32}, 41230}, #Port<0.640>}, :dtls_gen_connection}, [#PID<0.31297.0>]}}, impl: Grizzly.Transports.DTLS}, commands: %Grizzly.Connections.CommandList{commands: [{#PID<0.31313.0>, {#PID<0.30312.0>, [:alias | #Reference<0.3425214232.890568707.90742>]}, #Reference<0.3425214232.890503171.90744>}], keep_alive_command: nil}, keep_alive: %Grizzly.Connections.KeepAlive{ref: #Reference<0.3425214232.891027457.176241>, last_send: nil, interval: 25000, owner: #PID<0.31296.0>, command_runner: nil, node_id: 32}, node_id: 32}
```

Rather than crash, just translate the 100 to 99 for the code that
follows. Presumably the Leviton dimmer may want 100 for 100% on rather
than 99, but it that doesn't seem to cause any noticeable difference to
me. The dimmer shows 100% via its on-switch LED indicator and it looks
fully on to me.
