### PR TITLE
Ignore extra trailing bytes when decoding ThermostatSetpointReport

### DIFF
--- a/lib/grizzly/zwave/commands/thermostat_setpoint_report.ex
+++ b/lib/grizzly/zwave/commands/thermostat_setpoint_report.ex
@@ -55,7 +55,8 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointReport do
   @impl Command
   def decode_params(
         <<_::size(4), type_byte::size(4), precision::size(3), scale_byte::size(2),
-          byte_size::size(3), int_value::size(byte_size)-unit(8)>>
+          byte_size::size(3), int_value::size(byte_size)-unit(8), _::binary>>
+        # trailing binary to capture extra 0 sent by the Aidoo
       ) do
     type = ThermostatSetpoint.decode_type(type_byte)
 

--- a/test/grizzly/zwave/commands/thermostat_setpoint_report_test.exs
+++ b/test/grizzly/zwave/commands/thermostat_setpoint_report_test.exs
@@ -28,6 +28,17 @@ defmodule Grizzly.ZWave.Commands.ThermostatSetpointReportTest do
     assert Keyword.get(params, :value) == 75.5
   end
 
+  test "decodes params correctly when there is a trailing junk byte (Aidoo Airzone)" do
+    binary_params =
+      <<0x00::size(4), 0x01::size(4), 0x01::size(3), 0x01::size(2), 0x02::size(3), 0x02, 0xF3,
+        0x00>>
+
+    {:ok, params} = ThermostatSetpointReport.decode_params(binary_params)
+    assert Keyword.get(params, :type) == :heating
+    assert Keyword.get(params, :scale) == :f
+    assert Keyword.get(params, :value) == 75.5
+  end
+
   test "encodes :na type" do
     {:ok, command} =
       ThermostatSetpointReport.new(


### PR DESCRIPTION
A trailing 0 is sent by the Aidoo Airzone which must be ignored to avoid a parameter decoding failure.

[SRH-1012]

[SRH-1012]: https://smartrent.atlassian.net/browse/SRH-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ