### PR TITLE
Make network management command arguments more consistent

### DIFF
--- a/lib/grizzly/network.ex
+++ b/lib/grizzly/network.ex
@@ -32,10 +32,11 @@ defmodule Grizzly.Network do
   """
   @spec get_node_ids([opt()]) :: Grizzly.send_command_response()
   def get_node_ids(opts \\ []) do
-    seq_number = opts[:seq_number] || SeqNumber.get_and_inc()
-    node_id = node_id_from_opts(opts)
+    {param_opts, send_command_opts} = Keyword.split(opts, [:seq_number, :node_id])
+    seq_number = param_opts[:seq_number] || SeqNumber.get_and_inc()
+    node_id = node_id_from_opts(param_opts)
 
-    Grizzly.send_command(node_id, :node_list_get, seq_number: seq_number)
+    Grizzly.send_command(node_id, :node_list_get, [seq_number: seq_number], send_command_opts)
   end
 
   @doc """
@@ -108,10 +109,16 @@ defmodule Grizzly.Network do
   @spec delete_node_provisioning(Grizzly.ZWave.DSK.t(), [opt()]) ::
           Grizzly.send_command_response()
   def delete_node_provisioning(dsk, opts \\ []) do
-    seq_number = SeqNumber.get_and_inc()
-    node_id = node_id_from_opts(opts)
+    {param_opts, send_command_opts} = Keyword.split(opts, [:seq_number, :node_id])
+    seq_number = param_opts[:seq_number] || SeqNumber.get_and_inc()
+    node_id = node_id_from_opts(param_opts)
 
-    Grizzly.send_command(node_id, :node_provisioning_delete, seq_number: seq_number, dsk: dsk)
+    Grizzly.send_command(
+      node_id,
+      :node_provisioning_delete,
+      [seq_number: seq_number, dsk: dsk],
+      send_command_opts
+    )
   end
 
   @doc """
@@ -126,10 +133,16 @@ defmodule Grizzly.Network do
   @spec get_node_provisioning(Grizzly.ZWave.DSK.t(), [opt()]) ::
           Grizzly.send_command_response()
   def get_node_provisioning(dsk, opts \\ []) do
-    seq_number = SeqNumber.get_and_inc()
-    node_id = node_id_from_opts(opts)
+    {param_opts, send_command_opts} = Keyword.split(opts, [:seq_number, :node_id])
+    seq_number = param_opts[:seq_number] || SeqNumber.get_and_inc()
+    node_id = node_id_from_opts(param_opts)
 
-    Grizzly.send_command(node_id, :node_provisioning_get, seq_number: seq_number, dsk: dsk)
+    Grizzly.send_command(
+      node_id,
+      :node_provisioning_get,
+      [seq_number: seq_number, dsk: dsk],
+      send_command_opts
+    )
   end
 
   @doc """
@@ -147,15 +160,15 @@ defmodule Grizzly.Network do
           [opt()]
         ) :: Grizzly.send_command_response()
   def set_node_provisioning(dsk, meta_extensions, opts \\ []) do
-    seq_number = SeqNumber.get_and_inc()
-    node_id = node_id_from_opts(opts)
+    {param_opts, send_command_opts} = Keyword.split(opts, [:seq_number, :node_id])
+    seq_number = param_opts[:seq_number] || SeqNumber.get_and_inc()
+    node_id = node_id_from_opts(param_opts)
 
     Grizzly.send_command(
       node_id,
       :node_provisioning_set,
-      seq_number: seq_number,
-      dsk: dsk,
-      meta_extensions: meta_extensions
+      [seq_number: seq_number, dsk: dsk, meta_extensions: meta_extensions],
+      send_command_opts
     )
   end
 
@@ -184,14 +197,15 @@ defmodule Grizzly.Network do
   """
   @spec list_node_provisionings(integer(), [opt()]) :: Grizzly.send_command_response()
   def list_node_provisionings(remaining_counter, opts \\ []) do
-    seq_number = SeqNumber.get_and_inc()
-    node_id = node_id_from_opts(opts)
+    {param_opts, send_command_opts} = Keyword.split(opts, [:seq_number, :node_id])
+    seq_number = param_opts[:seq_number] || SeqNumber.get_and_inc()
+    node_id = node_id_from_opts(param_opts)
 
     Grizzly.send_command(
       node_id,
       :node_provisioning_list_iteration_get,
-      seq_number: seq_number,
-      remaining_counter: remaining_counter
+      [seq_number: seq_number, remaining_counter: remaining_counter],
+      send_command_opts
     )
   end
 
@@ -207,20 +221,33 @@ defmodule Grizzly.Network do
   @spec remove_failed_node([opt()]) ::
           Grizzly.send_command_response()
   def remove_failed_node(opts \\ []) do
-    seq_number = SeqNumber.get_and_inc()
-    node_id = node_id_from_opts(opts)
+    {param_opts, send_command_opts} = Keyword.split(opts, [:seq_number, :node_id])
+    seq_number = param_opts[:seq_number] || SeqNumber.get_and_inc()
+    node_id = node_id_from_opts(param_opts)
 
-    Grizzly.send_command(:gateway, :failed_node_remove, seq_number: seq_number, node_id: node_id)
+    Grizzly.send_command(
+      :gateway,
+      :failed_node_remove,
+      [seq_number: seq_number, node_id: node_id],
+      send_command_opts
+    )
   end
 
   @doc """
   Get the list of ids of all failed nodes.
   """
-  @spec report_failed_node_ids() :: {:ok, [Grizzly.ZWave.node_id()]} | {:error, atom}
-  def report_failed_node_ids() do
-    seq_number = Grizzly.SeqNumber.get_and_inc()
+  @spec report_failed_node_ids([opt()]) :: {:ok, [Grizzly.ZWave.node_id()]} | {:error, atom}
+  def report_failed_node_ids(opts \\ []) do
+    {param_opts, send_command_opts} = Keyword.split(opts, [:seq_number, :node_id])
+    seq_number = param_opts[:seq_number] || SeqNumber.get_and_inc()
+    node_id = node_id_from_opts(param_opts)
 
-    case Grizzly.send_command(1, :failed_node_list_get, seq_number: seq_number) do
+    case Grizzly.send_command(
+           node_id,
+           :failed_node_list_get,
+           [seq_number: seq_number],
+           send_command_opts
+         ) do
       {:ok,
        %Grizzly.Report{
          command: %Grizzly.ZWave.Command{
@@ -266,10 +293,16 @@ defmodule Grizzly.Network do
   @spec request_network_update([opt()]) ::
           Grizzly.send_command_response()
   def request_network_update(opts \\ []) do
-    seq_number = SeqNumber.get_and_inc()
-    node_id = node_id_from_opts(opts)
+    {param_opts, send_command_opts} = Keyword.split(opts, [:seq_number, :node_id])
+    seq_number = param_opts[:seq_number] || SeqNumber.get_and_inc()
+    node_id = node_id_from_opts(param_opts)
 
-    Grizzly.send_command(node_id, :network_update_request, seq_number: seq_number)
+    Grizzly.send_command(
+      node_id,
+      :network_update_request,
+      [seq_number: seq_number],
+      send_command_opts
+    )
   end
 
   defp node_id_from_opts(opts) do

--- a/lib/grizzly/zwave/commands/node_info_cached_get.ex
+++ b/lib/grizzly/zwave/commands/node_info_cached_get.ex
@@ -28,7 +28,7 @@ defmodule Grizzly.ZWave.Commands.NodeInfoCachedGet do
   will be 2 ^ number minutes. So if you pass the number `4` the receiving
   Z-Wave device will consider that 16 minutes.
 
-  Two other options are `:infinite` and `:force_update`. Where `:infinite`
+  Two other options are `:infinity` and `:force_update`. Where `:infinity`
   means that the cache will not be freshed regardless of how old the data is
   and where `:force_update` means that no matter the age of the cached node
   data the cache will attempt to be updated.
@@ -41,7 +41,7 @@ defmodule Grizzly.ZWave.Commands.NodeInfoCachedGet do
 
   @behaviour Grizzly.ZWave.Command
 
-  @type max_age() :: 1..14 | :infinite | :force_update
+  @type max_age() :: 1..14 | :infinity | :force_update
 
   @type param() ::
           {:seq_number, Grizzly.seq_number()}
@@ -100,12 +100,12 @@ defmodule Grizzly.ZWave.Commands.NodeInfoCachedGet do
 
   @spec encode_max_age(max_age()) :: 0..15
   def encode_max_age(n) when n > 0 and n < 15, do: n
-  def encode_max_age(:infinite), do: 15
+  def encode_max_age(:infinity), do: 15
   def encode_max_age(:force_update), do: 0
 
   @spec decode_max_age(byte()) :: {:ok, max_age()} | {:error, DecodeError.t()}
   def decode_max_age(0), do: {:ok, :force_update}
-  def decode_max_age(15), do: {:ok, :infinite}
+  def decode_max_age(15), do: {:ok, :infinity}
   def decode_max_age(n) when n > 0 and n < 15, do: {:ok, n}
 
   def decode_max_age(n),


### PR DESCRIPTION
* Most functions in `Grizzly.Network` and `Grizzly.Node` now allow
  specifying send command options (`t:Grizzly.command_opt/0`)
* `Grizzly.Node.get_info/2` now supports specifying the max age
  parameter
* Node info cached get's max age parameter now uses `:infinity` instead
  of `:infinite` to be more consistent with Elixir's standard library
