### PR TITLE
Firmware update transmission delay is 15ms at 100kbps

### DIFF
--- a/lib/grizzly/firmware_updates/firmware_update_runner/firmware_update.ex
+++ b/lib/grizzly/firmware_updates/firmware_update_runner/firmware_update.ex
@@ -92,14 +92,14 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate do
   @doc """
   Returns the delay between sending fragments. If set in the `FirmwareUpdate`,
   that value will always be used. Otherwise, the delay is calculated based on
-  the last transmission speed: 10ms for 100kbit/s, 35ms for 40kbit/s and 9.6kbit/s.
+  the last transmission speed: 15ms for 100kbit/s, 35ms for 40kbit/s and 9.6kbit/s.
   """
   @spec transmission_delay(t()) :: pos_integer()
   def transmission_delay(%__MODULE__{transmission_delay: delay})
       when is_integer(delay) and delay > 0,
       do: delay
 
-  def transmission_delay(%__MODULE__{last_transmission_speed: {100, :kbit_sec}}), do: 10
+  def transmission_delay(%__MODULE__{last_transmission_speed: {100, :kbit_sec}}), do: 15
   def transmission_delay(%__MODULE__{last_transmission_speed: {40, :kbit_sec}}), do: 35
   def transmission_delay(%__MODULE__{}), do: 35
 

--- a/test/grizzly/firmware_updates/firmware_update_runner/firmware_update_test.exs
+++ b/test/grizzly/firmware_updates/firmware_update_runner/firmware_update_test.exs
@@ -149,7 +149,7 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdateTest do
       assert 35 == FirmwareUpdate.transmission_delay(update)
 
       update = FirmwareUpdate.put_last_transmission_speed(update, {100, :kbit_sec})
-      assert 10 == FirmwareUpdate.transmission_delay(update)
+      assert 15 == FirmwareUpdate.transmission_delay(update)
 
       update = FirmwareUpdate.put_last_transmission_speed(firmware_update, {9.6, :kbit_sec})
       assert 35 == FirmwareUpdate.transmission_delay(update)


### PR DESCRIPTION
After reviewing the spec, I'm not sure where 10ms originally came from.
