### PR TITLE
Trace prints command binary exactly as received

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,6 @@ workflows:
               image-tag:
                 - 1.15.0-erlang-26.0.1-alpine-3.18.2
                 - 1.14.3-erlang-25.2.3-alpine-3.18.0
-                - 1.13.4-erlang-25.3.2-alpine-3.18.0
       - lint:
           image-tag: 1.15.0-erlang-26.0.1-alpine-3.18.2
           requires:
@@ -129,4 +128,3 @@ workflows:
               image-tag:
                 - 1.15.0-erlang-26.0.1-alpine-3.18.2
                 - 1.14.3-erlang-25.2.3-alpine-3.18.0
-                - 1.13.4-erlang-25.3.2-alpine-3.18.0

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Grizzly.MixProject do
     [
       app: :grizzly,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/grizzly/trace/record_test.exs
+++ b/test/grizzly/trace/record_test.exs
@@ -12,23 +12,26 @@ defmodule Grizzly.Trace.RecordTest do
     record = Record.new(binary, src: "192.168.0.1", dest: "192.168.0.2")
 
     expected_string =
-      "#{Time.to_string(record.timestamp)} #{record.src} #{record.dest} 1   switch_binary_set <<255>>"
+      "#{Time.to_string(record.timestamp)} #{record.src} #{record.dest} 1   switch_binary_set <<37, 1, 255>>"
 
     assert expected_string == Record.to_string(record)
   end
 
   test "decodes NodeAddDSKReport for S2 unauthenticated device without crashing" do
+    zip_packet_binary = <<35, 2, 0, 208, 42, 0, 0, 5, 132, 2, 4, 0>>
+
+    command_binary =
+      <<52, 19, 123, 0, 110, 113, 215, 70, 212, 90, 35, 31, 65, 21, 237, 23, 121, 95, 97, 122>>
+
     trace = %Grizzly.Trace.Record{
       src: "[fd00:bbbb::1]:41230",
       dest: "[fd00:aaaa::2]:41230",
-      binary:
-        <<35, 2, 0, 208, 42, 0, 0, 5, 132, 2, 4, 0, 52, 19, 123, 0, 110, 113, 215, 70, 212, 90,
-          35, 31, 65, 21, 237, 23, 121, 95, 97, 122>>,
+      binary: zip_packet_binary <> command_binary,
       timestamp: ~T[21:11:41.766545]
     }
 
     expected_string =
-      "21:11:41.766545 [fd00:bbbb::1]:41230 [fd00:aaaa::2]:41230 42  node_add_dsk_report <<123, 0, 110, 113, 215, 70, 212, 90, 35, 31, 65, 21, 237, 23, 121, 95, 97, 122>>"
+      "21:11:41.766545 [fd00:bbbb::1]:41230 [fd00:aaaa::2]:41230 42  node_add_dsk_report #{inspect(command_binary)}"
 
     assert expected_string == Record.to_string(trace)
   end


### PR DESCRIPTION
Previously, the `:text` trace format printed command parameters by
re-encoding them using the command module. This had two major issues:

1. There are many commands that controllers do not typically send, and
   thus Grizzly does not encode except when printing traces. We were
   occasionally running into cases where we could decode a command but
   hit bug when re-encoding it.
2. There are some commands whose encoding and decoding functions are not
   invertable. This can be due to amgibuity between command class
   versions in the spec or because of allowances made for devices that
   fail to follow the spec. In the latter case, it is particularly
   important that traces print the command binary exactly as it was
   received.

Going forward, the `:text` trace format will print the full command
binary (including the command class and command bytes) exactly as
received. Z/IP Packet encapsulation will be removed unless there is an
error extracting the command from the received binary, in which case the
binary will be printed exactly as received including any encapsulation.
