### PR TITLE
Firmware update dynamic transmission delays

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 [
   inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  import_deps: [:telemetry_registry]
+  import_deps: [:telemetry_registry, :mimic]
 ]

--- a/lib/grizzly/connections/async_connection.ex
+++ b/lib/grizzly/connections/async_connection.ex
@@ -244,6 +244,10 @@ defmodule Grizzly.Connections.AsyncConnection do
     updated_state =
       case CommandList.response_for_zip_packet(state.commands, zip_packet) do
         {:retry, command_runner, new_command_list} ->
+          # TODO: this could be better, but do a little sleep between retries.
+          # This is mostly for firmware updates.
+          Process.sleep(100)
+
           :ok = do_send_command(command_runner, state)
           %State{state | commands: new_command_list}
 

--- a/lib/grizzly/firmware_updates.ex
+++ b/lib/grizzly/firmware_updates.ex
@@ -54,6 +54,7 @@ defmodule Grizzly.FirmwareUpdates do
           | {:firmware_target, byte}
           | {:max_fragment_size, non_neg_integer}
           | {:activation_may_be_delayed?, boolean}
+          | {:transmission_delay, pos_integer()}
 
   @type image_path :: String.t()
 

--- a/test/grizzly/firmware_updates/firmware_update_runner/firmware_update_test.exs
+++ b/test/grizzly/firmware_updates/firmware_update_runner/firmware_update_test.exs
@@ -136,5 +136,23 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdateTest do
       assert Command.param!(command, :last?) == false
       assert new_firmware_update.state == :uploading
     end
+
+    test "dynamic transmission delays", %{firmware_update: firmware_update} do
+      update = %FirmwareUpdate{
+        firmware_update
+        | transmission_delay: 500
+      }
+
+      assert 500 == FirmwareUpdate.transmission_delay(update)
+
+      update = FirmwareUpdate.put_last_transmission_speed(firmware_update, {40, :kbit_sec})
+      assert 35 == FirmwareUpdate.transmission_delay(update)
+
+      update = FirmwareUpdate.put_last_transmission_speed(update, {100, :kbit_sec})
+      assert 10 == FirmwareUpdate.transmission_delay(update)
+
+      update = FirmwareUpdate.put_last_transmission_speed(firmware_update, {9.6, :kbit_sec})
+      assert 35 == FirmwareUpdate.transmission_delay(update)
+    end
   end
 end

--- a/test/grizzly/firmware_updates/firmware_update_runner_test.exs
+++ b/test/grizzly/firmware_updates/firmware_update_runner_test.exs
@@ -1,8 +1,13 @@
 defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunnerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
+  use Mimic.DSL
 
   alias Grizzly.FirmwareUpdates.FirmwareUpdateRunner
+  alias Grizzly.ZWave.Command
+  alias Grizzly.ZWave.Commands.FirmwareUpdateMDStatusReport
   alias GrizzlyTest.Utils
+
+  setup :set_mimic_global
 
   @tag :firmware_update
   test "request that a device begin a firmware update" do
@@ -20,24 +25,79 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunnerTest do
     assert received_command.name == :firmware_update_md_request_report
   end
 
+  @tag :firmware_update
   test "request that a device updates its firmware" do
+    Grizzly.Trace.clear()
+    GrizzlyTest.Server.reset()
+
+    # mypid = self()
+    node_id = 201
     image_path = "test/serialapi_controller_bridge_OTW_SD3503_US.gbl"
 
     {:ok, runner} =
       FirmwareUpdateRunner.start_link(
         Utils.default_options(),
-        device_id: 201,
-        manufacturer_id: 1
+        max_fragment_size: 30,
+        device_id: node_id,
+        manufacturer_id: 1,
+        transmission_delay: 1
       )
 
+    Process.monitor(runner)
+
     :ok = FirmwareUpdateRunner.start_firmware_update(runner, image_path)
-    assert_receive {:grizzly, :report, received_command}, 500
+
+    assert_receive {:grizzly, :report, received_command}
     assert received_command.name == :firmware_update_md_request_report
-    :timer.sleep(500)
-    assert_receive {:grizzly, :report, get_command}, 500
+
+    assert_receive {:grizzly, :report, get_command}
     assert get_command.name == :firmware_update_md_get
-    :timer.sleep(500)
-    assert_receive {:grizzly, :report, status_command}, 500
+
+    # Let everything finish
+    Process.sleep(500)
+
+    runner_state = :sys.get_state(runner)
+    assert 6 == runner_state.fragment_index
+
+    [frag5_attempt_1, nack_response, frag5_attempt_2, ack_response] =
+      Enum.slice(Grizzly.Trace.list(), -4..-1//1)
+
+    assert 5 ==
+             frag5_attempt_1.binary
+             |> Grizzly.ZWave.from_binary()
+             |> elem(1)
+             |> Command.param!(:command)
+             |> Command.param!(:report_number)
+
+    assert :nack_response ==
+             nack_response.binary
+             |> Grizzly.ZWave.from_binary()
+             |> elem(1)
+             |> Command.param!(:flag)
+
+    assert 5 ==
+             frag5_attempt_2.binary
+             |> Grizzly.ZWave.from_binary()
+             |> elem(1)
+             |> Command.param!(:command)
+             |> Command.param!(:report_number)
+
+    assert :ack_response ==
+             ack_response.binary
+             |> Grizzly.ZWave.from_binary()
+             |> elem(1)
+             |> Command.param!(:flag)
+
+    {:ok, cmd} = FirmwareUpdateMDStatusReport.new(status: :successful_restarting)
+
+    send(
+      runner,
+      {:grizzly, :report, Grizzly.Report.new(:complete, :command, node_id, command: cmd)}
+    )
+
+    assert_receive {:grizzly, :report, status_command}
     assert status_command.name == :firmware_update_md_status_report
+
+    assert_receive {:DOWN, _ref, :process, ^runner, :normal}
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,6 @@
 {:ok, _pid} = GrizzlyTest.Server.start(5000)
 
+Mimic.copy(Grizzly.Connections.AsyncConnection)
 Mimic.copy(MockStatusReporter)
 Mimic.copy(MockZWaveResetter)
 Mimic.copy(MuonTrap)


### PR DESCRIPTION
Firmware updates now dynamically adjust the delay between transmitting
fragments based on the active transmission speed (10ms for 100kbps and
35ms otherwise, as defined by the spec).

It is also possible to override the transmission delay in case rapid
transmissions cause issues for a particular device.

Additionally, any commands that fail during a firmware update will be
retried up to 2 times in case of nack responses due to transmission
bursts.
