### PR TITLE
Fix incorrect installation and maintenance header extension name

### DIFF
--- a/lib/grizzly/commands/command.ex
+++ b/lib/grizzly/commands/command.ex
@@ -324,7 +324,7 @@ defmodule Grizzly.Commands.Command do
 
   defp maybe_add_installation_and_maintenance_get(opts, grizzly_command) do
     if grizzly_command.with_transmission_stats do
-      Keyword.put(opts, :header_extensions, [:install_and_maintenance_get])
+      Keyword.put(opts, :header_extensions, [:installation_and_maintenance_get])
     else
       opts
     end

--- a/lib/grizzly/zwave/commands/zip_packet/header_extensions.ex
+++ b/lib/grizzly/zwave/commands/zip_packet/header_extensions.ex
@@ -12,12 +12,14 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions do
     InstallationAndMaintenanceReport
   }
 
+  require Logger
+
   @type encapsulation_format_info :: :crc16 | EncapsulationFormatInfo.security()
 
   @type extension ::
           {:expected_delay, Command.delay_seconds()}
-          | {:install_and_maintenance_report, list()}
-          | :install_and_maintenance_get
+          | {:installation_and_maintenance_report, list()}
+          | :installation_and_maintenance_get
           | {:encapsulation_format_info, [encapsulation_format_info()]}
           | :multicast_addressing
 
@@ -43,11 +45,18 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions do
       :multicast_addressing, bin ->
         bin <> <<0x05, 0x00>>
 
-      :install_and_maintenance_get, bin ->
+      :installation_and_maintenance_get, bin ->
         bin <> <<0x02, 0x00>>
 
       # We don't ever need to send this to Z/IP Gateway even if it's specified
-      {:install_and_maintenance_report, _}, bin ->
+      {:installation_and_maintenance_report, _}, bin ->
+        bin
+
+      extension, bin ->
+        Logger.warning(
+          "[Grizzly] Encoding not supported for Z/IP Packet header extension: #{inspect(extension)}"
+        )
+
         bin
     end)
   end


### PR DESCRIPTION
The fix in #843 did not work because the header is
`:installation_and_maintenance_report`, not
`:install_and_maintenance_report` (copy/pasted from the typespec, which
was wrong to begin with).
