### PR TITLE
Trace option to ignore keepalive frames

### DIFF
--- a/lib/grizzly/trace/record.ex
+++ b/lib/grizzly/trace/record.ex
@@ -7,6 +7,7 @@ defmodule Grizzly.Trace.Record do
 
   alias Grizzly.{Trace, ZWave}
   alias Grizzly.ZWave.Command
+  alias Grizzly.ZWave.Commands.ZIPPacket
 
   @type t() :: %__MODULE__{
           timestamp: Time.t(),
@@ -76,6 +77,12 @@ defmodule Grizzly.Trace.Record do
     flag = Command.param!(zip_packet, :flag)
 
     cond do
+      flag == :nack_waiting ->
+        expected_delay = ZIPPacket.extension(zip_packet, :expected_delay, nil)
+
+        command_info_empty_response(seq_number, flag) <>
+          " expected_delay=#{inspect(expected_delay)}"
+
       flag in [:ack_response, :nack_response, :nack_waiting] ->
         command_info_empty_response(seq_number, flag)
 

--- a/test/grizzly/trace_test.exs
+++ b/test/grizzly/trace_test.exs
@@ -1,0 +1,138 @@
+defmodule Grizzly.TraceTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.Trace
+  alias Grizzly.ZWave
+  alias Grizzly.ZWave.Commands.{SwitchBinaryGet, ZIPKeepAlive, ZIPPacket}
+
+  setup %{test: test} = ctx do
+    opts =
+      ctx
+      |> Map.take([:size, :record_keepalives])
+      |> Map.put(:name, test)
+      |> Enum.into([])
+
+    pid = start_supervised!({Trace, opts})
+    Map.put(ctx, :tracer, pid)
+  end
+
+  @tag size: 2
+  test "log/3", %{tracer: tracer} do
+    {:ok, cmd} = SwitchBinaryGet.new()
+
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 1)
+    Trace.log(tracer, ZWave.to_binary(zip_packet), [])
+
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 2)
+    Trace.log(tracer, ZWave.to_binary(zip_packet), src: "src1", dest: "dest1")
+
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 3)
+    Trace.log(tracer, ZWave.to_binary(zip_packet), src: "src2", dest: "dest2")
+
+    list = Trace.list(tracer)
+    assert length(list) == 2
+
+    assert [
+             %{binary: <<_::32, 2, _::binary>>, src: "src1", dest: "dest1"},
+             %{binary: <<_::32, 3, _::binary>>, src: "src2", dest: "dest2"}
+           ] = list
+  end
+
+  @tag size: 1
+  test "resize/2", %{tracer: tracer} do
+    {:ok, cmd} = SwitchBinaryGet.new()
+
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 1)
+    Trace.log(tracer, ZWave.to_binary(zip_packet), [])
+
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 2)
+    Trace.log(tracer, ZWave.to_binary(zip_packet), [])
+
+    list = Trace.list(tracer)
+    assert length(list) == 1
+
+    assert [%{binary: <<_::32, 2, _::binary>>}] = list
+
+    Trace.resize(tracer, 3)
+
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 3)
+    Trace.log(tracer, ZWave.to_binary(zip_packet), [])
+
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 4)
+    Trace.log(tracer, ZWave.to_binary(zip_packet), [])
+
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 5)
+    Trace.log(tracer, ZWave.to_binary(zip_packet), [])
+
+    list = Trace.list(tracer)
+    assert length(list) == 3
+
+    assert [
+             %{binary: <<_::32, 3, _::binary>>},
+             %{binary: <<_::32, 4, _::binary>>},
+             %{binary: <<_::32, 5, _::binary>>}
+           ] = list
+
+    Trace.resize(tracer, 2)
+
+    list = Trace.list(tracer)
+    assert length(list) == 2
+
+    assert [
+             %{binary: <<_::32, 4, _::binary>>},
+             %{binary: <<_::32, 5, _::binary>>}
+           ] = list
+  end
+
+  test "clear/1", %{tracer: tracer} do
+    {:ok, cmd} = SwitchBinaryGet.new()
+
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 1)
+    Trace.log(tracer, ZWave.to_binary(zip_packet), [])
+
+    {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 2)
+    Trace.log(tracer, ZWave.to_binary(zip_packet), [])
+
+    list = Trace.list(tracer)
+    assert length(list) == 2
+
+    Trace.clear(tracer)
+
+    list = Trace.list(tracer)
+    assert list == []
+  end
+
+  test "records keepalives by default", %{tracer: tracer} do
+    {:ok, keepalive} = ZIPKeepAlive.new(ack_flag: :ack_request)
+    Trace.log(tracer, ZWave.to_binary(keepalive), [])
+
+    {:ok, keepalive} = ZIPKeepAlive.new(ack_flag: :ack_response)
+    Trace.log(tracer, ZWave.to_binary(keepalive), [])
+
+    list = Trace.list(tracer)
+    assert length(list) == 2
+
+    assert [
+             %{binary: <<0x23, 0x03, 0x80>>},
+             %{binary: <<0x23, 0x03, 0x40>>}
+           ] = list
+  end
+
+  @tag record_keepalives: false
+  test "enable/disable keepalives", %{tracer: tracer} do
+    {:ok, keepalive} = ZIPKeepAlive.new(ack_flag: :ack_request)
+    Trace.log(tracer, ZWave.to_binary(keepalive), [])
+
+    list = Trace.list(tracer)
+    assert list == []
+
+    Trace.record_keepalives(tracer, true)
+    Trace.log(tracer, ZWave.to_binary(keepalive), [])
+
+    Trace.record_keepalives(tracer, false)
+    Trace.log(tracer, ZWave.to_binary(keepalive), [])
+
+    list = Trace.list(tracer)
+    assert [%{binary: <<0x23, 0x03, 0x80>>}] = list
+  end
+end


### PR DESCRIPTION
Z/IP KeepAlive frames are fairly noisy and recording them is really only
useful for debugging the keepalives themselves. Keepalive frames can
quickly fill the trace buffer, especially in networks with many active
nodes.

This also makes a minor change to the default trace format to include the
expected delay field when printing nack+waiting Z/IP Packet frames.
