### PR TITLE
Remove more info flag from ack responses

### DIFF
--- a/lib/grizzly/unsolicited_server/socket.ex
+++ b/lib/grizzly/unsolicited_server/socket.ex
@@ -134,31 +134,13 @@ defmodule Grizzly.UnsolicitedServer.Socket do
   defp send_ack_response(zippacket, transport) do
     header_extensions = Command.param!(zippacket, :header_extensions)
     seq = Command.param!(zippacket, :seq_number)
-    more_info = more_info?(zippacket)
-
-    if more_info do
-      Logger.debug("[Grizzly] Adding More Information flag to ACK response")
-    end
 
     ack_bin =
       seq
-      |> ZIPPacket.make_ack_response(
-        header_extensions: header_extensions,
-        more_info: more_info
-      )
+      |> ZIPPacket.make_ack_response(header_extensions: header_extensions)
       |> ZWave.to_binary()
 
     Transport.send(transport, ack_bin)
-  end
-
-  defp more_info?(zip_packet) do
-    encapsulated_command = Command.param(zip_packet, :command)
-
-    if encapsulated_command && encapsulated_command.name == :supervision_get do
-      true
-    else
-      false
-    end
   end
 
   defp client_ip(sslsocket) do


### PR DESCRIPTION
Setting more info in an ack response doesn't do anything. The flag is
only respected for requests (and only requests that go through Z/IP
Gateway's mailbox).
