### PR TITLE
Correct CC name from multi_command  to multi_cmd

### DIFF
--- a/lib/grizzly/version_reports.ex
+++ b/lib/grizzly/version_reports.ex
@@ -14,7 +14,7 @@ defmodule Grizzly.VersionReports do
     :association_group_info,
     :device_reset_locally,
     :multi_channel_association,
-    :multi_command,
+    :multi_cmd,
     :supervision
   ]
 
@@ -45,7 +45,7 @@ defmodule Grizzly.VersionReports do
     VersionCommandClassReport.new(command_class: name, version: 1)
   end
 
-  def version_report_for(:multi_command = name) do
+  def version_report_for(:multi_cmd = name) do
     VersionCommandClassReport.new(command_class: name, version: 1)
   end
 

--- a/lib/grizzly/zwave/command_classes/multi_command.ex
+++ b/lib/grizzly/zwave/command_classes/multi_command.ex
@@ -12,5 +12,5 @@ defmodule Grizzly.ZWave.CommandClasses.MultiCommand do
   def byte(), do: 0x8F
 
   @impl true
-  def name(), do: :multi_command
+  def name(), do: :multi_cmd
 end

--- a/test/grizzly_test.exs
+++ b/test/grizzly_test.exs
@@ -133,7 +133,7 @@ defmodule Grizzly.Test do
 
     test "multi command" do
       {:ok, report} =
-        Grizzly.send_command(:gateway, :version_command_class_get, command_class: :multi_command)
+        Grizzly.send_command(:gateway, :version_command_class_get, command_class: :multi_cmd)
 
       assert Command.param!(report.command, :version) == 1
     end


### PR DESCRIPTION
The controller reports support for command class `multi_cmd` not `multi_command`.