### PR TITLE
Update Alpine Version in CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults: &defaults
     image-tag:
       description: "Docker image tag"
       type: string
-      default: "1.16.0-erlang-26.2.1-alpine-3.18.4"
+      default: "1.16.2-erlang-26.2.4-alpine-3.19.1"
 
 install_hex_rebar: &install_hex_rebar
   run:
@@ -110,15 +110,15 @@ workflows:
           matrix:
             parameters:
               image-tag:
-                - 1.16.0-erlang-26.2.1-alpine-3.18.4
-                - 1.15.7-erlang-26.1.2-alpine-3.18.6
-                - 1.14.3-erlang-25.2.3-alpine-3.18.0
+                - 1.16.2-erlang-26.2.4-alpine-3.19.1
+                - 1.15.7-erlang-26.2.4-alpine-3.19.1
+                - 1.14.5-erlang-25.3.2.11-alpine-3.19.1
       - lint:
-          image-tag: 1.16.0-erlang-26.2.1-alpine-3.18.4
+          image-tag: 1.16.2-erlang-26.2.4-alpine-3.19.1
           requires:
             - build
       - dialyzer:
-          image-tag: 1.16.0-erlang-26.2.1-alpine-3.18.4
+          image-tag: 1.16.2-erlang-26.2.4-alpine-3.19.1
           requires:
             - build
       - test:
@@ -127,6 +127,6 @@ workflows:
           matrix:
             parameters:
               image-tag:
-                - 1.16.0-erlang-26.2.1-alpine-3.18.4
-                - 1.15.7-erlang-26.1.2-alpine-3.18.6
-                - 1.14.3-erlang-25.2.3-alpine-3.18.0
+                - 1.16.2-erlang-26.2.4-alpine-3.19.1
+                - 1.15.7-erlang-26.2.4-alpine-3.19.1
+                - 1.14.5-erlang-25.3.2.11-alpine-3.19.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults: &defaults
     image-tag:
       description: "Docker image tag"
       type: string
-      default: "1.16.0-erlang-26.2.1-alpine-3.18.6"
+      default: "1.16.0-erlang-26.2.1-alpine-3.18.4"
 
 install_hex_rebar: &install_hex_rebar
   run:
@@ -110,15 +110,15 @@ workflows:
           matrix:
             parameters:
               image-tag:
-                - 1.16.0-erlang-26.2.1-alpine-3.18.6
-                - 1.15.6-erlang-26.1-alpine-3.18.2
+                - 1.16.0-erlang-26.2.1-alpine-3.18.4
+                - 1.15.6-erlang-26.1.1-alpine-3.18.6
                 - 1.14.3-erlang-25.2.3-alpine-3.18.0
       - lint:
-          image-tag: 1.16.0-erlang-26.2.1-alpine-3.18.6
+          image-tag: 1.16.0-erlang-26.2.1-alpine-3.18.4
           requires:
             - build
       - dialyzer:
-          image-tag: 1.16.0-erlang-26.2.1-alpine-3.18.6
+          image-tag: 1.16.0-erlang-26.2.1-alpine-3.18.4
           requires:
             - build
       - test:
@@ -127,6 +127,6 @@ workflows:
           matrix:
             parameters:
               image-tag:
-                - 1.16.0-erlang-26.2.1-alpine-3.18.6
-                - 1.15.6-erlang-26.1-alpine-3.18.2
+                - 1.16.0-erlang-26.2.1-alpine-3.18.4
+                - 1.15.6-erlang-26.1.1-alpine-3.18.6
                 - 1.14.3-erlang-25.2.3-alpine-3.18.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ workflows:
             parameters:
               image-tag:
                 - 1.16.0-erlang-26.2.1-alpine-3.18.4
-                - 1.15.6-erlang-26.1.1-alpine-3.18.6
+                - 1.15.7-erlang-26.1.2-alpine-3.18.6
                 - 1.14.3-erlang-25.2.3-alpine-3.18.0
       - lint:
           image-tag: 1.16.0-erlang-26.2.1-alpine-3.18.4
@@ -128,5 +128,5 @@ workflows:
             parameters:
               image-tag:
                 - 1.16.0-erlang-26.2.1-alpine-3.18.4
-                - 1.15.6-erlang-26.1.1-alpine-3.18.6
+                - 1.15.7-erlang-26.1.2-alpine-3.18.6
                 - 1.14.3-erlang-25.2.3-alpine-3.18.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults: &defaults
     image-tag:
       description: "Docker image tag"
       type: string
-      default: "1.16.0-erlang-26.2.1-alpine-3.18.4"
+      default: "1.16.0-erlang-26.2.1-alpine-3.18.6"
 
 install_hex_rebar: &install_hex_rebar
   run:
@@ -110,15 +110,15 @@ workflows:
           matrix:
             parameters:
               image-tag:
-                - 1.16.0-erlang-26.2.1-alpine-3.18.4
+                - 1.16.0-erlang-26.2.1-alpine-3.18.6
                 - 1.15.6-erlang-26.1-alpine-3.18.2
                 - 1.14.3-erlang-25.2.3-alpine-3.18.0
       - lint:
-          image-tag: 1.16.0-erlang-26.2.1-alpine-3.18.4
+          image-tag: 1.16.0-erlang-26.2.1-alpine-3.18.6
           requires:
             - build
       - dialyzer:
-          image-tag: 1.16.0-erlang-26.2.1-alpine-3.18.4
+          image-tag: 1.16.0-erlang-26.2.1-alpine-3.18.6
           requires:
             - build
       - test:
@@ -127,6 +127,6 @@ workflows:
           matrix:
             parameters:
               image-tag:
-                - 1.16.0-erlang-26.2.1-alpine-3.18.4
+                - 1.16.0-erlang-26.2.1-alpine-3.18.6
                 - 1.15.6-erlang-26.1-alpine-3.18.2
                 - 1.14.3-erlang-25.2.3-alpine-3.18.0


### PR DESCRIPTION
Changed all instances of 3.18.4 to 3.18.6. I'm not sure if my changes deal with all of the vulnerabilities. When I changed 3.18.4 to 3.18.6 it errored and said that version didn't exist.