### PR TITLE
Support signed values in Thermostat Setpoint Set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ install_system_deps: &install_system_deps
       apk add build-base
 
 jobs:
-  build_elixir_1_14_otp_25:
+  build_elixir_1_14_otp_26:
     docker:
-      - image: hexpm/elixir:1.14.3-erlang-25.2.3-alpine-3.15.6
+      - image: hexpm/elixir:1.14.4-erlang-26.0-alpine-3.18.0
     <<: *defaults
     steps:
       - checkout
@@ -48,9 +48,9 @@ jobs:
             - _build
             - deps
 
-  build_elixir_1_13_otp_24:
+  build_elixir_1_14_otp_25:
     docker:
-      - image: hexpm/elixir:1.13.3-erlang-24.2.2-alpine-3.15.0
+      - image: hexpm/elixir:1.14.3-erlang-25.2.3-alpine-3.18.0
     <<: *defaults
     steps:
       - checkout
@@ -60,9 +60,9 @@ jobs:
       - run: mix compile
       - run: mix test
 
-  build_elixir_1_12_otp_24:
+  build_elixir_1_13_otp_25:
     docker:
-      - image: hexpm/elixir:1.12.1-erlang-24.0.2-alpine-3.13.3
+      - image: hexpm/elixir:1.13.4-erlang-25.3.2-alpine-3.18.0
     <<: *defaults
     steps:
       - checkout
@@ -76,6 +76,6 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_14_otp_26
       - build_elixir_1_14_otp_25
-      - build_elixir_1_13_otp_24
-      - build_elixir_1_12_otp_24
+      - build_elixir_1_13_otp_25

--- a/lib/grizzly/zwave/commands/thermostat_setpoint_set.ex
+++ b/lib/grizzly/zwave/commands/thermostat_setpoint_set.ex
@@ -76,7 +76,9 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSet do
   def __bits_needed__(int_value) do
     bits = ceil(:math.log2(abs(int_value)) + 1)
 
-    <<msb::1, _rest::size(bits - 1)>> = <<int_value::signed-size(bits)>>
+    # <<x::size(foo - 1)>> is only supported in Elixir >= 1.14
+    rest_size = bits - 1
+    <<msb::1, _rest::size(rest_size)>> = <<int_value::signed-size(bits)>>
 
     if msb == 1 && int_value > 0 do
       bits + 1

--- a/lib/grizzly/zwave/commands/thermostat_setpoint_set.ex
+++ b/lib/grizzly/zwave/commands/thermostat_setpoint_set.ex
@@ -41,16 +41,16 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSet do
     value = Command.param!(command, :value)
     precision = precision(value)
     int_value = round(value * :math.pow(10, precision))
-    byte_size = ceil(:math.log2(int_value) / 8)
+    byte_size = __bytes_needed__(int_value)
 
     <<0x00::size(4), type_byte::size(4), precision::size(3), scale_byte::size(2),
-      byte_size::size(3), int_value::size(byte_size)-unit(8)>>
+      byte_size::size(3), int_value::signed-size(byte_size)-unit(8)>>
   end
 
   @impl Command
   def decode_params(
         <<_::size(4), type_byte::size(4), precision::size(3), scale_byte::size(2),
-          byte_size::size(3), int_value::size(byte_size)-unit(8)>>
+          byte_size::size(3), int_value::signed-size(byte_size)-unit(8)>>
       ) do
     type = ThermostatSetpoint.decode_type(type_byte)
 
@@ -64,10 +64,29 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSet do
     end
   end
 
-  defp precision(value) when is_number(value) do
+  def precision(value) when is_number(value) do
     case String.split("#{value}", ".") do
       [_] -> 0
       [_, dec] -> String.length(dec)
     end
+  end
+
+  def __bits_needed__(0), do: 1
+
+  def __bits_needed__(int_value) do
+    bits = ceil(:math.log2(abs(int_value)) + 1)
+
+    <<msb::1, _rest::size(bits - 1)>> = <<int_value::signed-size(bits)>>
+
+    if msb == 1 && int_value > 0 do
+      bits + 1
+    else
+      bits
+    end
+  end
+
+  def __bytes_needed__(int_value) do
+    bits = __bits_needed__(int_value)
+    ceil(bits / 8)
   end
 end

--- a/test/grizzly/connections/sync_connection_test.exs
+++ b/test/grizzly/connections/sync_connection_test.exs
@@ -16,7 +16,7 @@ defmodule Grizzly.Connections.SyncConnectionTest do
   end
 
   test "reports timeout" do
-    assert {:error, :timeout} == SyncConnection.start_link(Utils.default_options(), 600)
+    assert {:error, :timeout} == Connection.open(600)
   end
 
   test "handles nack responses" do

--- a/test/grizzly/zwave/commands/thermostat_setpoint_set_test.exs
+++ b/test/grizzly/zwave/commands/thermostat_setpoint_set_test.exs
@@ -16,6 +16,14 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSetTest do
       <<0x00::size(4), 0x01::size(4), 0x01::size(3), 0x01::size(2), 0x02::size(3), 0x02, 0xF3>>
 
     assert expected_binary == ThermostatSetpointSet.encode_params(command)
+
+    params = [type: :heating, scale: :f, value: -2.5]
+    {:ok, command} = ThermostatSetpointSet.new(params)
+
+    expected_binary =
+      <<0x00::size(4), 0x01::size(4), 0x01::size(3), 0x01::size(2), 0x01::size(3), 0xE7>>
+
+    assert expected_binary == ThermostatSetpointSet.encode_params(command)
   end
 
   test "decodes params correctly" do
@@ -26,5 +34,40 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSetTest do
     assert Keyword.get(params, :type) == :heating
     assert Keyword.get(params, :scale) == :f
     assert Keyword.get(params, :value) == 75.5
+
+    binary_params =
+      <<0x00::size(4), 0x01::size(4), 0x01::size(3), 0x01::size(2), 0x01::size(3), 0xE7>>
+
+    {:ok, params} = ThermostatSetpointSet.decode_params(binary_params)
+    assert Keyword.get(params, :type) == :heating
+    assert Keyword.get(params, :scale) == :f
+    assert Keyword.get(params, :value) == -2.5
+  end
+
+  test "calculates number of bits needed correctly" do
+    assert 8 == ThermostatSetpointSet.__bits_needed__(127)
+    assert 9 == ThermostatSetpointSet.__bits_needed__(128)
+    assert 8 == ThermostatSetpointSet.__bits_needed__(-128)
+    assert 9 == ThermostatSetpointSet.__bits_needed__(-129)
+
+    assert 16 == ThermostatSetpointSet.__bits_needed__(32767)
+    assert 17 == ThermostatSetpointSet.__bits_needed__(32768)
+    assert 16 == ThermostatSetpointSet.__bits_needed__(-32768)
+    assert 17 == ThermostatSetpointSet.__bits_needed__(-32769)
+  end
+
+  test "calculates number of bytes needed correctly" do
+    assert 1 == ThermostatSetpointSet.__bytes_needed__(0)
+    assert 1 == ThermostatSetpointSet.__bytes_needed__(1)
+    assert 1 == ThermostatSetpointSet.__bytes_needed__(-1)
+    assert 1 == ThermostatSetpointSet.__bytes_needed__(127)
+    assert 2 == ThermostatSetpointSet.__bytes_needed__(128)
+    assert 1 == ThermostatSetpointSet.__bytes_needed__(-128)
+    assert 2 == ThermostatSetpointSet.__bytes_needed__(-129)
+
+    assert 2 == ThermostatSetpointSet.__bytes_needed__(32767)
+    assert 3 == ThermostatSetpointSet.__bytes_needed__(32768)
+    assert 2 == ThermostatSetpointSet.__bytes_needed__(-32768)
+    assert 3 == ThermostatSetpointSet.__bytes_needed__(-32769)
   end
 end


### PR DESCRIPTION
The Thermostat Setpoint Set CC uses signed values in its binary
encoding, but we were encoding and decoding values as unsigned.

On top of being incorrect, the calculation for the number of bytes
needed to encode the value would raise an error for any negative number
(because log-n is undefined for values <= 0).
