### PR TITLE
Fix NACK responses for queued commands

### DIFF
--- a/lib/grizzly/report.ex
+++ b/lib/grizzly/report.ex
@@ -154,6 +154,7 @@ defmodule Grizzly.Report do
 
   @type type() ::
           :ack_response
+          | :nack_response
           | :command
           | :queued_ping
           | :unsolicited

--- a/test/grizzly/commands/command_runner_test.exs
+++ b/test/grizzly/commands/command_runner_test.exs
@@ -96,7 +96,7 @@ defmodule Grizzly.Commands.CommandRunnerTest do
 
   test "handles a queued command" do
     {:ok, command} = SwitchBinaryGet.new()
-    {:ok, runner} = CommandRunner.start_link(command, 1)
+    {:ok, runner} = CommandRunner.start_link(command, 1, timeout: 1000)
     command_ref = CommandRunner.reference(runner)
 
     nack_waiting = ZIPPacket.make_nack_waiting_response(CommandRunner.seq_number(runner), 3)
@@ -113,7 +113,7 @@ defmodule Grizzly.Commands.CommandRunnerTest do
 
   test "handles queued complete command" do
     {:ok, command} = SwitchBinarySet.new(target_value: :off)
-    {:ok, runner} = CommandRunner.start_link(command, 1)
+    {:ok, runner} = CommandRunner.start_link(command, 1, timeout: 1000)
     command_ref = CommandRunner.reference(runner)
 
     nack_waiting = ZIPPacket.make_nack_waiting_response(CommandRunner.seq_number(runner), 3)
@@ -140,7 +140,7 @@ defmodule Grizzly.Commands.CommandRunnerTest do
   @tag :integration
   test "handles queued complete command with long timeout" do
     {:ok, command} = SwitchBinarySet.new(target_value: :off)
-    {:ok, runner} = CommandRunner.start_link(command, 1)
+    {:ok, runner} = CommandRunner.start_link(command, 1, timeout: 5000)
     command_ref = CommandRunner.reference(runner)
 
     nack_waiting = ZIPPacket.make_nack_waiting_response(CommandRunner.seq_number(runner), 10)

--- a/test/grizzly/connections/command_list_test.exs
+++ b/test/grizzly/connections/command_list_test.exs
@@ -50,10 +50,10 @@ defmodule Grizzly.Connections.CommandListTest do
     {:ok, runner, ref, command_list} =
       CommandList.create(CommandList.empty(), zwave_command, 1, self())
 
-    queued_response = ZIPPacket.make_nack_waiting_response(CommandRunner.seq_number(runner), 3)
+    queued_response = ZIPPacket.make_nack_waiting_response(CommandRunner.seq_number(runner), 30)
 
     report =
-      Report.new(:inflight, :queued_delay, 1, command_ref: ref, queued: true, queued_delay: 3)
+      Report.new(:inflight, :queued_delay, 1, command_ref: ref, queued: true, queued_delay: 30)
 
     assert {self(), {report, command_list}} ==
              CommandList.response_for_zip_packet(command_list, queued_response)

--- a/test/grizzly/connections/sync_connection_test.exs
+++ b/test/grizzly/connections/sync_connection_test.exs
@@ -4,7 +4,6 @@ defmodule Grizzly.Connections.SyncConnectionTest do
   alias Grizzly.{Connection, Report}
   alias Grizzly.Connections.SyncConnection
   alias Grizzly.ZWave.Commands.SwitchBinaryGet
-  alias GrizzlyTest.Utils
 
   setup do
     # establish the connections for the tests
@@ -33,7 +32,7 @@ defmodule Grizzly.Connections.SyncConnectionTest do
     # 102 will always respond with nack waiting with 2 seconds
     assert {:ok,
             %Report{status: :inflight, type: :queued_delay, queued_delay: 2, queued: true} =
-              report} = SyncConnection.send_command(102, command)
+              report} = SyncConnection.send_command(102, command, timeout: 1000)
 
     ref = report.command_ref
 


### PR DESCRIPTION
We were treating nack_responses to queued commands the same way as for
non-queued commands. That is, we were attempting to reply to the caller
using `GenServer.reply`. However, when a command is queued, we use
`GenServer.reply` to send a `:queued_delay` report to the caller.

When `Grizzly.send_command` returns a `:queued_delay` report, the caller
is supposed to receive the final result as a message to its mailbox,
which wasn't happening.

This PR introduces the following behavioral changes when receiving a
nack+waiting response:

* If the nack+waiting frame's expected delay is less than the command
  timeout (default 15s), `Grizzly.send_command` will continue to block
  until a response is received or until the timeout is reached. If the
  timeout is reached and the expected delay has not been, the command
  will be queued and treated as queued commands are.
* If the nack+waiting frame's expected delay is longer than the command
  timeout, `Grizzly.send_command` will queue the command and return a
  reference, which should be handled as per the existing implementation.
* Additional nack+waiting frames will extend the command timeout until a
  response is received or we stop receiving nack+waiting updates. When
  that occurs, a timeout report will be delivered to the calling process.
