### PR TITLE
Execute external callbacks in Tasks

### DIFF
--- a/lib/grizzly/status_reporter.ex
+++ b/lib/grizzly/status_reporter.ex
@@ -27,10 +27,10 @@ defmodule Grizzly.StatusReporter do
   After this callback is called the implementor can assume the it is safe to
   access the Z-Wave network through Grizzly.
   """
-  @callback ready() :: :ok
+  @callback ready() :: any()
 
   @doc """
   This callback is executed during a firmware update of the Z-Wave module
   """
-  @callback zwave_firmware_update_status(zwave_firmware_status()) :: :ok
+  @callback zwave_firmware_update_status(zwave_firmware_status()) :: any()
 end

--- a/lib/grizzly/supervisor.ex
+++ b/lib/grizzly/supervisor.ex
@@ -209,6 +209,7 @@ defmodule Grizzly.Supervisor do
 
   defp children(options) do
     [
+      {Task.Supervisor, name: Grizzly.TaskSupervisor},
       # According to Z-Wave specification we need to have a global
       # sequence number counter that starts at a random number between
       # 0 and 0xFF (255)

--- a/lib/grizzly/zipgateway/ready_checker.ex
+++ b/lib/grizzly/zipgateway/ready_checker.ex
@@ -86,16 +86,19 @@ defmodule Grizzly.ZIPGateway.ReadyChecker do
   end
 
   defp ready(state) do
-    cond do
-      is_function(state.reporter, 0) ->
-        state.reporter.()
+    _ =
+      Task.Supervisor.start_child(Grizzly.TaskSupervisor, fn ->
+        cond do
+          is_function(state.reporter, 0) ->
+            state.reporter.()
 
-      function_exported?(state.reporter, :ready, 0) ->
-        state.reporter.ready()
+          function_exported?(state.reporter, :ready, 0) ->
+            state.reporter.ready()
 
-      true ->
-        :ok
-    end
+          true ->
+            :ok
+        end
+      end)
 
     %{state | ready?: true}
   end

--- a/lib/grizzly/zwave_firmware.ex
+++ b/lib/grizzly/zwave_firmware.ex
@@ -142,7 +142,12 @@ defmodule Grizzly.ZwaveFirmware do
   end
 
   defp report(options, status) do
-    # Report the firmware update status
-    options.status_reporter.zwave_firmware_update_status(status)
+    _ =
+      Task.Supervisor.start_child(Grizzly.TaskSupervisor, fn ->
+        # Report the firmware update status
+        options.status_reporter.zwave_firmware_update_status(status)
+      end)
+
+    :ok
   end
 end

--- a/test/grizzly/zipgateway/ready_checker_test.exs
+++ b/test/grizzly/zipgateway/ready_checker_test.exs
@@ -32,4 +32,15 @@ defmodule Grizzly.ZIPGateway.ReadyCheckerTest do
     send(ready_checker, @report)
     assert_receive :received_ready
   end
+
+  test "exception in callback does not crash ReadyChecker", ctx do
+    on_ready = fn ->
+      raise "expected error"
+    end
+
+    ready_checker = start_supervised!({ReadyChecker, [name: ctx.test, status_reporter: on_ready]})
+    send(ready_checker, @report)
+
+    assert Process.alive?(ready_checker)
+  end
 end


### PR DESCRIPTION
This prevents crashes or side-effects in external callbacks from
affecting Grizzly processes (and potentially causing crashes).

In one instance, a `Grizzly.StatusReporter` callback was registering
with a pubsub registery, causing `Grizzly.ZIPGateway.ReadyChecker` to
receive messages that it wasn't expecting.
