### PR TITLE
Improve firmware updates for wakeup devices

### DIFF
--- a/lib/grizzly/commands/command.ex
+++ b/lib/grizzly/commands/command.ex
@@ -27,6 +27,7 @@ defmodule Grizzly.Commands.Command do
           transmission_stats: keyword(),
           node_id: ZWave.node_id(),
           supervision?: boolean(),
+          more_info?: boolean(),
           session_id: non_neg_integer() | nil,
           acknowledged: boolean()
         }
@@ -50,6 +51,7 @@ defmodule Grizzly.Commands.Command do
             transmission_stats: [],
             node_id: nil,
             supervision?: false,
+            more_info?: false,
             session_id: nil,
             acknowledged: false
 
@@ -59,6 +61,7 @@ defmodule Grizzly.Commands.Command do
     command_ref = Keyword.get(opts, :reference, make_ref())
     timeout_ref = Keyword.get(opts, :timeout_ref)
     with_transmission_stats = Keyword.get(opts, :transmission_stats, false)
+    more_info = Keyword.get(opts, :more_info, false)
 
     {zwave_command, handler, handler_init_args, supervision?, session_id} =
       if use_supervision?(zwave_command, opts) do
@@ -94,7 +97,8 @@ defmodule Grizzly.Commands.Command do
       with_transmission_stats: with_transmission_stats,
       node_id: node_id,
       supervision?: supervision?,
-      session_id: session_id
+      session_id: session_id,
+      more_info?: more_info
     }
   end
 
@@ -319,12 +323,21 @@ defmodule Grizzly.Commands.Command do
   defp make_zip_packet_command_opts(grizzly_command) do
     Keyword.new()
     |> maybe_add_installation_and_maintenance_get(grizzly_command)
+    |> maybe_add_more_info_flag(grizzly_command)
     |> add_seq_number(grizzly_command)
   end
 
   defp maybe_add_installation_and_maintenance_get(opts, grizzly_command) do
     if grizzly_command.with_transmission_stats do
       Keyword.put(opts, :header_extensions, [:installation_and_maintenance_get])
+    else
+      opts
+    end
+  end
+
+  defp maybe_add_more_info_flag(opts, grizzly_command) do
+    if grizzly_command.more_info? do
+      Keyword.put(opts, :more_info, true)
     else
       opts
     end

--- a/lib/grizzly/firmware_updates.ex
+++ b/lib/grizzly/firmware_updates.ex
@@ -52,7 +52,7 @@ defmodule Grizzly.FirmwareUpdates do
           | {:hardware_version, byte}
           | {:handler, pid() | module() | {module, keyword()}}
           | {:firmware_target, byte}
-          | {:fragment_size, non_neg_integer}
+          | {:max_fragment_size, non_neg_integer}
           | {:activation_may_be_delayed?, boolean}
 
   @type image_path :: String.t()
@@ -79,11 +79,12 @@ defmodule Grizzly.FirmwareUpdates do
     end
   end
 
+  @doc """
+  A firmware update is in progress when a `FirmwareUpdateRunner` process is running
+  and has received at least one request for one or more image fragments.
+  """
   @spec firmware_update_running?() :: boolean()
-  def firmware_update_running?() do
-    child_count = DynamicSupervisor.count_children(FirmwareUpdateRunnerSupervisor)
-    child_count.active == 1
-  end
+  defdelegate firmware_update_running?(), to: FirmwareUpdateRunner, as: :in_progress?
 
   @doc """
   Stop the current firmware update runner, if any.

--- a/lib/grizzly/firmware_updates/firmware_update_runner/firmware_update.ex
+++ b/lib/grizzly/firmware_updates/firmware_update_runner/firmware_update.ex
@@ -65,6 +65,12 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate do
   def update_command_ref(firmware_update, new_command_ref),
     do: %__MODULE__{firmware_update | current_command_ref: new_command_ref}
 
+  @spec in_progress?(t()) :: boolean()
+  def in_progress?(firmware_update),
+    do:
+      firmware_update.state not in [:failed, :complete] and
+        (firmware_update.fragments_wanted > 0 or firmware_update.fragment_index > 1)
+
   @doc """
   Handle incoming command from the Z-Wave network
 


### PR DESCRIPTION
When starting a firmware update for a wakeup device, the firmware update
won't be considered as started until the device has requested at least
one image fragment. This allows users to enqueue a firmware update
request without blocking communication with other devices.

Additionally, all firmware update commands are now sent with the more
info flag set in the Z/IP Packet.
