### PR TITLE
Node Add Status always includes command classes list

### DIFF
--- a/lib/grizzly/zwave/command_classes/network_management_inclusion.ex
+++ b/lib/grizzly/zwave/command_classes/network_management_inclusion.ex
@@ -156,7 +156,7 @@ defmodule Grizzly.ZWave.CommandClasses.NetworkManagementInclusion do
 
   defp parse_additional_node_info(node_info, additional_info, command_class_length)
        when command_class_length <= 0 or byte_size(additional_info) == 0,
-       do: node_info
+       do: node_info |> Map.put(:command_classes, [])
 
   defp parse_additional_node_info(node_info, additional_info, command_class_length) do
     <<command_classes_bin::binary-size(command_class_length), more_info::binary>> =

--- a/lib/grizzly/zwave/commands/node_add_status.ex
+++ b/lib/grizzly/zwave/commands/node_add_status.ex
@@ -22,7 +22,7 @@ defmodule Grizzly.ZWave.Commands.NodeAddStatus do
   """
   @behaviour Grizzly.ZWave.Command
 
-  alias Grizzly.ZWave.{Command, CommandClasses, DSK, Security}
+  alias Grizzly.ZWave.{Command, CommandClasses, DeviceClasses, DSK, Security}
   alias Grizzly.ZWave.CommandClasses.NetworkManagementInclusion, as: NMI
 
   @type tagged_command_classes() ::
@@ -72,7 +72,7 @@ defmodule Grizzly.ZWave.Commands.NodeAddStatus do
       basic_device_class = Command.param!(command, :basic_device_class)
       generic_device_class = Command.param!(command, :generic_device_class)
       specific_device_class = Command.param!(command, :specific_device_class)
-      command_classes = Command.param!(command, :command_classes)
+      command_classes = Command.param(command, :command_classes, [])
 
       # We add 6 to the length of the command classes to account for the 3 device
       # classes 2 Z-Wave protocol bytes and the node info length byte.
@@ -83,9 +83,10 @@ defmodule Grizzly.ZWave.Commands.NodeAddStatus do
       # TODO: fix opt func bit (after the listening bit)
       binary =
         <<seq_number, NMI.node_add_status_to_byte(status), 0x00, node_id, node_info_length,
-          encode_listening_bit(listening?)::size(1), 0x00::size(7), 0x00, basic_device_class,
-          generic_device_class,
-          specific_device_class>> <>
+          encode_listening_bit(listening?)::size(1), 0x00::size(7), 0x00,
+          DeviceClasses.basic_device_class_to_byte(basic_device_class),
+          DeviceClasses.generic_device_class_to_byte(generic_device_class),
+          DeviceClasses.specific_device_class_to_byte(generic_device_class, specific_device_class)>> <>
           CommandClasses.command_class_list_to_binary(command_classes)
 
       maybe_add_version_2_fields(command, binary)

--- a/lib/grizzly/zwave/commands/zip_packet.ex
+++ b/lib/grizzly/zwave/commands/zip_packet.ex
@@ -218,8 +218,10 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket do
     binary_packet <> <<header_extensions_size>> <> header_extensions_bin
   end
 
-  defp maybe_add_command(binary_packet, nil), do: binary_packet
-  defp maybe_add_command(binary_packet, command), do: binary_packet <> Command.to_binary(command)
+  @spec maybe_add_command(binary(), Command.t() | binary() | nil) :: binary()
+  defp maybe_add_command(zip_packet, nil), do: zip_packet
+  defp maybe_add_command(zip_packet, command) when is_binary(command), do: zip_packet <> command
+  defp maybe_add_command(zip_packet, command), do: zip_packet <> Command.to_binary(command)
 
   defp meta_from_byte(byte) do
     <<header?::size(1), cmd?::size(1), more_info?::size(1), secure?::size(1), _::size(4)>> =


### PR DESCRIPTION
... even when it's empty. Also updates Node Add Status encoding to match
the decoding behavior updated in #759.
