### PR TITLE
Revert "Replace "slave" with "end node""

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Grizzly Logo](./assets/grizzly_main-md.png)
+![Grizzly Logo](assets/grizzly_main-md.png)
 
 [![CircleCI](https://circleci.com/gh/smartrent/grizzly.svg?style=svg)](https://circleci.com/gh/smartrent/grizzly)
 [![Hex.pm](https://img.shields.io/hexpm/v/grizzly?style=flat-square)](https://hex.pm/packages/grizzly)

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -361,7 +361,7 @@ iex> Grizzly.send_command(node_id, :firmware_md_get)
      impl: Grizzly.ZWave.Commands.VersionReport,
      name: :version_report,
      params: [
-       library_type: :enhanced_end_node,
+       library_type: :enhanced_slave,
        protocol_version: "4.24",
        firmware_version: "1.78",
        hardware_version: 255,

--- a/lib/grizzly/zwave/command_classes/zwaveplus_info.ex
+++ b/lib/grizzly/zwave/command_classes/zwaveplus_info.ex
@@ -14,11 +14,11 @@ defmodule Grizzly.ZWave.CommandClasses.ZwaveplusInfo do
           | :sub_static_controller
           | :portable_controller
           | :reporting_portable_controller
-          | :portable_end_node
-          | :always_on_end_node
-          | :reporting_sleeping_end_node
-          | :listening_sleeping_end_node
-          | :network_aware_end_node
+          | :portable_slave
+          | :always_on_slave
+          | :reporting_sleeping_slave
+          | :listening_sleeping_slave
+          | :network_aware_slave
 
   @type node_type :: :zwaveplus_node | :zwaveplus_for_ip_gateway
 
@@ -32,21 +32,21 @@ defmodule Grizzly.ZWave.CommandClasses.ZwaveplusInfo do
   def role_type_to_byte(:sub_static_controller), do: 0x01
   def role_type_to_byte(:portable_controller), do: 0x02
   def role_type_to_byte(:reporting_portable_controller), do: 0x03
-  def role_type_to_byte(:portable_end_node), do: 0x04
-  def role_type_to_byte(:always_on_end_node), do: 0x05
-  def role_type_to_byte(:reporting_sleeping_end_node), do: 0x06
-  def role_type_to_byte(:listening_sleeping_end_node), do: 0x07
-  def role_type_to_byte(:network_aware_end_node), do: 0x08
+  def role_type_to_byte(:portable_slave), do: 0x04
+  def role_type_to_byte(:always_on_slave), do: 0x05
+  def role_type_to_byte(:reporting_sleeping_slave), do: 0x06
+  def role_type_to_byte(:listening_sleeping_slave), do: 0x07
+  def role_type_to_byte(:network_aware_slave), do: 0x08
 
   def role_type_from_byte(0x00), do: {:ok, :central_static_controller}
   def role_type_from_byte(0x01), do: {:ok, :sub_static_controller}
   def role_type_from_byte(0x02), do: {:ok, :portable_controller}
   def role_type_from_byte(0x03), do: {:ok, :reporting_portable_controller}
-  def role_type_from_byte(0x04), do: {:ok, :portable_end_node}
-  def role_type_from_byte(0x05), do: {:ok, :always_on_end_node}
-  def role_type_from_byte(0x06), do: {:ok, :reporting_sleeping_end_node}
-  def role_type_from_byte(0x07), do: {:ok, :listening_sleeping_end_node}
-  def role_type_from_byte(0x08), do: {:ok, :network_aware_end_node}
+  def role_type_from_byte(0x04), do: {:ok, :portable_slave}
+  def role_type_from_byte(0x05), do: {:ok, :always_on_slave}
+  def role_type_from_byte(0x06), do: {:ok, :reporting_sleeping_slave}
+  def role_type_from_byte(0x07), do: {:ok, :listening_sleeping_slave}
+  def role_type_from_byte(0x08), do: {:ok, :network_aware_slave}
   def role_type_from_byte(byte), do: {:error, %DecodeError{param: :role_type, value: byte}}
 
   def node_type_to_byte(:zwaveplus_node), do: 0x00

--- a/lib/grizzly/zwave/commands/version_report.ex
+++ b/lib/grizzly/zwave/commands/version_report.ex
@@ -24,10 +24,10 @@ defmodule Grizzly.ZWave.Commands.VersionReport do
   @type library_type ::
           :static_controller
           | :controller
-          | :enhanced_end_node
-          | :end_node
+          | :enhanced_slave
+          | :slave
           | :installer
-          | :routing_end_node
+          | :routing_slave
           | :bridge_controller
           | :device_under_test
           | :av_remote
@@ -162,10 +162,10 @@ defmodule Grizzly.ZWave.Commands.VersionReport do
 
   defp decode_library_type(0x01), do: {:ok, :static_controller}
   defp decode_library_type(0x02), do: {:ok, :controller}
-  defp decode_library_type(0x03), do: {:ok, :enhanced_end_node}
-  defp decode_library_type(0x04), do: {:ok, :end_node}
+  defp decode_library_type(0x03), do: {:ok, :enhanced_slave}
+  defp decode_library_type(0x04), do: {:ok, :slave}
   defp decode_library_type(0x05), do: {:ok, :installer}
-  defp decode_library_type(0x06), do: {:ok, :routing_end_node}
+  defp decode_library_type(0x06), do: {:ok, :routing_slave}
   defp decode_library_type(0x07), do: {:ok, :bridge_controller}
   defp decode_library_type(0x08), do: {:ok, :device_under_test}
   defp decode_library_type(0x0A), do: {:ok, :av_remote}
@@ -182,10 +182,10 @@ defmodule Grizzly.ZWave.Commands.VersionReport do
 
   defp encode_library_type(:static_controller), do: 0x01
   defp encode_library_type(:controller), do: 0x02
-  defp encode_library_type(:enhanced_end_node), do: 0x03
-  defp encode_library_type(:end_node), do: 0x04
+  defp encode_library_type(:enhanced_slave), do: 0x03
+  defp encode_library_type(:slave), do: 0x04
   defp encode_library_type(:installer), do: 0x05
-  defp encode_library_type(:routing_end_node), do: 0x06
+  defp encode_library_type(:routing_slave), do: 0x06
   defp encode_library_type(:bridge_controller), do: 0x07
   defp encode_library_type(:device_under_test), do: 0x08
   defp encode_library_type(:av_remote), do: 0x0A

--- a/lib/grizzly/zwave/device_class.ex
+++ b/lib/grizzly/zwave/device_class.ex
@@ -60,7 +60,7 @@ defmodule Grizzly.ZWave.DeviceClass do
   @spec thermostat_hvac() :: t()
   def thermostat_hvac() do
     %{
-      basic_device_class: :routing_end_node,
+      basic_device_class: :routing_slave,
       generic_device_class: :thermostat,
       specific_device_class: :thermostat_general_v2,
       command_classes: %{
@@ -89,7 +89,7 @@ defmodule Grizzly.ZWave.DeviceClass do
       manufacturer_id: 0x0000,
       product_id: 0x0000,
       product_type_id: 0x0000,
-      library_type: :routing_end_node
+      library_type: :routing_slave
     }
   end
 
@@ -99,7 +99,7 @@ defmodule Grizzly.ZWave.DeviceClass do
   @spec multilevel_sensor() :: t()
   def multilevel_sensor() do
     %{
-      basic_device_class: :routing_end_node,
+      basic_device_class: :routing_slave,
       generic_device_class: :sensor_multilevel,
       specific_device_class: :routing_sensor_multilevel,
       command_classes: %{
@@ -121,7 +121,7 @@ defmodule Grizzly.ZWave.DeviceClass do
       manufacturer_id: 0x0000,
       product_id: 0x0000,
       product_type_id: 0x0000,
-      library_type: :routing_end_node
+      library_type: :routing_slave
     }
   end
 end

--- a/lib/grizzly/zwave/device_classes.ex
+++ b/lib/grizzly/zwave/device_classes.ex
@@ -9,8 +9,8 @@ defmodule Grizzly.ZWave.DeviceClasses do
     @basic_mappings [
       {0x01, :controller},
       {0x02, :static_controller},
-      {0x03, :end_node},
-      {0x04, :routing_end_node}
+      {0x03, :slave},
+      {0x04, :routing_slave}
     ]
 
     @generic_mappings [
@@ -23,7 +23,7 @@ defmodule Grizzly.ZWave.DeviceClasses do
       {0x07, :sensor_notification},
       {0x08, :thermostat},
       {0x09, :window_covering},
-      {0x0F, :repeater_end_node},
+      {0x0F, :repeater_slave},
       {0x10, :switch_binary},
       {0x11, :switch_multilevel},
       {0x12, :switch_remote},
@@ -109,10 +109,10 @@ defmodule Grizzly.ZWave.DeviceClasses do
       {:switch_multilevel, 0x06, :class_b_motor_control},
       {:switch_multilevel, 0x07, :class_c_motor_control},
       {:switch_multilevel, 0x08, :fan_switch},
-      # repeater end_node
-      {:repeater_end_node, 0x00, :not_used},
-      {:repeater_end_node, 0x01, :repeater_end_node},
-      {:repeater_end_node, 0x02, :virtual_node},
+      # repeater slave
+      {:repeater_slave, 0x00, :not_used},
+      {:repeater_slave, 0x01, :repeater_slave},
+      {:repeater_slave, 0x02, :virtual_node},
       # switch remote (0x13)
       {:switch_remote, 0x00, :not_used},
       {:switch_remote, 0x01, :switch_remote_binary},

--- a/lib/grizzly/zwave/icon_type.ex
+++ b/lib/grizzly/zwave/icon_type.ex
@@ -152,7 +152,7 @@ defmodule Grizzly.ZWave.IconType do
       {0x1900, :generic_window_covering_endpoint_aware},
       {0x1A00, :generic_window_covering_position_endpoint_aware},
       {0x1B00, :generic_repeater},
-      {0x1B01, :specific_repeater_end_node},
+      {0x1B01, :specific_repeater_slave},
       {0x1B03, :specific_ir_repeater},
       {0x1C00, :generic_dimmer_wall_switch},
       {0x1C01, :specific_dimmer_wall_switch_one_button},

--- a/test/grizzly/virtual_devices_test.exs
+++ b/test/grizzly/virtual_devices_test.exs
@@ -84,12 +84,12 @@ defmodule Grizzly.VirtualDeviceTest do
   end
 
   describe "version get reports" do
-    test "routing end_node" do
+    test "routing slave" do
       with_virtual_device(Thermostat, fn id ->
         {:ok, %Report{type: :command, command: command}} = Grizzly.send_command(id, :version_get)
 
         assert command.name == :version_report
-        assert Command.param!(command, :library_type) == :routing_end_node
+        assert Command.param!(command, :library_type) == :routing_slave
       end)
     end
   end


### PR DESCRIPTION
Temporarily reverts smartrent/grizzly#746 until we're ready to do a major release.