### PR TITLE
Add missing commands to SensorMultilevel CC

### DIFF
--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -214,6 +214,9 @@ defmodule Grizzly.Commands.Table do
       {:sensor_multilevel_supported_sensor_get,
        {Commands.SensorMultilevelSupportedSensorGet,
         handler: {WaitReport, complete_report: :sensor_multilevel_supported_sensor_report}}},
+      {:sensor_multilevel_supported_scale_get,
+       {Commands.SensorMultilevelSupportedScaleGet,
+        handler: {WaitReport, complete_report: :sensor_multilevel_supported_scale_report}}},
 
       # User code
       {:user_code_set, {Commands.UserCodeSet, handler: AckResponse}},

--- a/lib/grizzly/zwave/command_classes/sensor_multilevel.ex
+++ b/lib/grizzly/zwave/command_classes/sensor_multilevel.ex
@@ -12,7 +12,7 @@ defmodule Grizzly.ZWave.CommandClasses.SensorMultilevel do
   @sensor_types [
     # byte 1
     [
-      :air_temperature,
+      :temperature,
       :general_purpose,
       :luminance,
       :power,

--- a/lib/grizzly/zwave/commands/sensor_multilevel_supported_scale_get.ex
+++ b/lib/grizzly/zwave/commands/sensor_multilevel_supported_scale_get.ex
@@ -1,0 +1,46 @@
+defmodule Grizzly.ZWave.Commands.SensorMultilevelSupportedScaleGet do
+  @moduledoc """
+  This module implements command SENSOR_MULTILEVEL_SUPPORTED_SCALE_GET of command class COMMAND_CLASS_SENSOR_MULTILEVEL.
+  This command is used to retrieve the supported scales of the specific sensor type from the Multilevel Sensor device.
+
+  Params: * `:sensor_type` - `one of :temperature or :illuminance or :power or :humidity`
+
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.{Command, DecodeError}
+  alias Grizzly.ZWave.CommandClasses.SensorMultilevel
+
+  @type param :: {:sensor_type, atom()}
+
+  @impl Grizzly.ZWave.Command
+  def new(params) do
+    command = %Command{
+      name: :sensor_multilevel_supported_scale_get,
+      command_byte: 0x03,
+      command_class: SensorMultilevel,
+      params: params,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl Grizzly.ZWave.Command
+  def encode_params(command) do
+    sensor_type = Command.param(command, :sensor_type)
+    sensor_type_byte = SensorMultilevel.encode_sensor_type(sensor_type)
+    <<sensor_type_byte>>
+  end
+
+  @impl Grizzly.ZWave.Command
+  def decode_params(<<sensor_type_byte>>) do
+    with {:ok, sensor_type} <- SensorMultilevel.decode_sensor_type(sensor_type_byte) do
+      {:ok, [sensor_type: sensor_type]}
+    else
+      {:error, %DecodeError{}} = error ->
+        error
+    end
+  end
+end

--- a/lib/grizzly/zwave/commands/sensor_multilevel_supported_scale_report.ex
+++ b/lib/grizzly/zwave/commands/sensor_multilevel_supported_scale_report.ex
@@ -1,0 +1,51 @@
+defmodule Grizzly.ZWave.Commands.SensorMultilevelSupportedScaleReport do
+  @moduledoc """
+  This module implements command SENSOR_MULTILEVEL_SUPPORTED_SCALE_REPORT of the COMMAND_CLASS_SENSOR_MULTILEVEL command class.
+  This command is used to advertise the supported scales of a specified multilevel sensor type.
+
+  ## Parameters
+
+  * `:sensor_type` - `list  of :temperature or :illuminance or :power or :humidity` etc. (required)
+  * `:supported_scales` - `list  of supported scales, e.g. [0, 1, 3]. (required)
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.{Command, DecodeError, Encoding}
+  alias Grizzly.ZWave.CommandClasses.SensorMultilevel
+
+  @type param :: {:sensor_type, atom()} | {:supported_scales, [byte()]}
+
+  @impl Grizzly.ZWave.Command
+  def new(params) do
+    command = %Command{
+      name: :sensor_multilevel_supported_scale_report,
+      command_byte: 0x06,
+      command_class: SensorMultilevel,
+      params: params,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl Grizzly.ZWave.Command
+  def encode_params(command) do
+    sensor_type = Command.param(command, :sensor_type)
+    supported_scales = Command.param(command, :supported_scales)
+    sensor_type_byte = SensorMultilevel.encode_sensor_type(sensor_type)
+    <<scales_bitmask>> = Encoding.encode_bitmask(supported_scales)
+    <<sensor_type_byte, 0x00::4, scales_bitmask::4>>
+  end
+
+  @impl Grizzly.ZWave.Command
+  def decode_params(<<sensor_type_byte, 0x00::4, scales_bitmask::4>>) do
+    with {:ok, sensor_type} <- SensorMultilevel.decode_sensor_type(sensor_type_byte),
+         supported_scales <- Encoding.decode_bitmask(<<scales_bitmask>>) do
+      {:ok, [sensor_type: sensor_type, supported_scales: supported_scales]}
+    else
+      {:error, %DecodeError{}} = error ->
+        error
+    end
+  end
+end

--- a/lib/grizzly/zwave/decoder.ex
+++ b/lib/grizzly/zwave/decoder.ex
@@ -299,8 +299,10 @@ defmodule Grizzly.ZWave.Decoder do
       # Sensor multilevel
       {0x31, 0x01, Commands.SensorMultilevelSupportedSensorGet},
       {0x31, 0x02, Commands.SensorMultilevelSupportedSensorReport},
+      {0x31, 0x03, Commands.SensorMultilevelSupportedScaleGet},
       {0x31, 0x04, Commands.SensorMultilevelGet},
       {0x31, 0x05, Commands.SensorMultilevelReport},
+      {0x31, 0x06, Commands.SensorMultilevelSupportedScaleReport},
 
       # Meter
       {0x32, 0x01, Commands.MeterGet},

--- a/test/grizzly/zwave/commands/sensor_multilevel_supported_scale_get_test.exs
+++ b/test/grizzly/zwave/commands/sensor_multilevel_supported_scale_get_test.exs
@@ -1,0 +1,23 @@
+defmodule Grizzly.ZWave.Commands.SensorMultilevelSupportedScaleGetTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave.Commands.SensorMultilevelSupportedScaleGet
+
+  test "creates the command and validates params" do
+    params = [sensor_type: :temperature]
+    {:ok, _command} = SensorMultilevelSupportedScaleGet.new(params)
+  end
+
+  test "encodes params correctly" do
+    params = [sensor_type: :temperature]
+    {:ok, command} = SensorMultilevelSupportedScaleGet.new(params)
+    expected_binary = <<0x01>>
+    assert expected_binary == SensorMultilevelSupportedScaleGet.encode_params(command)
+  end
+
+  test "decodes params correctly" do
+    binary_params = <<0x01>>
+    {:ok, params} = SensorMultilevelSupportedScaleGet.decode_params(binary_params)
+    assert Keyword.get(params, :sensor_type) == :temperature
+  end
+end

--- a/test/grizzly/zwave/commands/sensor_multilevel_supported_scale_report_test.exs
+++ b/test/grizzly/zwave/commands/sensor_multilevel_supported_scale_report_test.exs
@@ -1,0 +1,24 @@
+defmodule Grizzly.ZWave.Commands.SensorMultilevelSupportedScaleReportTest do
+  use ExUnit.Case, async: true
+
+  alias Grizzly.ZWave.Commands.SensorMultilevelSupportedScaleReport
+
+  test "creates the command and validates params" do
+    params = [sensor_type: :temperature, supported_scales: [0, 1]]
+    {:ok, _command} = SensorMultilevelSupportedScaleReport.new(params)
+  end
+
+  test "encodes params correctly" do
+    params = [sensor_type: :temperature, supported_scales: [0, 1]]
+    {:ok, command} = SensorMultilevelSupportedScaleReport.new(params)
+    expected_binary = <<0x01, 0x00::4, 0x03::4>>
+    assert expected_binary == SensorMultilevelSupportedScaleReport.encode_params(command)
+  end
+
+  test "decodes params correctly" do
+    binary_params = <<0x01, 0x00::4, 0x03::4>>
+    {:ok, params} = SensorMultilevelSupportedScaleReport.decode_params(binary_params)
+    assert :temperature == params[:sensor_type]
+    assert [0, 1] == Enum.sort(params[:supported_scales])
+  end
+end

--- a/test/grizzly/zwave/commands/sensor_multilevel_supported_sensor_report_test.exs
+++ b/test/grizzly/zwave/commands/sensor_multilevel_supported_sensor_report_test.exs
@@ -5,14 +5,14 @@ defmodule Grizzly.ZWave.Commands.SensorMultilevelSupportedSensorReportTest do
 
   test "creates the command and validates params" do
     params = [
-      sensor_types: [:air_temperature, :luminance, :seismic_magnitude, :water_temperature]
+      sensor_types: [:temperature, :luminance, :seismic_magnitude, :water_temperature]
     ]
 
     {:ok, _command} = SensorMultilevelSupportedSensorReport.new(params)
   end
 
   test "encodes params correctly" do
-    params = [sensor_types: [:air_temperature, :humidity, :seismic_magnitude, :water_temperature]]
+    params = [sensor_types: [:temperature, :humidity, :seismic_magnitude, :water_temperature]]
     {:ok, command} = SensorMultilevelSupportedSensorReport.new(params)
     expected_binary = <<17, 0, 64, 2>>
     assert expected_binary == SensorMultilevelSupportedSensorReport.encode_params(command)
@@ -26,7 +26,7 @@ defmodule Grizzly.ZWave.Commands.SensorMultilevelSupportedSensorReportTest do
 
     assert Enum.sort(sensor_types) ==
              Enum.sort([
-               :air_temperature,
+               :temperature,
                :humidity,
                :seismic_magnitude,
                :water_temperature


### PR DESCRIPTION
Added SensorMultilevelSupportedScaleGet and SensorMultilevelSupportedScaleReport

[SRH-1063]

[SRH-1063]: https://smartrent.atlassian.net/browse/SRH-1063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ