### PR TITLE
Fix decoding of meter type in Meter Reports

### DIFF
--- a/lib/grizzly/zwave/commands/meter_report.ex
+++ b/lib/grizzly/zwave/commands/meter_report.ex
@@ -53,8 +53,8 @@ defmodule Grizzly.ZWave.Commands.MeterReport do
   @impl true
   @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
   def decode_params(
-        <<_::size(3), meter_type_byte::size(5), precision::size(3), scale_byte::size(2),
-          size::size(3), int_value::size(size)-unit(8), _::binary>>
+        <<meter_type_byte::size(8), precision::size(3), scale_byte::size(2), size::size(3),
+          int_value::size(size)-unit(8), _::binary>>
       ) do
     with {:ok, meter_type} <- decode_meter_type(meter_type_byte),
          {:ok, scale} <- decode_meter_scale(scale_byte, meter_type) do


### PR DESCRIPTION
All versions of the Meter command class specify this field as a full
byte, not 5 bits.
