### PR TITLE
Fix response handler for Multi Channel Association Get

### DIFF
--- a/lib/grizzly/unsolicited_server/response_handler.ex
+++ b/lib/grizzly/unsolicited_server/response_handler.ex
@@ -204,14 +204,18 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandler do
           MultiChannelAssociationReport.new(
             grouping_identifier: 1,
             max_nodes_supported: 1,
-            nodes: []
+            nodes: [],
+            reports_to_follow: 0,
+            node_endpoints: []
           )
 
         association ->
           MultiChannelAssociationReport.new(
             grouping_identifier: association.grouping_id,
             max_nodes_supported: 1,
-            nodes: association.node_ids
+            nodes: association.node_ids,
+            reports_to_follow: 0,
+            node_endpoints: []
           )
       end
 

--- a/lib/grizzly/zwave/commands/multi_channel_association_report.ex
+++ b/lib/grizzly/zwave/commands/multi_channel_association_report.ex
@@ -54,7 +54,7 @@ defmodule Grizzly.ZWave.Commands.MultiChannelAssociationReport do
     node_endpoints = Command.param!(command, :node_endpoints)
 
     if Enum.empty?(node_endpoints) do
-      <<Command.param!(command, :grouping_identifier)>> <> nodes_bin
+      <<grouping_identifier, max_nodes_supported, reports_to_follow>> <> nodes_bin
     else
       encoded_node_endpoints = MultiChannelAssociation.encode_node_endpoints(node_endpoints)
 

--- a/test/grizzly/zwave/commands/multi_channel_association_report_test.exs
+++ b/test/grizzly/zwave/commands/multi_channel_association_report_test.exs
@@ -43,7 +43,7 @@ defmodule Grizzly.ZWave.Commands.MultiChannelAssociationReportTest do
       ]
 
       {:ok, command} = MultiChannelAssociationReport.new(params)
-      expected_binary = <<0x02, 0x04, 0x05, 0x06>>
+      expected_binary = <<0x02, 0x0A, 0x00, 0x04, 0x05, 0x06>>
       assert expected_binary == MultiChannelAssociationReport.encode_params(command)
     end
 


### PR DESCRIPTION
We weren't providing all of the required parameters when constructing
the Multi Channel Association Report response. Additionally, the
encoding of that command was incorrect in cases where the controller has
zero node endpoints (so always).
