### PR TITLE
Report Serial API status

### DIFF
--- a/lib/grizzly/status_reporter.ex
+++ b/lib/grizzly/status_reporter.ex
@@ -4,6 +4,7 @@ defmodule Grizzly.StatusReporter do
   runtime
   """
 
+  alias Grizzly.ZIPGateway.LogMonitor
   alias Grizzly.ZWaveFirmware
 
   @doc """
@@ -19,4 +20,12 @@ defmodule Grizzly.StatusReporter do
   This callback is executed during a firmware update of the Z-Wave module
   """
   @callback zwave_firmware_update_status(ZWaveFirmware.update_status()) :: any()
+
+  @doc """
+  Called when the Serial API status changes. Only applicable if Grizzly is managing
+  the Z/IP Gateway process.
+  """
+  @callback serial_api_status(LogMonitor.serial_api_status()) :: any()
+
+  @optional_callbacks [serial_api_status: 1]
 end

--- a/lib/grizzly/status_reporter/console.ex
+++ b/lib/grizzly/status_reporter/console.ex
@@ -16,4 +16,15 @@ defmodule Grizzly.StatusReporter.Console do
   def zwave_firmware_update_status(status) do
     Logger.info("[Grizzly] Z-Wave module firmware update status: #{inspect(status)}")
   end
+
+  @impl Grizzly.StatusReporter
+  def serial_api_status(status) do
+    level =
+      case status do
+        :unresponsive -> :error
+        _ -> :info
+      end
+
+    Logger.log(level, "[Grizzly] Z-Wave Serial API status: #{inspect(status)}")
+  end
 end

--- a/lib/grizzly/zipgateway/supervisor.ex
+++ b/lib/grizzly/zipgateway/supervisor.ex
@@ -68,7 +68,7 @@ defmodule Grizzly.ZIPGateway.Supervisor do
     ]
 
     [
-      LogMonitor,
+      {LogMonitor, [status_reporter: options.status_reporter]},
       {BEAMNotify, beam_notify_options},
       zipgateway_process_supervisor_spec(options)
     ]


### PR DESCRIPTION
Inspecting Z/IP Gateway's logs can tell us when there's a problem with
the Z-Wave SAPI. Changes in SAPI status are now reported via
`Grizzly.StatusReporter`.
