### PR TITLE
Implement Priority Route Set and fix Priority Route Report

### DIFF
--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -412,6 +412,7 @@ defmodule Grizzly.Commands.Table do
       {:clock_set, {Commands.ClockSet, handler: AckResponse}},
 
       # Network Management Installation Maintenance
+      {:priority_route_set, {Commands.PriorityRouteSet, handler: AckResponse}},
       {:priority_route_get,
        {Commands.PriorityRouteGet, handler: {WaitReport, complete_report: :priority_route_report}}},
       {:statistics_get,

--- a/lib/grizzly/zwave/decoder.ex
+++ b/lib/grizzly/zwave/decoder.ex
@@ -179,6 +179,7 @@ defmodule Grizzly.ZWave.Decoder do
       {0x66, 0x08, Commands.BarrierOperatorSignalReport},
 
       # Network management installation maintenance
+      {0x67, 0x01, Commands.PriorityRouteSet},
       {0x67, 0x02, Commands.PriorityRouteGet},
       {0x67, 0x03, Commands.PriorityRouteReport},
       {0x67, 0x04, Commands.StatisticsGet},

--- a/test/grizzly/zwave/commands/priority_route_report_test.exs
+++ b/test/grizzly/zwave/commands/priority_route_report_test.exs
@@ -9,9 +9,9 @@ defmodule Grizzly.ZWave.Commands.PriorityRouteReportTest do
   end
 
   test "encodes params correctly" do
-    params = [node_id: 4, speed: [:"100kbit/s"], type: :last_working_route, repeaters: [5, 6]]
+    params = [node_id: 4, speed: :"100kbit/s", type: :last_working_route, repeaters: [5, 6]]
     {:ok, command} = PriorityRouteReport.new(params)
-    expected_binary = <<0x04, 0x01, 0x05, 0x06, 0x00, 0x00, 0x04>>
+    expected_binary = <<0x04, 0x01, 0x05, 0x06, 0x00, 0x00, 0x03>>
     assert expected_binary == PriorityRouteReport.encode_params(command)
   end
 
@@ -19,7 +19,7 @@ defmodule Grizzly.ZWave.Commands.PriorityRouteReportTest do
     params_binary = <<0x04, 0x01, 0x05, 0x06, 0x00, 0x00, 0x03>>
     {:ok, params} = PriorityRouteReport.decode_params(params_binary)
     assert Keyword.get(params, :node_id) == 4
-    assert Keyword.get(params, :speed) == [:"9.6kbit/s", :"40kbit/s"]
+    assert Keyword.get(params, :speed) == :"100kbit/s"
     assert Keyword.get(params, :type) == :last_working_route
     assert Keyword.get(params, :repeaters) == [5, 6]
   end


### PR DESCRIPTION
Priority Route Report was trying to parse the speed parameter the same
as the neighbor speed bitmask from Statistics Report. They are not the
same.
