### PR TITLE
Increase default command timeout to 15s

### DIFF
--- a/lib/grizzly.ex
+++ b/lib/grizzly.ex
@@ -134,7 +134,7 @@ defmodule Grizzly do
   Options for `Grizzly.send_command/4`.
 
   * `:timeout` - Time (in milliseconds) to wait for an ACK or report before timing out.
-    Maximum 140 seconds. Default `5_000`.
+    Maximum 140 seconds. Default `15_000`.
   * `:retries` - Number of retries in case the node responds with a NACK. Default `0`.
   * `:handler` - A custom response handler (see `Grizzly.CommandHandler`).
   * `:transmission_stats` - If true, transmission stats will be included with the

--- a/lib/grizzly/commands/command_runner.ex
+++ b/lib/grizzly/commands/command_runner.ex
@@ -17,7 +17,7 @@ defmodule Grizzly.Commands.CommandRunner do
 
   @spec start_link(Command.t(), [Grizzly.command_opt()]) :: GenServer.on_start()
   def start_link(command, node_id, opts \\ []) do
-    opts = Keyword.merge([owner: self(), timeout: 5_000], opts)
+    opts = Keyword.merge([owner: self(), timeout: 15_000], opts)
     GenServer.start_link(__MODULE__, [command, node_id, opts])
   end
 


### PR DESCRIPTION
From my own observations, this is how long before the Z-Wave module
actually gives up when sending a command to an offline/failed node.
