### PR TITLE
Z/IP Gateway ready checker waits for initial node list report

### DIFF
--- a/lib/grizzly/zipgateway/ready_checker.ex
+++ b/lib/grizzly/zipgateway/ready_checker.ex
@@ -1,39 +1,102 @@
 defmodule Grizzly.ZIPGateway.ReadyChecker do
   @moduledoc false
 
-  # A process that runs at the start of the Grizzly supervisor to when the
-  # zipgateway is up and running.
+  @ready_timeout :timer.seconds(60)
+
+  # Waits for Z/IP Gateway to signal its readiness by waiting for a node list
+  # report. If 60 seconds pass and we haven't received the node list report,
+  # we'll try to solicit one by sending a Node List Get. If that succeeds,
+  # we'll signal that we're ready.
 
   use GenServer, restart: :transient
 
-  alias Grizzly.Connection
+  require Logger
 
   @type init_arg() :: {:status_reporter, module()}
 
+  @doc """
+  Returns true if Z/IP Gateway has reported that it is ready.
+  """
+  @spec ready?(GenServer.server()) :: boolean()
+  def ready?(server \\ __MODULE__) do
+    GenServer.call(server, :ready?)
+  end
+
   @spec start_link([init_arg()]) :: GenServer.on_start()
   def start_link(args) do
-    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+    {name, args} = Keyword.pop(args, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, args, name: name)
   end
 
   @impl GenServer
   def init(args) do
-    {:ok, %{reporter: args[:status_reporter]}, {:continue, :try_connect}}
+    Grizzly.subscribe_command(:node_list_report)
+
+    state = %{
+      reporter: args[:status_reporter],
+      started_at: System.monotonic_time(),
+      ready?: false
+    }
+
+    Process.send_after(self(), :check_ready, @ready_timeout)
+
+    {:ok, state}
   end
 
   @impl GenServer
-  def handle_continue(:try_connect, state) do
-    case Connection.open(:gateway) do
-      {:ok, _} ->
+  def handle_call(:ready?, _from, state) do
+    {:reply, state.ready?, state}
+  end
+
+  @impl GenServer
+  def handle_info({:grizzly, :report, _report}, %{ready?: true} = state) do
+    {:noreply, state}
+  end
+
+  def handle_info({:grizzly, :report, %Grizzly.Report{command: command}} = report, state) do
+    Logger.info("[Grizzly.ZIPGateway.ReadyChecker] received report #{inspect(report)}")
+
+    if command.name == :node_list_report do
+      {:noreply, ready(state)}
+    else
+      {:noreply, state}
+    end
+  end
+
+  def handle_info(:check_ready, %{ready?: true} = state), do: {:noreply, state}
+
+  def handle_info(:check_ready, state) do
+    case Grizzly.Network.get_all_node_ids() do
+      {:ok, [_node_1 | _tail]} ->
+        # If we got here, then we somehow missed the node list report, so that's awkward.
+        Logger.warning(
+          "[Grizzly.ZIPGateway.ReadyChecker] Timed out waiting for node list but Z/IP Gateway looks ready anyway."
+        )
+
+        {:noreply, ready(state)}
+
+      {:error, reason} ->
+        Logger.error(
+          "[Grizzly.ZIPGateway.ReadyChecker] Timed out waiting for node list and test command failed: #{inspect(reason)}"
+        )
+
+        Process.send_after(self(), :check_ready, @ready_timeout)
+        {:noreply, state}
+    end
+  end
+
+  defp ready(state) do
+    cond do
+      is_function(state.reporter, 0) ->
+        state.reporter.()
+
+      function_exported?(state.reporter, :ready, 0) ->
         state.reporter.ready()
 
-        {:stop, :normal, state}
-
-      {:error, _reason} ->
-        # give a little breathing space
-        :timer.sleep(500)
-
-        # try again
-        {:noreply, state, {:continue, :try_connect}}
+      true ->
+        :ok
     end
+
+    %{state | ready?: true}
   end
 end

--- a/lib/grizzly/zipgateway/supervisor.ex
+++ b/lib/grizzly/zipgateway/supervisor.ex
@@ -77,6 +77,7 @@ defmodule Grizzly.ZIPGateway.Supervisor do
          options.zipgateway_binary,
          ["-c", options.zipgateway_config_path, "-s", options.serial_port],
          [
+           name: Grizzly.ZIPGateway.Daemon,
            cd: priv,
            log_output: :debug,
            log_transform: &zipgateway_log_transform/1,

--- a/test/grizzly/zipgateway/ready_checker_test.exs
+++ b/test/grizzly/zipgateway/ready_checker_test.exs
@@ -1,0 +1,35 @@
+defmodule Grizzly.ZIPGateway.ReadyCheckerTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZIPGateway.ReadyChecker
+
+  @report {:grizzly, :report,
+           %Grizzly.Report{
+             status: :complete,
+             type: :unsolicited,
+             node_id: 1,
+             command: %{name: :node_list_report}
+           }}
+
+  test "ready? returns false when not ready", ctx do
+    ready_checker = start_supervised!({ReadyChecker, [name: ctx.test]})
+
+    refute ReadyChecker.ready?(ready_checker)
+
+    send(ready_checker, @report)
+    assert ReadyChecker.ready?(ready_checker)
+  end
+
+  test "notifies when ready", ctx do
+    pid = self()
+
+    on_ready = fn ->
+      send(pid, :received_ready)
+    end
+
+    ready_checker = start_supervised!({ReadyChecker, [name: ctx.test, status_reporter: on_ready]})
+
+    send(ready_checker, @report)
+    assert_receive :received_ready
+  end
+end


### PR DESCRIPTION
Z/IP Gateway sends an unsolicited Node List Report when it is far enough
along in its initialization process to receive commands. Instead of
testing that we can merely open a connection, we'll wait for that
signal.

If we don't receive it after 60 seconds (and every 60 seconds thereafter
until success), we'll try to get the node list ourselves.
