### PR TITLE
Implement Included NIF Report command

### DIFF
--- a/lib/grizzly/zwave/commands/included_nif_report.ex
+++ b/lib/grizzly/zwave/commands/included_nif_report.ex
@@ -1,0 +1,50 @@
+defmodule Grizzly.ZWave.Commands.IncludedNIFReport do
+  @moduledoc """
+  This command is sent by Z/IP Gateway to the unsolicited destination(s) when a
+  SmartStart Included Node Information Frame (NIF) is received and both of the
+  following conditions are fulfilled:
+
+  * The advertised NWI Home ID (bytes 9-12 of the node's DSK) matches a DSK on
+    the provisioning list
+  * The advertised Home ID is different from the current network Home ID
+
+  This indicates that the a SmartStart node on the provisioning list is included
+  into a different network and must be excluded/reset before it can be included.
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.{Command, DSK}
+  alias Grizzly.ZWave.CommandClasses.NetworkManagementInclusion
+
+  @type param :: {:seq_number, byte()} | {:dsk, DSK.t()}
+
+  @impl Command
+  @spec new([param()]) :: {:ok, Grizzly.ZWave.Command.t()}
+  def new(params) do
+    command = %Command{
+      name: :included_nif_report,
+      command_byte: 0x19,
+      command_class: NetworkManagementInclusion,
+      params: params,
+      impl: __MODULE__
+    }
+
+    {:ok, command}
+  end
+
+  @impl Command
+  @spec encode_params(Command.t()) :: binary()
+  def encode_params(command) do
+    sequence_number = Command.param!(command, :seq_number)
+    %DSK{raw: dsk} = Command.param!(command, :dsk)
+
+    <<sequence_number, 0::3, byte_size(dsk)::5, dsk::binary>>
+  end
+
+  @impl Command
+  @spec decode_params(binary()) :: {:ok, [param()]}
+  def decode_params(<<seq_number::8, _::3, dsk_length::5, dsk::binary-size(dsk_length)>>) do
+    {:ok, seq_number: seq_number, dsk: DSK.new(dsk)}
+  end
+end

--- a/lib/grizzly/zwave/decoder.ex
+++ b/lib/grizzly/zwave/decoder.ex
@@ -61,6 +61,7 @@ defmodule Grizzly.ZWave.Decoder do
       {0x34, 0x14, Commands.NodeAddDSKSet},
       {0x34, 0x15, Commands.SmartStartJoinStarted},
       {0x34, 0x16, Commands.ExtendedNodeAddStatus},
+      {0x34, 0x19, Commands.IncludedNIFReport},
 
       # Network Management Basic Node (0x4D)
       {0x4D, 0x01, Commands.LearnModeSet},

--- a/lib/grizzly/zwave/dsk.ex
+++ b/lib/grizzly/zwave/dsk.ex
@@ -59,6 +59,17 @@ defmodule Grizzly.ZWave.DSK do
     do_parse(dsk_string, <<>>)
   end
 
+  @doc """
+  Same as `parse/1` but raises an ArgumentError if the DSK is invalid.
+  """
+  @spec parse!(dsk_string()) :: t() | no_return()
+  def parse!(dsk_string) do
+    case parse(dsk_string) do
+      {:ok, dsk} -> dsk
+      {:error, :invalid_dsk} -> raise ArgumentError, "Invalid DSK"
+    end
+  end
+
   defp do_parse(<<>>, parts) when parts != <<>> and byte_size(parts) <= 16 do
     {:ok, new(parts)}
   end


### PR DESCRIPTION
Implements the Included NIF Report command from the Network Management
Inclusion CC. This command is received when a node that is on the
provisioning list sends a SmartStart INIF but has another network's home
id.
