### PR TITLE
Decode state_idle event params for all notification types

### DIFF
--- a/lib/grizzly/zwave/notifications.ex
+++ b/lib/grizzly/zwave/notifications.ex
@@ -987,14 +987,14 @@ defmodule Grizzly.ZWave.Notifications do
     end
   end
 
-  def decode_event_params(:home_security, :state_idle, <<byte::8>>) do
-    case event_from_byte(:home_security, byte) do
+  def decode_event_params(notification_type, :state_idle, <<byte::8>>) do
+    case event_from_byte(notification_type, byte) do
       {:ok, event} ->
         {:ok, [state: event]}
 
       {:error, :invalid_event_byte} ->
         Logger.warning(
-          "[Grizzly] Failed to decode state variable from home_security state_idle event"
+          "[Grizzly] Failed to decode state variable from #{inspect(notification_type)} state_idle event"
         )
 
         {:ok, []}


### PR DESCRIPTION
Every notification type has a state_idle event with a single
parameter indicating which state variable has returned to idle.
