### PR TITLE
Catch exits when closing all connections

### DIFF
--- a/lib/grizzly/connections/supervisor.ex
+++ b/lib/grizzly/connections/supervisor.ex
@@ -36,11 +36,17 @@ defmodule Grizzly.Connections.Supervisor do
   """
   @spec close_all_connections() :: :ok
   def close_all_connections() do
-    connections_pids = DynamicSupervisor.which_children(__MODULE__)
+    if GenServer.whereis(__MODULE__) != nil do
+      connections_pids = DynamicSupervisor.which_children(__MODULE__)
 
-    Enum.each(connections_pids, fn {_, connection_pid, _, _} ->
-      :ok = Connection.close(connection_pid)
-    end)
+      Enum.each(connections_pids, fn {_, connection_pid, _, _} ->
+        :ok = Connection.close(connection_pid)
+      end)
+    end
+
+    :ok
+  catch
+    {:exit, {:noproc, _}} -> :ok
   end
 
   @impl DynamicSupervisor


### PR DESCRIPTION
If `Grizzly.Connections.Supervisor` is not running,
`close_all_connections/0` should be a no-op.
