### PR TITLE
UnsolicitedServer includes node id in Logger metadata

### DIFF
--- a/lib/grizzly/transports/DTLS.ex
+++ b/lib/grizzly/transports/DTLS.ex
@@ -199,6 +199,12 @@ defmodule Grizzly.Transports.DTLS do
     end
   end
 
+  @impl Grizzly.Transport
+  def peername(transport) do
+    socket = Transport.assign(transport, :socket)
+    :ssl.peername(socket)
+  end
+
   @doc false
   def user_lookup(:psk, _username, userstate) do
     {:ok, userstate}

--- a/lib/grizzly/transports/UDP.ex
+++ b/lib/grizzly/transports/UDP.ex
@@ -53,12 +53,19 @@ defmodule Grizzly.Transports.UDP do
     |> :gen_udp.send(host, port, binary)
   end
 
+  @impl Grizzly.Transport
   def send(transport, binary, opts) do
     {ip_address, port} = Keyword.fetch!(opts, :to)
 
     transport
     |> Transport.assign(:socket)
     |> :gen_udp.send(ip_address, port, binary)
+  end
+
+  @impl Grizzly.Transport
+  def peername(transport) do
+    socket = Transport.assign(transport, :socket)
+    :inet.peername(socket)
   end
 
   @impl Grizzly.Transport

--- a/lib/grizzly/unsolicited_server/socket.ex
+++ b/lib/grizzly/unsolicited_server/socket.ex
@@ -33,6 +33,9 @@ defmodule Grizzly.UnsolicitedServer.Socket do
   def handle_continue(:accept, listening_transport) do
     with {:ok, accept_transport} <- Transport.accept(listening_transport),
          {:ok, transport} <- Transport.handshake(accept_transport) do
+      {:ok, node_id} = Transport.node_id(transport)
+      Logger.metadata(node_id: node_id)
+
       # Start a new listen socket to replace this one as this one is now bound
       # to a single node in the Z-Wave PAN.
       {:ok, _} = SocketSupervisor.start_socket(listening_transport)

--- a/test/support/UDP.ex
+++ b/test/support/UDP.ex
@@ -40,6 +40,12 @@ defmodule GrizzlyTest.Transport.UDP do
   end
 
   @impl Grizzly.Transport
+  def peername(transport) do
+    socket = Transport.assign(transport, :socket)
+    :inet.peername(socket)
+  end
+
+  @impl Grizzly.Transport
   def parse_response({:udp, _, ip, _, binary}, opts) do
     if Keyword.get(opts, :raw, false) do
       {:ok, binary}


### PR DESCRIPTION
Similar to #864, this adds the sending node's id to Logger metadata for
UnsolicitedServer sockets.
