### PR TITLE
Do not retry commands by default

### DIFF
--- a/lib/grizzly/commands/command.ex
+++ b/lib/grizzly/commands/command.ex
@@ -37,7 +37,7 @@ defmodule Grizzly.Commands.Command do
           | {:transmission_stats, boolean()}
 
   defstruct owner: nil,
-            retries: 2,
+            retries: 0,
             source: nil,
             handler_state: nil,
             handler: nil,
@@ -53,7 +53,7 @@ defmodule Grizzly.Commands.Command do
 
   @spec from_zwave_command(ZWaveCommand.t(), ZWave.node_id(), pid(), [opt()]) :: t()
   def from_zwave_command(zwave_command, node_id, owner, opts \\ []) do
-    retries = Keyword.get(opts, :retries, 2)
+    retries = Keyword.get(opts, :retries, 0)
     command_ref = Keyword.get(opts, :reference, make_ref())
     timeout_ref = Keyword.get(opts, :timeout_ref)
     with_transmission_stats = Keyword.get(opts, :transmission_stats, false)

--- a/test/grizzly/commands/command_test.exs
+++ b/test/grizzly/commands/command_test.exs
@@ -26,7 +26,7 @@ defmodule Grizzly.Commands.CommandTest do
       handler_state: nil,
       source: zwave_command,
       owner: self(),
-      retries: 2,
+      retries: 0,
       seq_number: grizzly_command.seq_number,
       ref: grizzly_command.ref,
       node_id: 1,
@@ -105,9 +105,9 @@ defmodule Grizzly.Commands.CommandTest do
              Command.handle_zip_command(grizzly_command, ack_response)
   end
 
-  test "handles Z/IP Packet for nack response with retires" do
+  test "handles Z/IP Packet for nack response with retries" do
     {:ok, zwave_command} = SwitchBinaryGet.new()
-    grizzly_command = Command.from_zwave_command(zwave_command, 1, self())
+    grizzly_command = Command.from_zwave_command(zwave_command, 1, self(), retries: 2)
 
     nack_response = ZIPPacket.make_nack_response(grizzly_command.seq_number)
 
@@ -117,7 +117,7 @@ defmodule Grizzly.Commands.CommandTest do
              Command.handle_zip_command(grizzly_command, nack_response)
   end
 
-  test "handles Z/IP Packet for nack response with no retires" do
+  test "handles Z/IP Packet for nack response with no retries" do
     {:ok, zwave_command} = SwitchBinaryGet.new()
     grizzly_command = Command.from_zwave_command(zwave_command, 1, self(), retries: 0)
 

--- a/test/grizzly/connections/command_list_test.exs
+++ b/test/grizzly/connections/command_list_test.exs
@@ -65,7 +65,7 @@ defmodule Grizzly.Connections.CommandListTest do
     {:ok, zwave_command} = SwitchBinaryGet.new()
 
     {:ok, runner, _ref, command_list} =
-      CommandList.create(CommandList.empty(), zwave_command, 1, self())
+      CommandList.create(CommandList.empty(), zwave_command, 1, self(), retries: 2)
 
     nack_response = ZIPPacket.make_nack_response(CommandRunner.seq_number(runner))
 


### PR DESCRIPTION
Grizzly's retries are currently opaque to consumers, which can cause
issues if consumers implement their own retry mechanism. This makes
retries opt-in instead of opt-out.
