### PR TITLE
Fix Handling command timeouts and queueing when updating firmware

### DIFF
--- a/lib/grizzly/firmware_updates.ex
+++ b/lib/grizzly/firmware_updates.ex
@@ -85,6 +85,17 @@ defmodule Grizzly.FirmwareUpdates do
     child_count.active == 1
   end
 
+  @doc """
+  Stop the current firmware update runner, if any.
+  """
+  @spec stop_firmware_update() :: :ok
+  def stop_firmware_update() do
+    case DynamicSupervisor.which_children(FirmwareUpdateRunnerSupervisor) do
+      [{_, pid, _, _} | _] when is_pid(pid) -> GenServer.stop(pid, :normal)
+      _other -> :ok
+    end
+  end
+
   @spec firmware_image_fragment_count :: {:ok, non_neg_integer} | {:error, :not_updating}
   def firmware_image_fragment_count() do
     if firmware_update_running?() do

--- a/lib/grizzly/firmware_updates/firmware_update_runner.ex
+++ b/lib/grizzly/firmware_updates/firmware_update_runner.ex
@@ -121,6 +121,26 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner do
       :ack_response ->
         {:noreply, firmware_update}
 
+      :timeout ->
+        Logger.info(
+          "[Grizzly] Updating firmware of device #{firmware_update.device_id} failed: timed out: timeout."
+        )
+
+        respond_to_handler(
+          format_handler_spec(firmware_update.handler),
+          {:error, :timeout}
+        )
+
+        {:stop, :normal, firmware_update}
+
+      type when type in [:queued_delay, :queued_ping] ->
+        respond_to_handler(
+          format_handler_spec(firmware_update.handler),
+          {:ok, :queued}
+        )
+
+        {:noreply, firmware_update}
+
       :command ->
         handle_report(report, firmware_update)
     end


### PR DESCRIPTION
Also support stopping a firmware update run

Timeouts were not handled, crashing the firmware update process.

Required by the Piston DeviceFirmwareUpdater.

[SRH-552]

[SRH-552]: https://smartrent.atlassian.net/browse/SRH-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ