### PR TITLE
Allow any value when decoding battery level

### DIFF
--- a/lib/grizzly/zwave/commands/battery_report.ex
+++ b/lib/grizzly/zwave/commands/battery_report.ex
@@ -149,9 +149,11 @@ defmodule Grizzly.ZWave.Commands.BatteryReport do
   defp encode_low_temperature(false), do: 0x00
   defp encode_low_temperature(true), do: 0x01
 
-  defp level_from_byte(level_byte) when level_byte in 0..100, do: {:ok, level_byte}
   # low battery warning
   defp level_from_byte(0xFF), do: {:ok, 0}
+  defp level_from_byte(level_byte) when level_byte in 0..100, do: {:ok, level_byte}
+  # some locks sometimes report a battery level of 101%... (:
+  defp level_from_byte(level_byte) when level_byte > 100, do: {:ok, 100}
 
   defp level_from_byte(byte),
     do: {:error, %DecodeError{value: byte, param: :level, command: :battery_report}}

--- a/test/grizzly/zwave/commands/battery_report_test.exs
+++ b/test/grizzly/zwave/commands/battery_report_test.exs
@@ -59,9 +59,26 @@ defmodule Grizzly.ZWave.Commands.BatteryReportTest do
   end
 
   test "decodes v1 params correctly" do
-    binary_params = <<0x20>>
-    {:ok, params} = BatteryReport.decode_params(binary_params)
+    {:ok, params} = BatteryReport.decode_params(<<0x20>>)
     assert Keyword.get(params, :level) == 0x20
+
+    {:ok, params} = BatteryReport.decode_params(<<0xFF>>)
+    assert Keyword.get(params, :level) == 0
+
+    {:ok, params} = BatteryReport.decode_params(<<0>>)
+    assert Keyword.get(params, :level) == 0
+
+    {:ok, params} = BatteryReport.decode_params(<<1>>)
+    assert Keyword.get(params, :level) == 1
+
+    {:ok, params} = BatteryReport.decode_params(<<100>>)
+    assert Keyword.get(params, :level) == 100
+
+    {:ok, params} = BatteryReport.decode_params(<<101>>)
+    assert Keyword.get(params, :level) == 100
+
+    {:ok, params} = BatteryReport.decode_params(<<254>>)
+    assert Keyword.get(params, :level) == 100
   end
 
   test "decodes v2 params correctly" do


### PR DESCRIPTION
Some door locks can sometimes report a battery level > 100. Allow any
value in Battery Reports and clamp to 0..100.
