### PR TITLE
Suppress DTLS errors for "TLS Alert: unexpected message"

### DIFF
--- a/lib/grizzly/transport_error.ex
+++ b/lib/grizzly/transport_error.ex
@@ -1,7 +1,0 @@
-defmodule Grizzly.TransportError do
-  @moduledoc """
-  Raised on errors in the transport layer.
-  """
-
-  defexception message: nil
-end


### PR DESCRIPTION
The content of the message is not helpful for debugging. Replaced with a
debug log for now. Future investigation will require some inspection
with tcpdump.
