### PR TITLE
Catch exit when stopping dead CommandRunner

### DIFF
--- a/lib/grizzly/commands/command_runner.ex
+++ b/lib/grizzly/commands/command_runner.ex
@@ -45,7 +45,11 @@ defmodule Grizzly.Commands.CommandRunner do
     GenServer.call(runner, :reference)
   end
 
-  def stop(runner), do: GenServer.stop(runner, :normal)
+  def stop(runner) do
+    GenServer.stop(runner, :normal)
+  catch
+    :exit, {:noproc, _} -> :ok
+  end
 
   @impl true
   def init([command, node_id, opts]) do


### PR DESCRIPTION
Stopping an already-stopped CommandRunner shouldn't be an error.
