### PR TITLE
Record original command binary in Logger metadata

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -28,7 +28,8 @@
         ### Below are checks we will want to enable at later date ###
         {Credo.Check.Refactor.WithClauses, false},
         {Credo.Check.Refactor.CyclomaticComplexity, false},
-        {Credo.Check.Readability.WithSingleClause, false}
+        {Credo.Check.Readability.WithSingleClause, false},
+        {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig, false}
       ]
     }
   ]


### PR DESCRIPTION
When errors are raised while parsing a command, the original binary
will be included in Logger metadata so that it can be reported to error
monitoring service(s).
