### PR TITLE
Reports indicate command acknowledgement

### DIFF
--- a/lib/grizzly/connections/async_connection.ex
+++ b/lib/grizzly/connections/async_connection.ex
@@ -259,13 +259,17 @@ defmodule Grizzly.Connections.AsyncConnection do
       report =
         Report.new(:complete, :timeout, grizzly_command.node_id,
           command_ref: grizzly_command.ref,
+          acknowledged: grizzly_command.acknowledged,
           queued: true
         )
 
       send(waiter, {:grizzly, :report, report})
     else
       report =
-        Report.new(:complete, :timeout, grizzly_command.node_id, command_ref: grizzly_command.ref)
+        Report.new(:complete, :timeout, grizzly_command.node_id,
+          command_ref: grizzly_command.ref,
+          acknowledged: grizzly_command.acknowledged
+        )
 
       send(waiter, {:grizzly, :report, report})
     end

--- a/lib/grizzly/connections/sync_connection.ex
+++ b/lib/grizzly/connections/sync_connection.ex
@@ -235,13 +235,17 @@ defmodule Grizzly.Connections.SyncConnection do
       report =
         Report.new(:complete, :timeout, grizzly_command.node_id,
           command_ref: grizzly_command.ref,
+          acknowledged: grizzly_command.acknowledged,
           queued: true
         )
 
       send(pid, {:grizzly, :report, report})
     else
       report =
-        Report.new(:complete, :timeout, grizzly_command.node_id, command_ref: grizzly_command.ref)
+        Report.new(:complete, :timeout, grizzly_command.node_id,
+          command_ref: grizzly_command.ref,
+          acknowledged: grizzly_command.acknowledged
+        )
 
       GenServer.reply(waiter, {:ok, report})
     end

--- a/lib/grizzly/report.ex
+++ b/lib/grizzly/report.ex
@@ -141,7 +141,7 @@ defmodule Grizzly.Report do
     - `:queued` - this flag marks if the command was ever queued before
       completing
     - `:acknowledged` - whether the destination node acknowledged the command.
-      Only valid when the status is `:complete. For commands using the `AckResponse`
+      Only valid when the status is `:complete`. For commands using the `AckResponse`
       command handler, this field will be true if `type` is `:ack_response` and false
       if `type` is `:nack_response`. For other command handlers, it will be true
       if the original command was acknowledged by the destination node (i.e. we

--- a/lib/grizzly/report.ex
+++ b/lib/grizzly/report.ex
@@ -140,10 +140,22 @@ defmodule Grizzly.Report do
     - `:node_id` - the node the report is responding from
     - `:queued` - this flag marks if the command was ever queued before
       completing
+    - `:acknowledged` - whether the destination node acknowledged the command.
+      Only valid when the status is `:complete. For commands using the `AckResponse`
+      command handler, this field will be true if `type` is `:ack_response` and false
+      if `type` is `:nack_response`. For other command handlers, it will be true
+      if the original command was acknowledged by the destination node (i.e. we
+      received an ACK Response from Z/IP Gateway). This is useful for differentiating
+      report timeouts where the destination received the command but didn't send
+      a report (e.g. it doesn't support the command or command version, it considered
+      some or all of the payload invalid, etc.) from other causes. Other types of
+      timeouts typically mean the timeout was too short and Grizzly had to return
+      before Z/IP Gateway could send a response
   """
   @type t() :: %__MODULE__{
           status: status(),
           type: type(),
+          acknowledged: boolean(),
           command: Command.t() | nil,
           transmission_stats: [transmission_stat()],
           queued_delay: non_neg_integer(),
@@ -169,6 +181,7 @@ defmodule Grizzly.Report do
           | {:command, Command.t()}
           | {:command_ref, reference()}
           | {:queued, boolean()}
+          | {:acknowledged, boolean()}
 
   @typedoc """
   The RSSI value between each device that command had to route through to get
@@ -219,7 +232,8 @@ defmodule Grizzly.Report do
             command_ref: nil,
             node_id: nil,
             type: nil,
-            queued: false
+            queued: false,
+            acknowledged: false
 
   @doc """
   Make a new `Grizzly.Report`
@@ -234,7 +248,8 @@ defmodule Grizzly.Report do
       transmission_stats: Keyword.get(opts, :transmission_stats, []),
       queued_delay: Keyword.get(opts, :queued_delay, 0),
       command: Keyword.get(opts, :command),
-      queued: Keyword.get(opts, :queued, false)
+      queued: Keyword.get(opts, :queued, false),
+      acknowledged: Keyword.get(opts, :acknowledged, false)
     }
   end
 end

--- a/test/grizzly/commands/command_runner_test.exs
+++ b/test/grizzly/commands/command_runner_test.exs
@@ -130,7 +130,8 @@ defmodule Grizzly.Commands.CommandRunnerTest do
     report =
       Report.new(:complete, :ack_response, 1,
         queued: true,
-        command_ref: command_ref
+        command_ref: command_ref,
+        acknowledged: true
       )
 
     assert report ==
@@ -156,7 +157,11 @@ defmodule Grizzly.Commands.CommandRunnerTest do
 
     ack_response = ZIPPacket.make_ack_response(CommandRunner.seq_number(runner))
 
-    assert Report.new(:complete, :ack_response, 1, command_ref: command_ref, queued: true) ==
+    assert Report.new(:complete, :ack_response, 1,
+             command_ref: command_ref,
+             queued: true,
+             acknowledged: true
+           ) ==
              CommandRunner.handle_zip_command(runner, ack_response)
   end
 

--- a/test/grizzly/commands/command_test.exs
+++ b/test/grizzly/commands/command_test.exs
@@ -52,7 +52,7 @@ defmodule Grizzly.Commands.CommandTest do
 
     report = Report.new(:complete, :ack_response, 1, command_ref: grizzly_command.ref)
 
-    assert {report, %Command{grizzly_command | status: :complete}} ==
+    assert {report, %Command{grizzly_command | status: :complete, acknowledged: true}} ==
              Command.handle_zip_command(grizzly_command, ack_response)
   end
 
@@ -99,9 +99,13 @@ defmodule Grizzly.Commands.CommandTest do
     ack_response = ZIPPacket.make_ack_response(grizzly_command.seq_number)
 
     report =
-      Report.new(:complete, :ack_response, 1, command_ref: grizzly_command.ref, queued: true)
+      Report.new(:complete, :ack_response, 1,
+        command_ref: grizzly_command.ref,
+        queued: true,
+        acknowledged: true
+      )
 
-    assert {report, %Command{grizzly_command | status: :complete}} ==
+    assert {report, %Command{grizzly_command | status: :complete, acknowledged: true}} ==
              Command.handle_zip_command(grizzly_command, ack_response)
   end
 


### PR DESCRIPTION
When dealing with timeouts, it was impossible to tell whether the
outgoing command had been acknowledged by the destination node or not.
This adds an `acknowledged` flag to `Grizzly.Report` to indicate such.
This is important in determining the reason for a timeout and whether
failed command should be retried.
