### PR TITLE
Allow DTLSv1.2

### DIFF
--- a/lib/grizzly/transports/DTLS.ex
+++ b/lib/grizzly/transports/DTLS.ex
@@ -214,7 +214,7 @@ defmodule Grizzly.Transports.DTLS do
       {:ssl_imp, :new},
       {:active, true},
       {:verify, :verify_none},
-      {:versions, [:dtlsv1]},
+      {:versions, [:"dtlsv1.2", :dtlsv1]},
       {:protocol, :dtls},
       {:ciphers, [{:psk, :aes_128_cbc, :sha}]},
       {:psk_identity, 'Client_identity'},


### PR DESCRIPTION
This enables support for versions of Z/IP Gateway compiled against
OpenSSL 3.0.
