### PR TITLE
Handle trailing bytes in SwitchMultilevelReport

### DIFF
--- a/lib/grizzly/zwave/commands/switch_multilevel_report.ex
+++ b/lib/grizzly/zwave/commands/switch_multilevel_report.ex
@@ -70,7 +70,13 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelReport do
   end
 
   # version 4
-  def decode_params(<<value_byte, target_value_byte, duration>>) do
+  def decode_params(<<value_byte, target_value_byte, duration, rest::binary>>) do
+    if byte_size(rest) > 0 do
+      Logger.warning(
+        "[Grizzly] Unexpected trailing bytes in SwitchMultilevelReport: #{inspect(rest)}"
+      )
+    end
+
     with {:ok, value} <- value_from_byte(value_byte),
          {:ok, target_value} <- value_from_byte(target_value_byte) do
       {:ok,
@@ -83,15 +89,6 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelReport do
       {:error, %DecodeError{}} = error ->
         error
     end
-  end
-
-  # no spec
-  def decode_params(<<_value_byte, _target_value_byte, duration::binary>>) do
-    Logger.warning(
-      "[Grizzly] Unexpected trailing bytes in SwitchMultilevelReport: #{inspect(duration)}"
-    )
-
-    {:error, %DecodeError{value: duration, param: :duration, command: :switch_multilevel_report}}
   end
 
   defp value_from_byte(0x00), do: {:ok, :off}

--- a/lib/grizzly/zwave/commands/switch_multilevel_report.ex
+++ b/lib/grizzly/zwave/commands/switch_multilevel_report.ex
@@ -86,7 +86,7 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelReport do
   end
 
   # no spec
-  def decode_params(<<value_byte, target_value_byte, duration::binary>>) do
+  def decode_params(<<_value_byte, _target_value_byte, duration::binary>>) do
     Logger.warning(
       "[Grizzly] Unexpected trailing bytes in SwitchMultilevelReport: #{inspect(duration)}"
     )

--- a/lib/grizzly/zwave/commands/switch_multilevel_report.ex
+++ b/lib/grizzly/zwave/commands/switch_multilevel_report.ex
@@ -9,7 +9,7 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelReport do
   """
 
   @behaviour Grizzly.ZWave.Command
-
+  require Logger
   alias Grizzly.ZWave.{Command, DecodeError}
   alias Grizzly.ZWave.CommandClasses.SwitchMultilevel
 
@@ -83,6 +83,15 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelReport do
       {:error, %DecodeError{}} = error ->
         error
     end
+  end
+
+  # no spec
+  def decode_params(<<value_byte, target_value_byte, duration::binary>>) do
+    Logger.warning(
+      "[Grizzly] Unexpected trailing bytes in SwitchMultilevelReport: #{inspect(duration)}"
+    )
+
+    {:error, %DecodeError{value: duration, param: :duration, command: :switch_multilevel_report}}
   end
 
   defp value_from_byte(0x00), do: {:ok, :off}

--- a/test/grizzly/zwave/commands/switch_multilevel_report_test.exs
+++ b/test/grizzly/zwave/commands/switch_multilevel_report_test.exs
@@ -43,20 +43,15 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelReportTest do
     assert Keyword.get(params, :duration) == 10
   end
 
-  test "error on more than 3 bytes" do
+  test "ignores bytes trailing bytes" do
     {result, log} =
       with_log(fn ->
         SwitchMultilevelReport.decode_params(<<0x32, 0x63, 0x0, 0x87>>)
       end)
 
-    assert {:error,
-            %Grizzly.ZWave.DecodeError{
-              value: <<0, 135>>,
-              param: :duration,
-              command: :switch_multilevel_report
-            }} = result
+    assert {:ok, [value: 50, target_value: 99, duration: 0]} = result
 
-    assert log =~ "Unexpected trailing bytes in SwitchMultilevelReport: <<0, 135>>"
+    assert log =~ "Unexpected trailing bytes in SwitchMultilevelReport: <<135>>"
   end
 
   test "decodes Leviton DZ1KD-1BZ dimmer" do


### PR DESCRIPTION
Instead of [crashing](https://smartrent.sentry.io/issues/4190192493/?project=4505127406141440&referrer=slack) when more than 3 bytes are received log a warning and return a `%DecodeError{}`

