### PR TITLE
Reply to unsolicited commands on the same DTLS connection

### DIFF
--- a/lib/grizzly/transports/DTLS.ex
+++ b/lib/grizzly/transports/DTLS.ex
@@ -184,7 +184,7 @@ defmodule Grizzly.Transports.DTLS do
 
     case :ssl.transport_accept(socket) do
       {:ok, socket} ->
-        {:ok, Transport.assigns(transport, :accept_socket, socket)}
+        {:ok, Transport.assigns(transport, :socket, socket)}
 
       error ->
         error
@@ -193,11 +193,11 @@ defmodule Grizzly.Transports.DTLS do
 
   @impl Grizzly.Transport
   def handshake(transport) do
-    accept_socket = Transport.assign(transport, :accept_socket)
+    socket = Transport.assign(transport, :socket)
 
-    case :ssl.handshake(accept_socket) do
-      {:ok, _handshake_socket} ->
-        {:ok, transport}
+    case :ssl.handshake(socket) do
+      {:ok, socket} ->
+        {:ok, Transport.assigns(transport, :socket, socket)}
 
       error ->
         error

--- a/lib/grizzly/zwave/commands/zip_packet.ex
+++ b/lib/grizzly/zwave/commands/zip_packet.ex
@@ -155,7 +155,17 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket do
 
   @spec ack_response?(Command.t()) :: boolean()
   def ack_response?(command) do
-    Command.param!(command, :flag) == :ack_response
+    Command.param(command, :flag, nil) == :ack_response
+  end
+
+  @spec nack_response?(Command.t()) :: boolean()
+  def nack_response?(command) do
+    Command.param(command, :flag, nil) == :nack_response
+  end
+
+  @spec nack_waiting?(Command.t()) :: boolean()
+  def nack_waiting?(command) do
+    Command.param(command, :flag, nil) == :nack_waiting
   end
 
   @spec make_ack_response(ZWave.seq_number(), keyword()) :: Command.t()


### PR DESCRIPTION
Previously, we were replying to unsolicited commands on a new or
already-established DTLS connection via `Grizzly.send_command` or
`Grizzly.send_binary`.

This frequently resulted in Z/IP Gateway sending the reply from a
different virtual node ID (and potentially incurring a fresh S2 nonce
exchange).

This also fixes a long-standing bug where any replies sent from the
unsolicited server were sent using the pre-handshake socket, which
resulted in Z/IP Gateway invalidating the connection and having to
open a new one.
