### PR TITLE
Fix User Code Set when User ID Status is 0x00

### DIFF
--- a/lib/grizzly/zwave/commands/user_code_set.ex
+++ b/lib/grizzly/zwave/commands/user_code_set.ex
@@ -40,6 +40,15 @@ defmodule Grizzly.ZWave.Commands.UserCodeSet do
     user_id_status = Command.param!(command, :user_id_status)
     user_code = Command.param!(command, :user_code)
 
+    # CC:0063.01.01.11.009 - The User Code field MUST be set to 0x00000000 (4 bytes)
+    # when User ID Status is equal to 0x00 (Available).
+    user_code =
+      if user_id_status == :available do
+        <<0x00, 0x00, 0x00, 0x00>>
+      else
+        user_code
+      end
+
     <<user_id, UserCode.user_id_status_to_byte(user_id_status)>> <> user_code
   end
 

--- a/test/grizzly/zwave/commands/user_code_set_test.exs
+++ b/test/grizzly/zwave/commands/user_code_set_test.exs
@@ -11,8 +11,8 @@ defmodule Grizzly.ZWave.Commands.UserCodeSetTest do
 
   describe "encodes params correctly" do
     test "setting user code available" do
-      {:ok, command} = UserCodeSet.new(user_id: 9, user_id_status: :available, user_code: "0000")
-      expected_binary = <<0x63, 0x01, 0x09, 0x00, 0x30, 0x30, 0x30, 0x30>>
+      {:ok, command} = UserCodeSet.new(user_id: 9, user_id_status: :available, user_code: "1234")
+      expected_binary = <<0x63, 0x01, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00>>
 
       assert expected_binary == ZWave.to_binary(command)
     end


### PR DESCRIPTION
The Z-Wave spec states that the User Code field must be set to
0x00000000 when User ID Status is 0x00 (available).
