### PR TITLE
Close all DTLS connections on Z/IP Gateway exit

### DIFF
--- a/lib/grizzly/zipgateway/exit_monitor.ex
+++ b/lib/grizzly/zipgateway/exit_monitor.ex
@@ -1,0 +1,22 @@
+defmodule Grizzly.ZIPGateway.ExitMonitor do
+  @moduledoc false
+
+  use GenServer
+
+  def start_link(_ \\ []) do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  @impl GenServer
+  def init(_) do
+    Process.flag(:trap_exit, true)
+    {:ok, []}
+  end
+
+  @impl GenServer
+  def terminate(_reason, _state) do
+    Grizzly.Connections.close_all()
+
+    :ok
+  end
+end


### PR DESCRIPTION
Since these are UDP connections, we have no way of knowing if the other
side has been closed until a keepalive fails.

This doesn't account for the UnsolicitedServer, but it's less of an
issue since it only deals with incoming datagrams. It's still leaking
resources and is something that sould be fixed (but separately).
