### PR TITLE
Remove support for Z/IP Gateway EEPROM migration

### DIFF
--- a/lib/grizzly/options.ex
+++ b/lib/grizzly/options.ex
@@ -48,7 +48,6 @@ defmodule Grizzly.Options do
           firmware_update_handler: Grizzly.handler() | nil,
           unsolicited_destination: {:inet.ip_address(), :inet.port_number()},
           associations_file: Path.t(),
-          eeprom_file: Path.t() | nil,
           database_file: Path.t() | nil,
           indicator_handler: (Grizzly.Indicator.event() -> :ok),
           rf_region: Supervisor.rf_region() | nil,
@@ -79,7 +78,6 @@ defmodule Grizzly.Options do
             firmware_update_handler: nil,
             unsolicited_destination: {{0xFD00, 0xAAAA, 0, 0, 0, 0, 0, 0x0002}, 41230},
             associations_file: nil,
-            eeprom_file: "/data/zipeeprom.dat",
             database_file: "/data/zipgateway.db",
             indicator_handler: nil,
             rf_region: nil,
@@ -100,16 +98,8 @@ defmodule Grizzly.Options do
     struct(__MODULE__, opts)
   end
 
-  @spec to_zipgateway_config(t(), boolean()) :: Config.t()
-  def to_zipgateway_config(%__MODULE__{database_file: file} = grizzly_opts, use_database?)
-      when file == nil or not use_database? do
-    # Build a zipgateway configuration for zipgateway <7.14.2
+  @spec to_zipgateway_config(t()) :: Config.t()
+  def to_zipgateway_config(%__MODULE__{} = grizzly_opts) do
     Config.new(grizzly_opts)
-  end
-
-  def to_zipgateway_config(%__MODULE__{} = grizzly_opts, true = _use_database?) do
-    # Build a zipgateway configuration for zipgateway >= 7.14.2. This version
-    # of zipgateway will exit if an eeprom file is specified
-    Config.new(%{grizzly_opts | eeprom_file: nil})
   end
 end

--- a/lib/grizzly/supervisor.ex
+++ b/lib/grizzly/supervisor.ex
@@ -115,9 +115,6 @@ defmodule Grizzly.Supervisor do
   - `:database_file` - `zipgateway` >= 7.14.2 uses an sqlite database to store
     information about the Z-Wave network. This will default to
     "/data/zipgateway.db".
-  - `:eeprom_file` - `zipgateway` < 7.14.2 uses an eeprom file to store
-    information about the Z-Wave network. This will default to
-    "/data/zipeeprom.dat".
   - `:indicator_handler` - A function to run when an `Grizzly.Indicator.event()`
     is received from `zipgateway`. The function should accept an event and
     return `:ok`.
@@ -157,7 +154,6 @@ defmodule Grizzly.Supervisor do
           | {:firmware_update_handler, Grizzly.handler()}
           | {:unsolicited_destination, {:inet.ip_address(), :inet.port_number()}}
           | {:unsolicited_data_path, Path.t()}
-          | {:eeprom_file, Path.t()}
           | {:database_file, Path.t()}
           | {:indicator_handler, (Grizzly.Indicator.event() -> :ok)}
           | {:rf_region, rf_region()}

--- a/lib/grizzly/zipgateway/config.ex
+++ b/lib/grizzly/zipgateway/config.ex
@@ -13,7 +13,6 @@ defmodule Grizzly.ZIPGateway.Config do
           ca_cert: Path.t(),
           cert: Path.t(),
           priv_key: Path.t(),
-          eeprom_file: Path.t() | nil,
           tun_script: Path.t(),
           pvs_storage_file: Path.t(),
           provisioning_config_file: Path.t(),
@@ -37,7 +36,6 @@ defmodule Grizzly.ZIPGateway.Config do
   defstruct ca_cert: "./Portal.ca_x509.pem",
             cert: "./ZIPR.x509_1024.pem",
             priv_key: "./ZIPR.key_1024.pem",
-            eeprom_file: nil,
             tun_script: "./zipgateway.tun",
             pvs_storage_file: "/root/provisioning_list_store.dat",
             provisioning_config_file: "/data/zipgateway_provisioning_list.cfg",
@@ -74,7 +72,6 @@ defmodule Grizzly.ZIPGateway.Config do
         :lan_ip,
         :pan_ip,
         :database_file,
-        :eeprom_file,
         :rf_region,
         :power_level,
         :extra_config
@@ -117,7 +114,6 @@ defmodule Grizzly.ZIPGateway.Config do
     |> maybe_put_config_item(cfg, :lan_ip, "ZipLanIp6")
     |> maybe_put_config_item(cfg, :unsolicited_destination, nil)
     |> maybe_put_config_item(cfg, :database_file, "ZipGwDatabase")
-    |> maybe_put_config_item(cfg, :eeprom_file, "Eepromfile")
     |> maybe_put_config_item(cfg, :identify_script, "ZipNodeIdentifyScript")
     |> maybe_put_config_item(cfg, :rf_region, "ZWRFRegion")
     |> maybe_put_config_item(cfg, :power_level, "")

--- a/priv/zipgateway.cfg
+++ b/priv/zipgateway.cfg
@@ -9,7 +9,6 @@ ZipUnsolicitedDestinationPort = 41230
 ZipCaCert=./Portal.ca_x509.pem
 ZipCert=./ZIPR.x509_1024.pem
 ZipPrivKey=./ZIPR.key_1024.pem
-Eepromfile=/root/zipeeprom.dat
 TunScript=./zipgateway.tun
 PVSStorageFile=/root/provisioning_list_store.dat
 ProvisioningConfigFile=/etc/zipgateway_provisioning_list.cfg

--- a/test/grizzly/zipgateway/config_test.exs
+++ b/test/grizzly/zipgateway/config_test.exs
@@ -28,30 +28,6 @@ defmodule Grizzly.ZIPGateway.ConfigTest do
     assert output == Config.to_string(cfg)
   end
 
-  test "with eeprom_file" do
-    output = """
-    ZipCaCert=./Portal.ca_x509.pem
-    ZipCert=./ZIPR.x509_1024.pem
-    ZipPrivKey=./ZIPR.key_1024.pem
-    TunScript=./zipgateway.tun
-    PVSStorageFile=/root/provisioning_list_store.dat
-    ProvisioningConfigFile=/data/zipgateway_provisioning_list.cfg
-    ZipLanGw6=::1
-    ZipPSK=123456789012345678901234567890AA
-    ExtraClasses= 133 89 90 142 108 143
-    ZipPanIp6=fd00:bbbb::1
-    ZipLanIp6=fd00:aaaa::1
-    ZipUnsolicitedDestinationIp6=fd00:aaaa::2
-    ZipUnsolicitedDestinationPort=41230
-    Eepromfile=/data/zipeeprom.dat
-    ZipNodeIdentifyScript=#{File.cwd!()}/_build/test/lib/grizzly/priv/indicator.sh
-    """
-
-    cfg = Config.new(%{eeprom_file: "/data/zipeeprom.dat"})
-
-    assert output == Config.to_string(cfg)
-  end
-
   test "when options are added as string" do
     output = """
     ZipCaCert=./Portal.ca_x509.pem


### PR DESCRIPTION
The old EEPROM file storage has been unsupported in Z/IP Gateway for a
few years now. Just including the `EepromFile` config item in the ZGW
config file will cause a fatal error at startup.
