### PR TITLE
Fix false positives in SAPI status reporting

### DIFF
--- a/lib/grizzly/status_reporter.ex
+++ b/lib/grizzly/status_reporter.ex
@@ -4,8 +4,9 @@ defmodule Grizzly.StatusReporter do
   runtime
   """
 
-  alias Grizzly.ZIPGateway.LogMonitor
   alias Grizzly.ZWaveFirmware
+
+  @type serial_api_status :: :ok | :unresponsive
 
   @doc """
   This callback is called when Grizzly starts up zipgateway and able to
@@ -25,7 +26,7 @@ defmodule Grizzly.StatusReporter do
   Called when the Serial API status changes. Only applicable if Grizzly is managing
   the Z/IP Gateway process.
   """
-  @callback serial_api_status(LogMonitor.serial_api_status()) :: any()
+  @callback serial_api_status(serial_api_status()) :: any()
 
   @optional_callbacks [serial_api_status: 1]
 end

--- a/lib/grizzly/zipgateway/log_monitor.ex
+++ b/lib/grizzly/zipgateway/log_monitor.ex
@@ -5,9 +5,8 @@ defmodule Grizzly.ZIPGateway.LogMonitor do
 
   use GenServer
 
+  alias Grizzly.ZIPGateway.SAPIMonitor
   require Logger
-
-  @type serial_api_status :: :ok | :initializing | :unknown | :unresponsive
 
   @type network_key_type ::
           :s0
@@ -16,15 +15,6 @@ defmodule Grizzly.ZIPGateway.LogMonitor do
           | :s2_access_control
           | :s2_authenticated_long_range
           | :s2_access_control_long_range
-
-  @doc """
-  Returns the estimated status of the Z-Wave module based on Z/IP Gateway's
-  log output.
-  """
-  @spec serial_api_status(GenServer.name()) :: serial_api_status()
-  def serial_api_status(name \\ __MODULE__) do
-    GenServer.call(name, :serial_api_status)
-  end
 
   @doc """
   Returns the network home id as extracted from the Z/IP Gateway logs.
@@ -75,27 +65,20 @@ defmodule Grizzly.ZIPGateway.LogMonitor do
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
+    GenServer.start_link(__MODULE__, [], name: name)
   end
 
   @impl GenServer
-  def init(opts) do
+  def init(_opts) do
     {:ok,
      %{
        home_id: nil,
        network_keys: [],
-       next_key_type: nil,
-       sapi_retransmissions: 0,
-       sapi_status: :unknown,
-       status_reporter: opts[:status_reporter]
+       next_key_type: nil
      }}
   end
 
   @impl GenServer
-  def handle_call(:serial_api_status, _from, %{sapi_status: sapi_status} = state) do
-    {:reply, sapi_status, state}
-  end
-
   def handle_call(:home_id, _from, %{home_id: home_id} = state) do
     {:reply, home_id, state}
   end
@@ -181,52 +164,16 @@ defmodule Grizzly.ZIPGateway.LogMonitor do
     {:noreply, %{state | home_id: home_id}}
   end
 
-  def handle_info({:message, "Serial Process init" <> _}, state) do
-    {:noreply, set_sapi_status(state, :initializing)}
-  end
-
   def handle_info({:message, "Bridge init done" <> _}, state) do
-    {:noreply, set_sapi_status(state, :ok)}
+    _ = SAPIMonitor.reset()
+    {:noreply, state}
   end
 
   def handle_info({:message, message}, state) do
-    cond do
-      not String.contains?(message, " SerialAPI: Retransmission") ->
-        {:noreply, state}
-
-      state.sapi_retransmissions + 1 > 4 ->
-        {:noreply, set_sapi_status(state, :unresponsive)}
-
-      true ->
-        {:noreply, %{state | sapi_retransmissions: state.sapi_retransmissions + 1}}
-    end
-  end
-
-  defp set_sapi_status(state, new_status) when new_status in [:ok, :initializing] do
-    maybe_notify_status_reporter(state, new_status)
-    %{state | sapi_status: new_status, sapi_retransmissions: 0}
-  end
-
-  defp set_sapi_status(state, new_status) do
-    maybe_notify_status_reporter(state, new_status)
-    %{state | sapi_status: new_status}
-  end
-
-  defp maybe_notify_status_reporter(%{sapi_status: status}, status), do: :ok
-
-  defp maybe_notify_status_reporter(state, new_status) do
-    cond do
-      is_function(state.status_reporter, 1) ->
-        state.status_reporter.(new_status)
-
-      is_atom(state.status_reporter) and
-          function_exported?(state.status_reporter, :serial_api_status, 1) ->
-        state.status_reporter.serial_api_status(new_status)
-
-      true ->
-        :ok
+    if String.contains?(message, " SerialAPI: Retransmission") do
+      SAPIMonitor.retransmission()
     end
 
-    :ok
+    {:noreply, state}
   end
 end

--- a/lib/grizzly/zipgateway/sapi_monitor.ex
+++ b/lib/grizzly/zipgateway/sapi_monitor.ex
@@ -1,0 +1,163 @@
+defmodule Grizzly.ZIPGateway.SAPIMonitor do
+  @moduledoc false
+
+  use GenServer
+
+  alias Grizzly.StatusReporter
+
+  @type option ::
+          {:period, pos_integer()}
+          | {:threshold, pos_integer()}
+          | {:status_reporter, (StatusReporter.serial_api_status() -> :ok) | {module(), atom()}}
+          | {:name, GenServer.name()}
+
+  # There must be THRESHOLD retransmissions within the last PERIOD milliseconds for
+  # the SAPI status to be considered unresponsive. This prevents occasional SAPI
+  # blips from accumulating and causing a false positive unresponsive status.
+  @default_period :timer.seconds(30)
+  @default_threshold 5
+
+  @spec retransmission(GenServer.name()) :: :ok
+  def retransmission(name \\ __MODULE__) do
+    GenServer.call(name, :retransmission)
+  end
+
+  @spec status(GenServer.name()) :: StatusReporter.serial_api_status()
+  def status(name \\ __MODULE__) do
+    GenServer.call(name, :status)
+  end
+
+  @spec reset(GenServer.name()) :: :ok
+  def reset(name \\ __MODULE__) do
+    GenServer.call(name, :reset)
+  end
+
+  @spec start_link([option()]) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+
+    default_period = Application.get_env(:grizzly, :sapi_monitor_period, @default_period)
+    default_threshold = Application.get_env(:grizzly, :sapi_monitor_threshold, @default_threshold)
+
+    period = Keyword.get(opts, :period, default_period)
+    threshold = Keyword.get(opts, :threshold, default_threshold)
+    status_reporter = Keyword.get(opts, :status_reporter)
+
+    GenServer.start_link(
+      __MODULE__,
+      [period: period, threshold: threshold, status_reporter: status_reporter],
+      name: name
+    )
+  end
+
+  @impl GenServer
+  def init(opts) do
+    period = Keyword.fetch!(opts, :period)
+    threshold = Keyword.fetch!(opts, :threshold)
+    status_reporter = Keyword.get(opts, :status_reporter)
+
+    state = %{
+      period: period,
+      threshold: threshold,
+      status_reporter: status_reporter,
+      retransmissions: [],
+      status: :ok,
+      check_timer: nil
+    }
+
+    notify_status_reporter(status_reporter, :ok)
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:retransmission, _from, state) do
+    state = %{
+      state
+      | retransmissions: [System.monotonic_time(:millisecond) | state.retransmissions]
+    }
+
+    {:reply, :ok, update(state)}
+  end
+
+  def handle_call(:status, _from, state) do
+    state = update(state)
+    {:reply, state.status, state}
+  end
+
+  def handle_call(:reset, _from, state) do
+    state = %{state | retransmissions: []}
+    {:reply, :ok, update(state)}
+  end
+
+  @impl GenServer
+  def handle_info(:check, state) do
+    {:noreply, update(state)}
+  end
+
+  defp update(state) do
+    state = %{state | retransmissions: drop_old(state.retransmissions, state.period)}
+
+    if length(state.retransmissions) >= state.threshold do
+      state
+      |> set_status(:unresponsive)
+      |> clear_timer()
+      |> schedule_check()
+    else
+      set_status(state, :ok)
+    end
+  end
+
+  defp set_status(state, new_status) do
+    maybe_notify_status_reporter(state, new_status)
+    %{state | status: new_status}
+  end
+
+  defp clear_timer(state) do
+    case state.check_timer do
+      nil ->
+        state
+
+      check_timer ->
+        _ = Process.cancel_timer(check_timer, info: false)
+        %{state | check_timer: nil}
+    end
+  end
+
+  defp schedule_check(state) do
+    # If there are any retransmissions in the current state, set a new timer to
+    # check again in PERIOD + 10 milliseconds
+    ref = Process.send_after(self(), :check, state.period + 10)
+    %{state | check_timer: ref}
+  end
+
+  # If status has not changed, do not notify
+  defp maybe_notify_status_reporter(%{status: status}, status), do: :ok
+
+  defp maybe_notify_status_reporter(state, new_status) do
+    notify_status_reporter(state.status_reporter, new_status)
+  end
+
+  defp notify_status_reporter(status_reporter, status) do
+    cond do
+      is_function(status_reporter, 1) ->
+        status_reporter.(status)
+
+      is_atom(status_reporter) and
+          function_exported?(status_reporter, :serial_api_status, 1) ->
+        status_reporter.serial_api_status(status)
+
+      true ->
+        :ok
+    end
+
+    :ok
+  end
+
+  # Drop retransmissions older than PERIOD milliseconds
+  defp drop_old(retransmissions, period) do
+    Enum.reject(retransmissions, fn timestamp ->
+      System.monotonic_time(:millisecond) - timestamp > period
+    end)
+  end
+end

--- a/lib/grizzly/zipgateway/supervisor.ex
+++ b/lib/grizzly/zipgateway/supervisor.ex
@@ -7,7 +7,7 @@ defmodule Grizzly.ZIPGateway.Supervisor do
   use Supervisor
 
   alias Grizzly.{Indicator, Options}
-  alias Grizzly.ZIPGateway.{Config, ExitMonitor, LogMonitor}
+  alias Grizzly.ZIPGateway.{Config, ExitMonitor, LogMonitor, SAPIMonitor}
   require Logger
 
   @zgw_eeprom_to_sqlite "/usr/bin/zgw_eeprom_to_sqlite"
@@ -68,7 +68,8 @@ defmodule Grizzly.ZIPGateway.Supervisor do
     ]
 
     [
-      {LogMonitor, [status_reporter: options.status_reporter]},
+      {SAPIMonitor, [status_reporter: options.status_reporter]},
+      LogMonitor,
       {BEAMNotify, beam_notify_options},
       zipgateway_process_supervisor_spec(options)
     ]

--- a/test/grizzly/zipgateway/sapi_monitor_test.exs
+++ b/test/grizzly/zipgateway/sapi_monitor_test.exs
@@ -1,0 +1,55 @@
+defmodule Grizzly.ZIPGateway.SAPIMonitorTest do
+  use ExUnit.Case, async: false
+
+  alias Grizzly.ZIPGateway.SAPIMonitor
+
+  setup %{test: test} do
+    test_pid = self()
+
+    opts = [
+      name: test,
+      status_reporter: fn status -> send(test_pid, status) end
+    ]
+
+    %{monitor_opts: opts}
+  end
+
+  test "transition into unresponsive status", %{monitor_opts: opts} do
+    pid =
+      start_supervised!({SAPIMonitor, Keyword.merge(opts, period: 250, threshold: 5)})
+
+    assert :ok = SAPIMonitor.status(pid)
+    assert_received :ok
+
+    SAPIMonitor.retransmission(pid)
+    SAPIMonitor.retransmission(pid)
+    SAPIMonitor.retransmission(pid)
+    SAPIMonitor.retransmission(pid)
+
+    assert :ok = SAPIMonitor.status(pid)
+
+    SAPIMonitor.retransmission(pid)
+    assert :unresponsive = SAPIMonitor.status(pid)
+    assert_received :unresponsive
+  end
+
+  test "transition out of unresponsive status automatically", %{monitor_opts: opts} do
+    pid =
+      start_supervised!({SAPIMonitor, Keyword.merge(opts, period: 250, threshold: 5)})
+
+    assert :ok = SAPIMonitor.status(pid)
+    assert_received :ok
+
+    SAPIMonitor.retransmission(pid)
+    SAPIMonitor.retransmission(pid)
+    SAPIMonitor.retransmission(pid)
+    SAPIMonitor.retransmission(pid)
+    SAPIMonitor.retransmission(pid)
+
+    assert :unresponsive = SAPIMonitor.status(pid)
+    assert_received :unresponsive
+
+    assert_receive :ok, 500
+    assert :ok = SAPIMonitor.status(pid)
+  end
+end


### PR DESCRIPTION
As it turns out, it's somewhat normal for SAPI hiccups to happen
occasionally. This refactors SAPI status monitoring/reporting such that
the unresponsive status is only triggered when X retransmissions occur in
the last Y seconds.
