### PR TITLE
Outgoing Z/IP Packets ignore install and maintenance header extension

### DIFF
--- a/lib/grizzly/zwave/commands/zip_packet/header_extensions.ex
+++ b/lib/grizzly/zwave/commands/zip_packet/header_extensions.ex
@@ -45,6 +45,10 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions do
 
       :install_and_maintenance_get, bin ->
         bin <> <<0x02, 0x00>>
+
+      # We don't ever need to send this to Z/IP Gateway even if it's specified
+      {:install_and_maintenance_report, _}, bin ->
+        bin
     end)
   end
 


### PR DESCRIPTION
There is no reason to send this header extension to Z/IP Gateway even if
it is specified (usually this happens because header extensions were
copied from an incoming Z/IP Packet).
