### PR TITLE
Fix Z/IP Gateway log prefix

### DIFF
--- a/lib/grizzly/zipgateway/supervisor.ex
+++ b/lib/grizzly/zipgateway/supervisor.ex
@@ -91,7 +91,7 @@ defmodule Grizzly.ZIPGateway.Supervisor do
            name: Grizzly.ZIPGateway.Daemon,
            cd: priv,
            log_output: :debug,
-           log_prefix: "zipgateway",
+           log_prefix: "zipgateway: ",
            log_transform: &zipgateway_log_transform/1,
            exit_status_to_reason: &zipgateway_exit_status/1
          ]


### PR DESCRIPTION
Turns out muontrap doesn't add the ": " for you when using a custom log
prefix.
