### PR TITLE
Allow `:mode` option in `Grizzly.send_command/4`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 import Config
 
-config :logger, level: :info
+config :logger, level: :debug
 
 if config_env() == :test do
   config :junit_formatter, report_dir: File.cwd!()


### PR DESCRIPTION
This allows callers to force Grizzly to send a command in async mode by
calling `Grizzly.send_command(node, :command, params, mode: :async)`.

The `:mode` option is now passed through from `Grizzly.send_command/4`
to `Grizzly.Connection.open/2`. `Grizzly.Connection.send_command/3` has
had its `:type` option renamed to `:mode` for consistency (`:type` will
be used as a fallback to maintain backwards compatibility).
