### PR TITLE
Grizzly supports v3 of Association Group Info CC

### DIFF
--- a/lib/grizzly/version_reports.ex
+++ b/lib/grizzly/version_reports.ex
@@ -30,7 +30,7 @@ defmodule Grizzly.VersionReports do
   end
 
   def version_report_for(:association_group_info = name) do
-    VersionCommandClassReport.new(command_class: name, version: 1)
+    VersionCommandClassReport.new(command_class: name, version: 3)
   end
 
   def version_report_for(:device_reset_locally = name) do

--- a/test/grizzly_test.exs
+++ b/test/grizzly_test.exs
@@ -103,7 +103,7 @@ defmodule Grizzly.Test do
           command_class: :association_group_info
         )
 
-      assert Command.param!(report.command, :version) == 1
+      assert Command.param!(report.command, :version) == 3
     end
 
     test "device reset locally" do


### PR DESCRIPTION
It was set to 1 for the extra command classes.