### PR TITLE
Send a Grizzly.Report for nack responses to queued commands

### DIFF
--- a/lib/grizzly/commands/command_runner.ex
+++ b/lib/grizzly/commands/command_runner.ex
@@ -76,9 +76,6 @@ defmodule Grizzly.Commands.CommandRunner do
       {:continue, new_command} ->
         {:reply, :continue, new_command}
 
-      {:error, :nack_response, new_command} ->
-        {:stop, :normal, {:error, :nack_response}, new_command}
-
       {:error, reason, new_command} ->
         {:stop, :normal, {:error, reason}, new_command}
 

--- a/lib/grizzly/connections/async_connection.ex
+++ b/lib/grizzly/connections/async_connection.ex
@@ -259,10 +259,6 @@ defmodule Grizzly.Connections.AsyncConnection do
 
           %State{state | commands: new_command_list}
 
-        {waiter, {:error, :nack_response, new_command_list}} ->
-          send(waiter, {:error, :nack_response})
-          %State{state | commands: new_command_list}
-
         {waiter, {%Report{} = report, new_command_list}} ->
           send(waiter, {:grizzly, :report, report})
           %State{state | commands: new_command_list}

--- a/lib/grizzly/connections/sync_connection.ex
+++ b/lib/grizzly/connections/sync_connection.ex
@@ -205,10 +205,6 @@ defmodule Grizzly.Connections.SyncConnection do
         {:continue, new_command_list} ->
           %State{state | commands: new_command_list}
 
-        {waiter, {:error, :nack_response, new_command_list}} ->
-          GenServer.reply(waiter, {:error, :nack_response})
-          %State{state | commands: new_command_list}
-
         {waiter, {%Report{} = report, new_command_list}} when is_pid(waiter) ->
           send(waiter, {:grizzly, :report, report})
           %State{state | commands: new_command_list}

--- a/lib/grizzly/report.ex
+++ b/lib/grizzly/report.ex
@@ -166,6 +166,7 @@ defmodule Grizzly.Report do
 
   @type type() ::
           :ack_response
+          | :nack_response
           | :command
           | :queued_ping
           | :unsolicited

--- a/test/grizzly/commands/command_runner_test.exs
+++ b/test/grizzly/commands/command_runner_test.exs
@@ -71,7 +71,8 @@ defmodule Grizzly.Commands.CommandRunnerTest do
 
     nack_response = ZIPPacket.make_nack_response(CommandRunner.seq_number(runner))
 
-    assert {:error, :nack_response} == CommandRunner.handle_zip_command(runner, nack_response)
+    assert %Report{status: :complete, type: :nack_response, node_id: 1} =
+             CommandRunner.handle_zip_command(runner, nack_response)
   end
 
   test "handles :nack_queue_full response" do

--- a/test/grizzly/commands/command_test.exs
+++ b/test/grizzly/commands/command_test.exs
@@ -127,8 +127,11 @@ defmodule Grizzly.Commands.CommandTest do
 
     nack_response = ZIPPacket.make_nack_response(grizzly_command.seq_number)
 
-    assert {:error, :nack_response, grizzly_command} ==
+    assert {report, grizzly_command} =
              Command.handle_zip_command(grizzly_command, nack_response)
+
+    assert %Report{status: :complete, type: :nack_response, node_id: 1} = report
+    assert grizzly_command.status == :complete
   end
 
   test "if Z/IP keep alive command, does not encode as a Z/IP Packet" do

--- a/test/grizzly/connections/command_list_test.exs
+++ b/test/grizzly/connections/command_list_test.exs
@@ -38,8 +38,12 @@ defmodule Grizzly.Connections.CommandListTest do
 
     ack_response = ZIPPacket.make_nack_response(CommandRunner.seq_number(runner))
 
-    assert {self(), {:error, :nack_response, CommandList.empty()}} ==
+    pid = self()
+
+    assert {^pid, {report, %CommandList{}}} =
              CommandList.response_for_zip_packet(command_list, ack_response)
+
+    assert %Report{status: :complete, type: :nack_response, node_id: 1} = report
 
     refute Process.alive?(runner)
   end

--- a/test/grizzly/connections/sync_connection_test.exs
+++ b/test/grizzly/connections/sync_connection_test.exs
@@ -4,7 +4,6 @@ defmodule Grizzly.Connections.SyncConnectionTest do
   alias Grizzly.{Connection, Report}
   alias Grizzly.Connections.SyncConnection
   alias Grizzly.ZWave.Commands.SwitchBinaryGet
-  alias GrizzlyTest.Utils
 
   setup do
     # establish the connections for the tests
@@ -23,7 +22,7 @@ defmodule Grizzly.Connections.SyncConnectionTest do
     {:ok, command} = SwitchBinaryGet.new()
 
     # 101 node_id will always return a nack_response
-    assert {:error, :nack_response} ==
+    assert {:ok, %Report{status: :complete, type: :nack_response, node_id: 101}} =
              SyncConnection.send_command(101, command)
   end
 


### PR DESCRIPTION
When a queued command resolves to a nack response, we were previously
sending `{:error, :nack_response}` back to the calling process. This is
lacking vital information (specifically, the command ref) that a caller
needs to know which queued command failed, especially if the caller has
queued multiple commands.

Instead, we will now send `{:grizzly, :report, %Grizzly.Report{}}` as we
do for other types of responses. The report will have a status of
`:complete` and a type of `:nack_response`.
