### PR TITLE
Fix `:ack_request` in response to AsyncConnection command

### DIFF
--- a/lib/grizzly/command_handlers/wait_report.ex
+++ b/lib/grizzly/command_handlers/wait_report.ex
@@ -23,7 +23,9 @@ defmodule Grizzly.CommandHandlers.WaitReport do
   @spec handle_command(Command.t(), state()) ::
           {:continue, state} | {:complete, Command.t()}
   def handle_command(command, state) do
-    if state.complete_report == :any or command.name == state.complete_report do
+    expected? = not is_nil(command) and command.name == state.complete_report
+
+    if state.complete_report == :any or expected? do
       {:complete, command}
     else
       {:continue, state}


### PR DESCRIPTION
Using `mode: :async` can potentially result in Z/IP Gateway requesting and `ACK` response which was previously unhandled. This would eventually crash a CommandRunner process which incorrectly attempts to run this as a command

This fixes by adding in ack_request handling in AsyncConnection to match how SyncConnection is handling