### PR TITLE
Simplify bitmask encoding and decoding

### DIFF
--- a/lib/grizzly/zwave/commands/thermostat_mode_supported_report.ex
+++ b/lib/grizzly/zwave/commands/thermostat_mode_supported_report.ex
@@ -35,13 +35,15 @@ defmodule Grizzly.ZWave.Commands.ThermostatModeSupportedReport do
   def encode_params(command) do
     modes = Command.param!(command, :modes)
 
-    encode_indexed_bitmask(modes, &ThermostatMode.encode_mode/1)
+    modes
+    |> Enum.map(&ThermostatMode.encode_mode/1)
+    |> encode_bitmask()
   end
 
   @impl Grizzly.ZWave.Command
   @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
   def decode_params(binary) do
-    modes = decode_indexed_bitmask(binary, &decode_mode/1)
+    modes = binary |> decode_bitmask() |> Enum.map(&decode_mode/1)
     {:ok, [modes: modes]}
   end
 

--- a/test/grizzly/zwave/commands/thermostat_mode_supported_report_test.exs
+++ b/test/grizzly/zwave/commands/thermostat_mode_supported_report_test.exs
@@ -7,22 +7,22 @@ defmodule Grizzly.ZWave.Commands.ThermostatModeSupportedReportTest do
     {:ok, _command} = ThermostatModeSupportedReport.new(modes: [])
 
     modes = [
-      off: true,
-      heat: true,
-      cool: true,
-      auto: true,
-      auxiliary: true,
-      resume_on: true,
-      fan: true,
-      furnace: true,
-      dry: true,
-      moist: true,
-      auto_changeover: true,
-      energy_heat: true,
-      energy_cool: true,
-      away: true,
-      full_power: true,
-      manufacturer_specific: true
+      :off,
+      :heat,
+      :cool,
+      :auto,
+      :auxiliary,
+      :resume_on,
+      :fan,
+      :furnace,
+      :dry,
+      :moist,
+      :auto_changeover,
+      :energy_heat,
+      :energy_cool,
+      :away,
+      :full_power,
+      :manufacturer_specific
     ]
 
     {:ok, _command} = ThermostatModeSupportedReport.new(modes: modes)
@@ -33,44 +33,35 @@ defmodule Grizzly.ZWave.Commands.ThermostatModeSupportedReportTest do
     assert <<>> = ThermostatModeSupportedReport.encode_params(command)
 
     modes = [
-      off: true,
-      heat: true,
-      cool: true,
-      auto: true,
-      auxiliary: true,
-      resume_on: false,
-      fan: false,
-      furnace: false,
-      dry: false,
-      moist: false,
-      auto_changeover: false,
-      energy_heat: true,
-      energy_cool: true,
-      away: false,
-      full_power: false,
-      manufacturer_specific: false
+      :off,
+      :heat,
+      :cool,
+      :auto,
+      :auxiliary,
+      :energy_heat,
+      :energy_cool
     ]
 
     {:ok, command} = ThermostatModeSupportedReport.new(modes: modes)
     assert <<0x1F, 0x18>> = ThermostatModeSupportedReport.encode_params(command)
 
     modes = [
-      off: true,
-      heat: true,
-      cool: true,
-      auto: true,
-      auxiliary: true,
-      resume_on: true,
-      fan: true,
-      furnace: true,
-      dry: true,
-      moist: true,
-      auto_changeover: true,
-      energy_heat: true,
-      energy_cool: true,
-      away: true,
-      full_power: true,
-      manufacturer_specific: true
+      :off,
+      :heat,
+      :cool,
+      :auto,
+      :auxiliary,
+      :resume_on,
+      :fan,
+      :furnace,
+      :dry,
+      :moist,
+      :auto_changeover,
+      :energy_heat,
+      :energy_cool,
+      :away,
+      :full_power,
+      :manufacturer_specific
     ]
 
     {:ok, command} = ThermostatModeSupportedReport.new(modes: modes)
@@ -80,21 +71,21 @@ defmodule Grizzly.ZWave.Commands.ThermostatModeSupportedReportTest do
   test "decodes params correctly" do
     assert {:ok, [modes: modes]} = ThermostatModeSupportedReport.decode_params(<<0x1F, 0x18>>)
 
-    assert modes[:off]
-    assert modes[:heat]
-    assert modes[:cool]
-    assert modes[:auto]
-    assert modes[:auxiliary]
-    refute modes[:resume_on]
-    refute modes[:fan]
-    refute modes[:furnace]
-    refute modes[:dry]
-    refute modes[:moist]
-    refute modes[:auto_changeover]
-    assert modes[:energy_heat]
-    assert modes[:energy_cool]
-    refute modes[:away]
-    refute modes[:full_power]
-    refute modes[:manufacturer_specific]
+    assert :off in modes
+    assert :heat in modes
+    assert :cool in modes
+    assert :auto in modes
+    assert :auxiliary in modes
+    refute :resume_on in modes
+    refute :fan in modes
+    refute :furnace in modes
+    refute :dry in modes
+    refute :moist in modes
+    refute :auto_changeover in modes
+    assert :energy_heat in modes
+    assert :energy_cool in modes
+    refute :away in modes
+    refute :full_power in modes
+    refute :manufacturer_specific in modes
   end
 end

--- a/test/grizzly/zwave/commands/thermostat_setpoint_supported_report_test.exs
+++ b/test/grizzly/zwave/commands/thermostat_setpoint_supported_report_test.exs
@@ -6,17 +6,17 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReportTest do
   test "creates the command and validates params" do
     params = [
       setpoint_types: [
-        heating: true,
-        cooling: true,
-        furnace: true,
-        dry_air: true,
-        moist_air: true,
-        auto_changeover: true,
-        energy_save_heating: true,
-        energy_save_cooling: true,
-        away_heating: true,
-        away_cooling: true,
-        full_power: true
+        :heating,
+        :cooling,
+        :furnace,
+        :dry_air,
+        :moist_air,
+        :auto_changeover,
+        :energy_save_heating,
+        :energy_save_cooling,
+        :away_heating,
+        :away_cooling,
+        :full_power
       ]
     ]
 
@@ -27,17 +27,12 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReportTest do
     # all the odd bits
     params = [
       setpoint_types: [
-        heating: true,
-        cooling: false,
-        furnace: true,
-        dry_air: false,
-        moist_air: true,
-        auto_changeover: false,
-        energy_save_heating: true,
-        energy_save_cooling: false,
-        away_heating: true,
-        away_cooling: false,
-        full_power: true
+        :heating,
+        :furnace,
+        :moist_air,
+        :energy_save_heating,
+        :away_heating,
+        :full_power
       ]
     ]
 
@@ -50,17 +45,11 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReportTest do
     # all the even bits
     params = [
       setpoint_types: [
-        heating: false,
-        cooling: true,
-        furnace: false,
-        dry_air: true,
-        moist_air: false,
-        auto_changeover: true,
-        energy_save_heating: false,
-        energy_save_cooling: true,
-        away_heating: false,
-        away_cooling: true,
-        full_power: false
+        :cooling,
+        :dry_air,
+        :auto_changeover,
+        :energy_save_cooling,
+        :away_cooling
       ]
     ]
 
@@ -71,7 +60,7 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReportTest do
     assert <<0b01010100, 0b00000101>> == ThermostatSetpointSupportedReport.encode_params(command)
 
     # just heating
-    params = [setpoint_types: [heating: true]]
+    params = [setpoint_types: [:heating]]
 
     {:ok, command} = ThermostatSetpointSupportedReport.new(params)
 
@@ -87,17 +76,12 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReportTest do
                ThermostatSetpointSupportedReport.decode_params(<<0b10101010, 0b10101010>>)
 
       assert setpoint_types == [
-               heating: true,
-               cooling: false,
-               furnace: true,
-               dry_air: false,
-               moist_air: true,
-               auto_changeover: false,
-               energy_save_heating: true,
-               energy_save_cooling: false,
-               away_heating: true,
-               away_cooling: false,
-               full_power: true
+               :heating,
+               :furnace,
+               :moist_air,
+               :energy_save_heating,
+               :away_heating,
+               :full_power
              ]
 
       # even bits are set in both bitmasks
@@ -105,17 +89,11 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReportTest do
                ThermostatSetpointSupportedReport.decode_params(<<0b01010101, 0b01010101>>)
 
       assert setpoint_types == [
-               heating: false,
-               cooling: true,
-               furnace: false,
-               dry_air: true,
-               moist_air: false,
-               auto_changeover: true,
-               energy_save_heating: false,
-               energy_save_cooling: true,
-               away_heating: false,
-               away_cooling: true,
-               full_power: false
+               :cooling,
+               :dry_air,
+               :auto_changeover,
+               :energy_save_cooling,
+               :away_cooling
              ]
 
       # all bits are set
@@ -123,36 +101,24 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReportTest do
                ThermostatSetpointSupportedReport.decode_params(<<0xFF, 0xFF>>)
 
       assert setpoint_types == [
-               heating: true,
-               cooling: true,
-               furnace: true,
-               dry_air: true,
-               moist_air: true,
-               auto_changeover: true,
-               energy_save_heating: true,
-               energy_save_cooling: true,
-               away_heating: true,
-               away_cooling: true,
-               full_power: true
+               :heating,
+               :cooling,
+               :furnace,
+               :dry_air,
+               :moist_air,
+               :auto_changeover,
+               :energy_save_heating,
+               :energy_save_cooling,
+               :away_heating,
+               :away_cooling,
+               :full_power
              ]
 
       # no bits are set
       assert {:ok, setpoint_types: setpoint_types} =
                ThermostatSetpointSupportedReport.decode_params(<<0x0, 0x0>>)
 
-      assert setpoint_types == [
-               heating: false,
-               cooling: false,
-               furnace: false,
-               dry_air: false,
-               moist_air: false,
-               auto_changeover: false,
-               energy_save_heating: false,
-               energy_save_cooling: false,
-               away_heating: false,
-               away_cooling: false,
-               full_power: false
-             ]
+      assert setpoint_types == []
     end
 
     test "just one byte" do
@@ -160,17 +126,13 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReportTest do
                ThermostatSetpointSupportedReport.decode_params(<<0xFF>>)
 
       assert setpoint_types == [
-               heating: true,
-               cooling: true,
-               furnace: true,
-               dry_air: true,
-               moist_air: true,
-               auto_changeover: true,
-               energy_save_heating: true,
-               energy_save_cooling: false,
-               away_heating: false,
-               away_cooling: false,
-               full_power: false
+               :heating,
+               :cooling,
+               :furnace,
+               :dry_air,
+               :moist_air,
+               :auto_changeover,
+               :energy_save_heating
              ]
     end
 
@@ -179,19 +141,7 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointSupportedReportTest do
       assert {:ok, setpoint_types: setpoint_types} =
                ThermostatSetpointSupportedReport.decode_params(<<0x00, 0x00, 0xFF>>)
 
-      assert setpoint_types == [
-               heating: false,
-               cooling: false,
-               furnace: false,
-               dry_air: false,
-               moist_air: false,
-               auto_changeover: false,
-               energy_save_heating: false,
-               energy_save_cooling: false,
-               away_heating: false,
-               away_cooling: false,
-               full_power: false
-             ]
+      assert setpoint_types == []
     end
   end
 end

--- a/test/grizzly/zwave/commands/user_code_capabilities_report_test.exs
+++ b/test/grizzly/zwave/commands/user_code_capabilities_report_test.exs
@@ -14,16 +14,8 @@ defmodule Grizzly.ZWave.Commands.UserCodeCapabilitiesReportTest do
       user_code_checksum_supported?: true,
       multi_user_code_report_supported?: false,
       multi_user_code_set_supported?: false,
-      supported_user_id_statuses: [
-        available: true,
-        occupied: true
-      ],
-      supported_keypad_modes: [
-        lockout: false,
-        normal: true,
-        privacy: true,
-        vacation: false
-      ],
+      supported_user_id_statuses: [:available, :occupied],
+      supported_keypad_modes: [:normal, :privacy],
       supported_keypad_keys: ~c"()*+,-./014567"
     ]
 
@@ -53,18 +45,18 @@ defmodule Grizzly.ZWave.Commands.UserCodeCapabilitiesReportTest do
     refute params[:multi_user_code_report_supported?]
     refute params[:multi_user_code_set_supported?]
 
-    refute params[:supported_user_id_statuses][:available]
-    refute params[:supported_user_id_statuses][:disabled]
-    assert params[:supported_user_id_statuses][:messaging]
-    assert params[:supported_user_id_statuses][:occupied]
-    assert params[:supported_user_id_statuses][:passage]
-    refute Keyword.has_key?(params[:supported_user_id_statuses], :unknown)
+    refute :available in params[:supported_user_id_statuses]
+    refute :disabled in params[:supported_user_id_statuses]
+    assert :messaging in params[:supported_user_id_statuses]
+    assert :occupied in params[:supported_user_id_statuses]
+    assert :passage in params[:supported_user_id_statuses]
+    refute :unknown in params[:supported_user_id_statuses]
 
-    assert params[:supported_keypad_modes][:normal]
-    refute params[:supported_keypad_modes][:vacation]
-    assert params[:supported_keypad_modes][:privacy]
-    refute params[:supported_keypad_modes][:lockout]
-    refute Keyword.has_key?(params[:supported_keypad_modes], :unknown)
+    assert :normal in params[:supported_keypad_modes]
+    refute :vacation in params[:supported_keypad_modes]
+    assert :privacy in params[:supported_keypad_modes]
+    refute :lockout in params[:supported_keypad_modes]
+    refute :unknown in params[:supported_keypad_modes]
 
     assert params[:supported_keypad_keys] == ~c"()*+,-./014567"
   end
@@ -81,16 +73,16 @@ defmodule Grizzly.ZWave.Commands.UserCodeCapabilitiesReportTest do
     refute params[:multi_user_code_report_supported?]
     refute params[:multi_user_code_set_supported?]
 
-    assert params[:supported_user_id_statuses][:available]
-    assert params[:supported_user_id_statuses][:disabled]
-    assert params[:supported_user_id_statuses][:messaging]
-    assert params[:supported_user_id_statuses][:occupied]
-    refute params[:supported_user_id_statuses][:passage]
+    assert :available in params[:supported_user_id_statuses]
+    assert :disabled in params[:supported_user_id_statuses]
+    assert :messaging in params[:supported_user_id_statuses]
+    assert :occupied in params[:supported_user_id_statuses]
+    refute :passage in params[:supported_user_id_statuses]
 
-    assert params[:supported_keypad_modes][:normal]
-    assert params[:supported_keypad_modes][:vacation]
-    assert params[:supported_keypad_modes][:privacy]
-    refute params[:supported_keypad_modes][:lockout]
+    assert :normal in params[:supported_keypad_modes]
+    assert :vacation in params[:supported_keypad_modes]
+    assert :privacy in params[:supported_keypad_modes]
+    refute :lockout in params[:supported_keypad_modes]
 
     assert params[:supported_keypad_keys] == ~c"0123456789"
   end


### PR DESCRIPTION
Instead of keyword lists of the form `[{value, boolean}, ...`, params
that use bitmask encoding will be represented as `[value, ...]` (a list
of enabled values). Lists are easier to work with, especially when
encoding into formats that don't support keyword lists / tuples (e.g.
JSON).
