### PR TITLE
Do not crash on trailing bytes in ConfigurationReport

### DIFF
--- a/lib/grizzly/zwave/commands/configuration_report.ex
+++ b/lib/grizzly/zwave/commands/configuration_report.ex
@@ -22,6 +22,8 @@ defmodule Grizzly.ZWave.Commands.ConfigurationReport do
   alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.CommandClasses.Configuration
 
+  require Logger
+
   @type param ::
           {:size, 1 | 2 | 4} | {:value, integer()} | {:param_number, byte()}
 
@@ -49,8 +51,15 @@ defmodule Grizzly.ZWave.Commands.ConfigurationReport do
 
   @impl true
   def decode_params(
-        <<param_number, _::size(5), size::size(3), value_int::signed-integer-size(size)-unit(8)>>
+        <<param_number, _::size(5), size::size(3), value_int::signed-integer-size(size)-unit(8),
+          rest::binary>>
       ) do
+    if byte_size(rest) > 0 do
+      Logger.warning(
+        "[Grizzly] Unexpected trailing bytes in ConfigurationReport: #{inspect(rest)}"
+      )
+    end
+
     {:ok, [param_number: param_number, value: value_int, size: size]}
   end
 end


### PR DESCRIPTION
A payload of `<<1, 1, 0, 0>>` was observed coming from a Yale YRD-642 ZW3. Instead of crashing, we'll drop any unexpected bytes and log a warning.