### PR TITLE
Allow creation of unnamed `AsyncConnection`s

### DIFF
--- a/lib/grizzly/commands/command.ex
+++ b/lib/grizzly/commands/command.ex
@@ -306,7 +306,8 @@ defmodule Grizzly.Commands.Command do
             {Report.new(:complete, :ack_response, command.node_id,
                command_ref: command.ref,
                acknowledged: true,
-               queued: true
+               queued: true,
+               transmission_stats: command.transmission_stats
              ), %__MODULE__{command | status: :complete}}
 
           %ZWaveCommand{} ->
@@ -314,7 +315,8 @@ defmodule Grizzly.Commands.Command do
                command_ref: command.ref,
                acknowledged: command.acknowledged,
                command: response,
-               queued: true
+               queued: true,
+               transmission_stats: command.transmission_stats
              ), %__MODULE__{command | status: :complete}}
         end
     end

--- a/lib/grizzly/connections/supervisor.ex
+++ b/lib/grizzly/connections/supervisor.ex
@@ -14,12 +14,10 @@ defmodule Grizzly.Connections.Supervisor do
   Start a connection to a Z-Wave Node or the Z/IP Gateway
   """
   @spec start_connection(ZWave.node_id() | :gateway, [Connection.opt()]) ::
-          {:ok, pid()} | {:error, :timeout}
+          DynamicSupervisor.on_start_child()
   def start_connection(node_id, opts \\ []) do
     case Keyword.get(opts, :mode, :sync) do
       :async ->
-        # put the calling process as the owner if sine the supervisor
-        # will be owner when calling form here.
         opts = Keyword.put_new(opts, :owner, self())
         do_start_connection(AsyncConnection, node_id, opts)
 
@@ -60,6 +58,7 @@ defmodule Grizzly.Connections.Supervisor do
            connection_module.child_spec(node_id, command_opts)
          ) do
       {:ok, _} = ok -> ok
+      {:ok, pid, _} -> {:ok, pid}
       {:error, {:already_started, pid}} -> {:ok, pid}
       {:error, _reason} = other_error -> other_error
     end

--- a/lib/grizzly/firmware_updates/firmware_update_runner/firmware_update.ex
+++ b/lib/grizzly/firmware_updates/firmware_update_runner/firmware_update.ex
@@ -22,6 +22,7 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate do
 
   @type t :: %__MODULE__{
           handler: pid() | module() | {module(), keyword},
+          conn: pid(),
           image: Image.t() | nil,
           manufacturer_id: non_neg_integer,
           firmware_id: non_neg_integer,
@@ -39,6 +40,7 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate do
         }
 
   defstruct handler: nil,
+            conn: nil,
             # Ref to the currently executing command - so it can be stopped if needed
             current_command_ref: nil,
             device_id: 1,

--- a/lib/grizzly/node_id.ex
+++ b/lib/grizzly/node_id.ex
@@ -1,0 +1,23 @@
+defmodule Grizzly.NodeId do
+  @moduledoc false
+
+  @doc "Returns true if the given value is a valid classic Z-Wave node ID"
+  defguard is_classic_node_id(node_id)
+           when is_integer(node_id) and node_id >= 0 and node_id <= 232
+
+  @doc "Returns true if the given value is a valid Z-Wave Long Range node ID"
+  defguard is_long_range_node_id(node_id)
+           when is_integer(node_id) and node_id > 255 and node_id <= 4000
+
+  @doc "Returns true if the given value is a valid Z-Wave node ID (classic or long range)"
+  defguard is_zwave_node_id(node_id)
+           when is_classic_node_id(node_id) or is_long_range_node_id(node_id)
+
+  @doc "Returns true if the given value is a virtual node ID"
+  defguard is_virtual_node_id(node_id)
+           when is_tuple(node_id) and tuple_size(node_id) == 2 and elem(node_id, 0) == :virtual and
+                  is_integer(elem(node_id, 1))
+
+  @doc "Returns true if the given value is a valid node ID (classic, long range, or virtual)"
+  defguard is_node_id(node_id) when is_zwave_node_id(node_id) or is_virtual_node_id(node_id)
+end

--- a/lib/grizzly/switch_binary.ex
+++ b/lib/grizzly/switch_binary.ex
@@ -41,7 +41,7 @@ defmodule Grizzly.SwitchBinary do
           | {:queued, reference(), non_neg_integer()}
           | {:error, :timeout | :including | :updating_firmware | :nack_response | any()}
   def get(node_id, command_opts \\ []) do
-    case Grizzly.send_command_no_warn(node_id, :switch_binary_get, [], command_opts) do
+    case Grizzly.send_command(node_id, :switch_binary_get, [], command_opts) do
       {:ok, %{type: :command} = report} ->
         target_value = Command.param!(report.command, :target_value)
         duration = Command.param(report.command, :duration)
@@ -83,7 +83,7 @@ defmodule Grizzly.SwitchBinary do
     duration = Keyword.get(opts, :duration)
     send_opts = Keyword.drop(opts, [:duration])
 
-    case Grizzly.send_command_no_warn(
+    case Grizzly.send_command(
            node_id,
            :switch_binary_set,
            [target_value: target_value, duration: duration],


### PR DESCRIPTION
`AsyncConnection` is a bit of a misnomer. While it does only support
sending commands asynchronously, the defining feature (and a critical
point that was never documented) is that an `AsyncConnection` is meant
to be owned and used by a single process (thus its use in inclusion and
firmware upgrades). A clearer name would be `OwnedConnection`.

The upshot of this behavior is that if two different processes were to
send a command with `mode: :async`, the first process to do so would
receive all of the status messages and the second process would get
nothing.

This adds an option to `AsyncConnection.start_link/3` to start an
unnamed connection rather than potentially reusing an existing named
connection.
