### PR TITLE
Update Z-Wave XML to 2024A specification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+resources/*.xml text eol=lf

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -361,7 +361,7 @@ iex> Grizzly.send_command(node_id, :firmware_md_get)
      impl: Grizzly.ZWave.Commands.VersionReport,
      name: :version_report,
      params: [
-       library_type: :enhanced_slave,
+       library_type: :enhanced_end_node,
        protocol_version: "4.24",
        firmware_version: "1.78",
        hardware_version: 255,

--- a/lib/grizzly/zwave/command_classes/zwaveplus_info.ex
+++ b/lib/grizzly/zwave/command_classes/zwaveplus_info.ex
@@ -14,11 +14,11 @@ defmodule Grizzly.ZWave.CommandClasses.ZwaveplusInfo do
           | :sub_static_controller
           | :portable_controller
           | :reporting_portable_controller
-          | :portable_slave
-          | :always_on_slave
-          | :reporting_sleeping_slave
-          | :listening_sleeping_slave
-          | :network_aware_slave
+          | :portable_end_node
+          | :always_on_end_node
+          | :reporting_sleeping_end_node
+          | :listening_sleeping_end_node
+          | :network_aware_end_node
 
   @type node_type :: :zwaveplus_node | :zwaveplus_for_ip_gateway
 
@@ -32,21 +32,21 @@ defmodule Grizzly.ZWave.CommandClasses.ZwaveplusInfo do
   def role_type_to_byte(:sub_static_controller), do: 0x01
   def role_type_to_byte(:portable_controller), do: 0x02
   def role_type_to_byte(:reporting_portable_controller), do: 0x03
-  def role_type_to_byte(:portable_slave), do: 0x04
-  def role_type_to_byte(:always_on_slave), do: 0x05
-  def role_type_to_byte(:reporting_sleeping_slave), do: 0x06
-  def role_type_to_byte(:listening_sleeping_slave), do: 0x07
-  def role_type_to_byte(:network_aware_slave), do: 0x08
+  def role_type_to_byte(:portable_end_node), do: 0x04
+  def role_type_to_byte(:always_on_end_node), do: 0x05
+  def role_type_to_byte(:reporting_sleeping_end_node), do: 0x06
+  def role_type_to_byte(:listening_sleeping_end_node), do: 0x07
+  def role_type_to_byte(:network_aware_end_node), do: 0x08
 
   def role_type_from_byte(0x00), do: {:ok, :central_static_controller}
   def role_type_from_byte(0x01), do: {:ok, :sub_static_controller}
   def role_type_from_byte(0x02), do: {:ok, :portable_controller}
   def role_type_from_byte(0x03), do: {:ok, :reporting_portable_controller}
-  def role_type_from_byte(0x04), do: {:ok, :portable_slave}
-  def role_type_from_byte(0x05), do: {:ok, :always_on_slave}
-  def role_type_from_byte(0x06), do: {:ok, :reporting_sleeping_slave}
-  def role_type_from_byte(0x07), do: {:ok, :listening_sleeping_slave}
-  def role_type_from_byte(0x08), do: {:ok, :network_aware_slave}
+  def role_type_from_byte(0x04), do: {:ok, :portable_end_node}
+  def role_type_from_byte(0x05), do: {:ok, :always_on_end_node}
+  def role_type_from_byte(0x06), do: {:ok, :reporting_sleeping_end_node}
+  def role_type_from_byte(0x07), do: {:ok, :listening_sleeping_end_node}
+  def role_type_from_byte(0x08), do: {:ok, :network_aware_end_node}
   def role_type_from_byte(byte), do: {:error, %DecodeError{param: :role_type, value: byte}}
 
   def node_type_to_byte(:zwaveplus_node), do: 0x00

--- a/lib/grizzly/zwave/commands/version_report.ex
+++ b/lib/grizzly/zwave/commands/version_report.ex
@@ -24,10 +24,10 @@ defmodule Grizzly.ZWave.Commands.VersionReport do
   @type library_type ::
           :static_controller
           | :controller
-          | :enhanced_slave
-          | :slave
+          | :enhanced_end_node
+          | :end_node
           | :installer
-          | :routing_slave
+          | :routing_end_node
           | :bridge_controller
           | :device_under_test
           | :av_remote
@@ -162,10 +162,10 @@ defmodule Grizzly.ZWave.Commands.VersionReport do
 
   defp decode_library_type(0x01), do: {:ok, :static_controller}
   defp decode_library_type(0x02), do: {:ok, :controller}
-  defp decode_library_type(0x03), do: {:ok, :enhanced_slave}
-  defp decode_library_type(0x04), do: {:ok, :slave}
+  defp decode_library_type(0x03), do: {:ok, :enhanced_end_node}
+  defp decode_library_type(0x04), do: {:ok, :end_node}
   defp decode_library_type(0x05), do: {:ok, :installer}
-  defp decode_library_type(0x06), do: {:ok, :routing_slave}
+  defp decode_library_type(0x06), do: {:ok, :routing_end_node}
   defp decode_library_type(0x07), do: {:ok, :bridge_controller}
   defp decode_library_type(0x08), do: {:ok, :device_under_test}
   defp decode_library_type(0x0A), do: {:ok, :av_remote}
@@ -182,10 +182,10 @@ defmodule Grizzly.ZWave.Commands.VersionReport do
 
   defp encode_library_type(:static_controller), do: 0x01
   defp encode_library_type(:controller), do: 0x02
-  defp encode_library_type(:enhanced_slave), do: 0x03
-  defp encode_library_type(:slave), do: 0x04
+  defp encode_library_type(:enhanced_end_node), do: 0x03
+  defp encode_library_type(:end_node), do: 0x04
   defp encode_library_type(:installer), do: 0x05
-  defp encode_library_type(:routing_slave), do: 0x06
+  defp encode_library_type(:routing_end_node), do: 0x06
   defp encode_library_type(:bridge_controller), do: 0x07
   defp encode_library_type(:device_under_test), do: 0x08
   defp encode_library_type(:av_remote), do: 0x0A

--- a/lib/grizzly/zwave/device_class.ex
+++ b/lib/grizzly/zwave/device_class.ex
@@ -60,7 +60,7 @@ defmodule Grizzly.ZWave.DeviceClass do
   @spec thermostat_hvac() :: t()
   def thermostat_hvac() do
     %{
-      basic_device_class: :routing_slave,
+      basic_device_class: :routing_end_node,
       generic_device_class: :thermostat,
       specific_device_class: :thermostat_general_v2,
       command_classes: %{
@@ -89,7 +89,7 @@ defmodule Grizzly.ZWave.DeviceClass do
       manufacturer_id: 0x0000,
       product_id: 0x0000,
       product_type_id: 0x0000,
-      library_type: :routing_slave
+      library_type: :routing_end_node
     }
   end
 
@@ -99,7 +99,7 @@ defmodule Grizzly.ZWave.DeviceClass do
   @spec multilevel_sensor() :: t()
   def multilevel_sensor() do
     %{
-      basic_device_class: :routing_slave,
+      basic_device_class: :routing_end_node,
       generic_device_class: :sensor_multilevel,
       specific_device_class: :routing_sensor_multilevel,
       command_classes: %{
@@ -121,7 +121,7 @@ defmodule Grizzly.ZWave.DeviceClass do
       manufacturer_id: 0x0000,
       product_id: 0x0000,
       product_type_id: 0x0000,
-      library_type: :routing_slave
+      library_type: :routing_end_node
     }
   end
 end

--- a/lib/grizzly/zwave/device_classes.ex
+++ b/lib/grizzly/zwave/device_classes.ex
@@ -3,134 +3,94 @@ defmodule Grizzly.ZWave.DeviceClasses do
   Z-Wave device classes
   """
 
-  defmodule Generate do
-    @moduledoc false
+  import Grizzly.ZWave.GeneratedMappings,
+    only: [
+      basic_device_class_mappings: 0,
+      generic_device_class_mappings: 0,
+      specific_device_class_mappings: 0
+    ]
 
-    import Grizzly.ZWave.GeneratedMappings,
-      only: [
-        basic_device_class_mappings: 0,
-        generic_device_class_mappings: 0,
-        specific_device_class_mappings: 0
-      ]
+  basic_mappings = basic_device_class_mappings()
+  generic_mappings = generic_device_class_mappings()
+  specific_mappings = specific_device_class_mappings()
 
-    defmacro __before_compile__(_) do
-      basic_mappings = basic_device_class_mappings()
-      generic_mappings = generic_device_class_mappings()
-      specific_mappings = specific_device_class_mappings()
+  basic_classes_union =
+    basic_mappings
+    |> Enum.map(&elem(&1, 1))
+    |> Enum.reverse()
+    |> Enum.reduce(&{:|, [], [&1, &2]})
 
-      basic_device_class_from_byte =
-        for {byte, device_class} <- basic_mappings do
-          quote do
-            def basic_device_class_from_byte(unquote(byte)), do: {:ok, unquote(device_class)}
-          end
-        end
+  generic_classes_union =
+    generic_mappings
+    |> Enum.map(&elem(&1, 1))
+    |> Enum.reverse()
+    |> Enum.reduce(&{:|, [], [&1, &2]})
 
-      basic_device_class_to_byte =
-        for {byte, device_class} <- basic_mappings do
-          quote do
-            def basic_device_class_to_byte(unquote(device_class)), do: unquote(byte)
-          end
-        end
+  specific_classes_union =
+    specific_mappings
+    |> Enum.map(&elem(&1, 2))
+    |> Enum.reverse()
+    |> Enum.uniq()
+    |> Enum.reduce(&{:|, [], [&1, &2]})
 
-      generic_device_class_from_byte =
-        for {byte, device_class} <- generic_mappings do
-          quote do
-            def generic_device_class_from_byte(unquote(byte)), do: {:ok, unquote(device_class)}
-          end
-        end
+  @type basic_device_class :: unquote(basic_classes_union)
+  @type generic_device_class :: unquote(generic_classes_union)
+  @type specific_device_class :: unquote(specific_classes_union)
 
-      generic_device_class_to_byte =
-        for {byte, device_class} <- generic_mappings do
-          quote do
-            def generic_device_class_to_byte(unquote(device_class)), do: unquote(byte)
-          end
-        end
-
-      specific_device_class_from_byte =
-        for {gen_class, byte, spec_class} <- specific_mappings do
-          quote do
-            def specific_device_class_from_byte(unquote(gen_class), unquote(byte)),
-              do: {:ok, unquote(spec_class)}
-          end
-        end
-
-      specific_device_class_to_byte =
-        for {gen_class, byte, spec_class} <- specific_mappings do
-          quote do
-            def specific_device_class_to_byte(unquote(gen_class), unquote(spec_class)),
-              do: unquote(byte)
-          end
-        end
-
-      basic_classes_union =
-        basic_mappings
-        |> Enum.map(&elem(&1, 1))
-        |> Enum.reverse()
-        |> Enum.reduce(&{:|, [], [&1, &2]})
-
-      generic_classes_union =
-        generic_mappings
-        |> Enum.map(&elem(&1, 1))
-        |> Enum.reverse()
-        |> Enum.reduce(&{:|, [], [&1, &2]})
-
-      specific_classes_union =
-        specific_mappings
-        |> Enum.map(&elem(&1, 2))
-        |> Enum.reverse()
-        |> Enum.uniq()
-        |> Enum.reduce(&{:|, [], [&1, &2]})
-
-      quote do
-        @type basic_device_class :: unquote(basic_classes_union)
-        @type generic_device_class :: unquote(generic_classes_union)
-        @type specific_device_class :: unquote(specific_classes_union)
-
-        @doc """
-        Try to make a basic device class from a byte
-        """
-        @spec basic_device_class_from_byte(byte()) ::
-                {:ok, basic_device_class()} | {:ok, :unknown}
-        unquote(basic_device_class_from_byte)
-        def basic_device_class_from_byte(_byte), do: {:ok, :unknown}
-
-        @doc """
-        Make a byte from a device class
-        """
-        @spec basic_device_class_to_byte(basic_device_class()) :: byte()
-        unquote(basic_device_class_to_byte)
-
-        @doc """
-        Try to get the generic device class for the byte
-        """
-        @spec generic_device_class_from_byte(byte()) ::
-                {:ok, generic_device_class()} | {:ok, :unknown}
-        unquote(generic_device_class_from_byte)
-        def generic_device_class_from_byte(_byte), do: {:ok, :unknown}
-
-        @doc """
-        Turn the generic device class into a byte
-        """
-        @spec generic_device_class_to_byte(generic_device_class()) :: byte()
-        unquote(generic_device_class_to_byte)
-
-        @doc """
-        Try to get the specific device class from the byte given the generic device class
-        """
-        @spec specific_device_class_from_byte(generic_device_class(), byte()) ::
-                {:ok, specific_device_class()} | {:ok, :unknown}
-        unquote(specific_device_class_from_byte)
-        def specific_device_class_from_byte(_, _byte), do: {:ok, :unknown}
-
-        @doc """
-        Make the specific device class into a byte
-        """
-        @spec specific_device_class_to_byte(generic_device_class(), specific_device_class()) ::
-                byte()
-        unquote(specific_device_class_to_byte)
-      end
-    end
+  @doc """
+  Try to make a basic device class from a byte
+  """
+  @spec basic_device_class_from_byte(byte()) :: {:ok, basic_device_class()} | {:ok, :unknown}
+  for {byte, device_class} <- basic_mappings do
+    def basic_device_class_from_byte(unquote(byte)), do: {:ok, unquote(device_class)}
   end
 
-  @before_compile Generate
+  def basic_device_class_from_byte(_byte), do: {:ok, :unknown}
+
+  @doc """
+  Make a byte from a device class
+  """
+  @spec basic_device_class_to_byte(basic_device_class()) :: byte()
+  for {byte, device_class} <- basic_mappings do
+    def basic_device_class_to_byte(unquote(device_class)), do: unquote(byte)
+  end
+
+  @doc """
+  Try to get the generic device class for the byte
+  """
+  @spec generic_device_class_from_byte(byte()) :: {:ok, generic_device_class()} | {:ok, :unknown}
+  for {byte, device_class} <- generic_mappings do
+    def generic_device_class_from_byte(unquote(byte)), do: {:ok, unquote(device_class)}
+  end
+
+  def generic_device_class_from_byte(_byte), do: {:ok, :unknown}
+
+  @doc """
+  Turn the generic device class into a byte
+  """
+  @spec generic_device_class_to_byte(generic_device_class()) :: byte()
+  for {byte, device_class} <- generic_mappings do
+    def generic_device_class_to_byte(unquote(device_class)), do: unquote(byte)
+  end
+
+  @doc """
+  Try to get the specific device class from the byte given the generic device class
+  """
+  @spec specific_device_class_from_byte(generic_device_class(), byte()) ::
+          {:ok, specific_device_class()} | {:ok, :unknown}
+  for {gen_class, byte, spec_class} <- specific_mappings do
+    def specific_device_class_from_byte(unquote(gen_class), unquote(byte)),
+      do: {:ok, unquote(spec_class)}
+  end
+
+  def specific_device_class_from_byte(_, _byte), do: {:ok, :unknown}
+
+  @doc """
+  Make the specific device class into a byte
+  """
+  @spec specific_device_class_to_byte(generic_device_class(), specific_device_class()) :: byte()
+  for {gen_class, byte, spec_class} <- specific_mappings do
+    def specific_device_class_to_byte(unquote(gen_class), unquote(spec_class)),
+      do: unquote(byte)
+  end
 end

--- a/lib/grizzly/zwave/generated_mappings.ex
+++ b/lib/grizzly/zwave/generated_mappings.ex
@@ -105,6 +105,7 @@ defmodule Grizzly.ZWave.GeneratedMappings do
       {128, :battery},
       {129, :clock},
       {130, :hail},
+      {131, :user_credential},
       {132, :wake_up},
       {133, :association},
       {134, :version},
@@ -142,7 +143,7 @@ defmodule Grizzly.ZWave.GeneratedMappings do
   end
 
   def basic_device_class_mappings() do
-    [{1, :controller}, {2, :static_controller}, {3, :slave}, {4, :routing_slave}]
+    [{1, :controller}, {2, :static_controller}, {3, :end_node}, {4, :routing_end_node}]
   end
 
   def generic_device_class_mappings() do
@@ -156,7 +157,7 @@ defmodule Grizzly.ZWave.GeneratedMappings do
       {7, :sensor_notification},
       {8, :thermostat},
       {9, :window_covering},
-      {15, :repeater_slave},
+      {15, :repeater_end_node},
       {16, :switch_binary},
       {17, :switch_multilevel},
       {18, :switch_remote},
@@ -215,10 +216,10 @@ defmodule Grizzly.ZWave.GeneratedMappings do
       {:network_extender, 0, :not_used},
       {:network_extender, 1, :secure_extender},
       {:non_interoperable, 0, :not_used},
-      {:repeater_slave, 0, :not_used},
-      {:repeater_slave, 1, :repeater_slave},
-      {:repeater_slave, 2, :virtual_node},
-      {:repeater_slave, 3, :ir_repeater},
+      {:repeater_end_node, 0, :not_used},
+      {:repeater_end_node, 1, :repeater_end_node},
+      {:repeater_end_node, 2, :virtual_node},
+      {:repeater_end_node, 3, :ir_repeater},
       {:security_panel, 0, :not_used},
       {:security_panel, 1, :zoned_security_panel},
       {:semi_interoperable, 0, :not_used},

--- a/lib/grizzly/zwave/icon_type.ex
+++ b/lib/grizzly/zwave/icon_type.ex
@@ -12,6 +12,9 @@ defmodule Grizzly.ZWave.IconType do
   provided by Silicon Labs for more information.
   """
 
+  @type name :: atom()
+  @type value :: 0x0000..0xFFFF
+
   @mappings [
     {0x0000, :unassigned},
     {0x0100, :generic_central_controller},
@@ -149,7 +152,7 @@ defmodule Grizzly.ZWave.IconType do
     {0x1900, :generic_window_covering_endpoint_aware},
     {0x1A00, :generic_window_covering_position_endpoint_aware},
     {0x1B00, :generic_repeater},
-    {0x1B01, :specific_repeater_slave},
+    {0x1B01, :specific_repeater_end_node},
     {0x1B03, :specific_ir_repeater},
     {0x1C00, :generic_dimmer_wall_switch},
     {0x1C01, :specific_dimmer_wall_switch_one_button},
@@ -179,10 +182,6 @@ defmodule Grizzly.ZWave.IconType do
     {0x2202, :specific_sound_switch_chime},
     {0x2203, :specific_sound_switch_alarm_clock}
   ]
-
-  @type name :: atom()
-
-  @type value :: 0x0000..0xFFFF
 
   @doc """
   Get the icon type's name from a 16-bit integer value

--- a/lib/mix/tasks/zwave.gen.xml_mappings.ex
+++ b/lib/mix/tasks/zwave.gen.xml_mappings.ex
@@ -20,7 +20,7 @@ if Code.ensure_loaded?(SweetXml) do
 
     @switches [dry_run: :boolean]
 
-    @skip_command_classes [:zwave_cmd_class, :zwave_cmd_class_lr]
+    @skip_command_classes [:zwave_cmd_class, :zwave_long_range]
     @command_class_name_overrides %{
       0x4F => :zip_6lowpan,
       0x59 => :association_group_info,

--- a/resources/ZWave_custom_cmd_classes.xml
+++ b/resources/ZWave_custom_cmd_classes.xml
@@ -1,8 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<zw_classes version="2.7.4">
+﻿<?xml version="1.0" encoding="US-ASCII"?>
+<!--
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-FileCopyrightText: 2022-2024 Z-Wave-Alliance <https://z-wavealliance.org/>
+-->
+<zw_classes version="2.15.0">
     <bas_dev key="0x01" name="BASIC_TYPE_CONTROLLER" help="Controller" comment="Node is a portable controller" />
-    <bas_dev key="0x04" name="BASIC_TYPE_ROUTING_SLAVE" help="Routing Slave" comment="Node is a slave with routing capabilities" />
-    <bas_dev key="0x03" name="BASIC_TYPE_SLAVE" help="Slave" comment="Node is a slave" />
+    <bas_dev key="0x04" name="BASIC_TYPE_ROUTING_END_NODE" help="Routing End Node" comment="Node is an End Node with routing capabilities" />
+    <bas_dev key="0x03" name="BASIC_TYPE_END_NODE" help="End Node" comment="Node is an End Node" />
     <bas_dev key="0x02" name="BASIC_TYPE_STATIC_CONTROLLER" help="Static Controller" comment="Node is a static controller" />
     <gen_dev key="0x03" name="GENERIC_TYPE_AV_CONTROL_POINT" help="Av Control Point" comment="AV Control Point">
         <spec_dev key="0x00" name="SPECIFIC_TYPE_NOT_USED" help="Not Used" comment="Specific Device Class Not Used" />
@@ -19,8 +23,8 @@
         <spec_dev key="0x00" name="SPECIFIC_TYPE_NOT_USED" help="Not Used" comment="Specific Device Class Not Used" />
         <spec_dev key="0x01" name="SPECIFIC_TYPE_DOOR_LOCK" help="Door Lock" comment="Door Lock" />
         <spec_dev key="0x02" name="SPECIFIC_TYPE_ADVANCED_DOOR_LOCK" help="Advanced Door Lock" comment="Advanced Door Lock" />
-        <spec_dev key="0x03" name="SPECIFIC_TYPE_SECURE_KEYPAD_DOOR_LOCK" help="Secure Keypad Door Lock" comment="Door Lock (keypad –lever) Device Type" />
-        <spec_dev key="0x04" name="SPECIFIC_TYPE_SECURE_KEYPAD_DOOR_LOCK_DEADBOLT" help="Door Lock Keypad Deadbolt" comment="Door Lock (keypad – deadbolt) Device Type" />
+        <spec_dev key="0x03" name="SPECIFIC_TYPE_SECURE_KEYPAD_DOOR_LOCK" help="Secure Keypad Door Lock" comment="Door Lock (keypad -lever) Device Type" />
+        <spec_dev key="0x04" name="SPECIFIC_TYPE_SECURE_KEYPAD_DOOR_LOCK_DEADBOLT" help="Door Lock Keypad Deadbolt" comment="Door Lock (keypad - deadbolt) Device Type" />
         <spec_dev key="0x05" name="SPECIFIC_TYPE_SECURE_DOOR" help="Secure Door" comment="Barrier Operator Specific Device Class" />
         <spec_dev key="0x06" name="SPECIFIC_TYPE_SECURE_GATE" help="Secure Gate" comment="Barrier Operator Specific Device Class" />
         <spec_dev key="0x07" name="SPECIFIC_TYPE_SECURE_BARRIER_ADDON" help="Secure Barrier Addon" comment="Barrier Operator Specific Device Class" />
@@ -49,9 +53,9 @@
     <gen_dev key="0xFF" name="GENERIC_TYPE_NON_INTEROPERABLE" help="Non Interoperable" comment="Non interoperable">
         <spec_dev key="0x00" name="SPECIFIC_TYPE_NOT_USED" help="Not Used" comment="Specific Device Class Not Used" />
     </gen_dev>
-    <gen_dev key="0x0F" name="GENERIC_TYPE_REPEATER_SLAVE" help="Repeater Slave" comment="Repeater Slave">
+    <gen_dev key="0x0F" name="GENERIC_TYPE_REPEATER_END_NODE" help="Repeater End Node" comment="Repeater End Node">
         <spec_dev key="0x00" name="SPECIFIC_TYPE_NOT_USED" help="Not Used" comment="Specific Device Class Not Used" />
-        <spec_dev key="0x01" name="SPECIFIC_TYPE_REPEATER_SLAVE" help="Repeater Slave" comment="Basic Repeater Slave" />
+        <spec_dev key="0x01" name="SPECIFIC_TYPE_REPEATER_END_NODE" help="Repeater End Node" comment="Basic Repeater End Node" />
         <spec_dev key="0x02" name="SPECIFIC_TYPE_VIRTUAL_NODE" help="Virtual Node" />
         <spec_dev key="0x03" name="SPECIFIC_TYPE_IR_REPEATER" help="IR Repeater" />
     </gen_dev>
@@ -1541,7 +1545,7 @@
             <param key="0x02" name="Max Command records" type="WORD" />
         </cmd>
     </cmd_class>
-    <cmd_class key="0x85" version="1" name="COMMAND_CLASS_ASSOCIATION" help="Command Class Association">
+    <cmd_class key="0x85" version="1" name="COMMAND_CLASS_ASSOCIATION" help="Command Class Association" comment="[OBSOLETED]">
         <cmd key="0x02" name="ASSOCIATION_GET" help="Association Get" support_mode="RX">
             <param key="0x00" name="Grouping Identifier" type="BYTE" />
         </cmd>
@@ -1604,6 +1608,39 @@
         </cmd>
     </cmd_class>
     <cmd_class key="0x85" version="3" name="COMMAND_CLASS_ASSOCIATION" help="Command Class Association">
+        <cmd key="0x02" name="ASSOCIATION_GET" help="Association Get" support_mode="RX">
+            <param key="0x00" name="Grouping Identifier" type="BYTE" />
+        </cmd>
+        <cmd key="0x05" name="ASSOCIATION_GROUPINGS_GET" help="Association Groupings Get" support_mode="RX" />
+        <cmd key="0x06" name="ASSOCIATION_GROUPINGS_REPORT" help="Association Groupings Report" support_mode="TX">
+            <param key="0x00" name="Supported Groupings" type="BYTE" />
+        </cmd>
+        <cmd key="0x04" name="ASSOCIATION_REMOVE" help="Association Remove" support_mode="RX">
+            <param key="0x00" name="Grouping Identifier" type="BYTE" />
+            <param key="0x01" name="Node ID" type="VARIANT" encaptype="NODE_NUMBER">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x03" name="ASSOCIATION_REPORT" help="Association Report" support_mode="TX">
+            <param key="0x00" name="Grouping Identifier" type="BYTE" />
+            <param key="0x01" name="Max Nodes Supported" type="BYTE" />
+            <param key="0x02" name="Reports to Follow" type="BYTE" />
+            <param key="0x03" name="NodeID" type="VARIANT" encaptype="NODE_NUMBER">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x01" name="ASSOCIATION_SET" help="Association Set" support_mode="RX">
+            <param key="0x00" name="Grouping Identifier" type="BYTE" />
+            <param key="0x01" name="Node ID" type="VARIANT" encaptype="NODE_NUMBER">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x0B" name="ASSOCIATION_SPECIFIC_GROUP_GET" help="Association Specific Group Get" support_mode="RX" />
+        <cmd key="0x0C" name="ASSOCIATION_SPECIFIC_GROUP_REPORT" help="Association Specific Group Report" support_mode="TX">
+            <param key="0x00" name="Group" type="BYTE" />
+        </cmd>
+    </cmd_class>
+    <cmd_class key="0x85" version="4" name="COMMAND_CLASS_ASSOCIATION" help="Command Class Association">
         <cmd key="0x02" name="ASSOCIATION_GET" help="Association Get" support_mode="RX">
             <param key="0x00" name="Grouping Identifier" type="BYTE" />
         </cmd>
@@ -2355,7 +2392,7 @@
             <param key="0x00" name="Parameter Number" type="WORD" />
             <param key="0x01" name="Reports to follow" type="BYTE" />
             <param key="0x02" name="Name" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" is_ascii="true" sizemask="0x00" />
             </param>
         </cmd>
         <cmd key="0x0C" name="CONFIGURATION_INFO_GET" help="Configuration Info Get" support_mode="RX">
@@ -2365,7 +2402,7 @@
             <param key="0x00" name="Parameter Number" type="WORD" />
             <param key="0x01" name="Reports to follow" type="BYTE" />
             <param key="0x02" name="Info" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" is_ascii="true" sizemask="0x00" />
             </param>
         </cmd>
         <cmd key="0x0E" name="CONFIGURATION_PROPERTIES_GET" help="Configuration Properties Get" support_mode="RX">
@@ -2462,7 +2499,7 @@
             <param key="0x00" name="Parameter Number" type="WORD" />
             <param key="0x01" name="Reports to follow" type="BYTE" />
             <param key="0x02" name="Name" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" is_ascii="true" sizemask="0x00" />
             </param>
         </cmd>
         <cmd key="0x0C" name="CONFIGURATION_INFO_GET" help="Configuration Info Get" support_mode="RX">
@@ -2472,7 +2509,7 @@
             <param key="0x00" name="Parameter Number" type="WORD" />
             <param key="0x01" name="Reports to follow" type="BYTE" />
             <param key="0x02" name="Info" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" is_ascii="true" sizemask="0x00" />
             </param>
         </cmd>
         <cmd key="0x0E" name="CONFIGURATION_PROPERTIES_GET" help="Configuration Properties Get" support_mode="RX">
@@ -2541,7 +2578,7 @@
             <param key="0x00" name="Command Class" type="BYTE" encaptype="CMD_CLASS_REF" />
             <param key="0x01" name="Command" type="BYTE" encaptype="CMD_REF" />
             <param key="0x02" name="Data" type="VARIANT" encaptype="CMD_DATA">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x03" name="Checksum" type="WORD" />
         </cmd>
@@ -2685,8 +2722,8 @@
                 <const key="0x01" flagname="Timed operation" flagmask="0x02" />
             </param>
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
-                <bitfield key="0x00" fieldname="Inside Door Handles State" fieldmask="0x0F" />
-                <bitfield key="0x01" fieldname="Outside Door Handles State" fieldmask="0xF0" shifter="4" />
+                <bitfield key="0x00" fieldname="Inside Door Handles Enabled" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Outside Door Handles Enabled" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Lock Timeout Minutes" type="BYTE" />
             <param key="0x03" name="Lock Timeout Seconds" type="BYTE" />
@@ -2697,8 +2734,8 @@
                 <const key="0x01" flagname="Timed operation" flagmask="0x02" />
             </param>
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
-                <bitfield key="0x00" fieldname="Inside Door Handles State" fieldmask="0x0F" />
-                <bitfield key="0x01" fieldname="Outside Door Handles State" fieldmask="0xF0" shifter="4" />
+                <bitfield key="0x00" fieldname="Inside Door Handles Enabled" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Outside Door Handles Enabled" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Lock Timeout Minutes" type="BYTE" />
             <param key="0x03" name="Lock Timeout Seconds" type="BYTE" />
@@ -2719,8 +2756,8 @@
                 <bitfield key="0x01" fieldname="Outside Door Handles Mode" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Door Condition" type="BYTE" />
-            <param key="0x03" name="Lock Timeout Minutes" type="BYTE" />
-            <param key="0x04" name="Lock Timeout Seconds" type="BYTE" />
+            <param key="0x03" name="Remaining Lock Time Minutes" type="BYTE" />
+            <param key="0x04" name="Remaining Lock Time Seconds" type="BYTE" />
         </cmd>
         <cmd key="0x01" name="DOOR_LOCK_OPERATION_SET" help="Door Lock Operation Set" support_mode="RX">
             <param key="0x00" name="Door Lock Mode" type="CONST">
@@ -2742,8 +2779,8 @@
                 <const key="0x01" flagname="Timed operation" flagmask="0x02" />
             </param>
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
-                <bitfield key="0x00" fieldname="Inside Door Handles State" fieldmask="0x0F" />
-                <bitfield key="0x01" fieldname="Outside Door Handles State" fieldmask="0xF0" shifter="4" />
+                <bitfield key="0x00" fieldname="Inside Door Handles Enabled" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Outside Door Handles Enabled" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Lock Timeout Minutes" type="BYTE" />
             <param key="0x03" name="Lock Timeout Seconds" type="BYTE" />
@@ -2754,8 +2791,8 @@
                 <const key="0x01" flagname="Timed operation" flagmask="0x02" />
             </param>
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
-                <bitfield key="0x00" fieldname="Inside Door Handles State" fieldmask="0x0F" />
-                <bitfield key="0x01" fieldname="Outside Door Handles State" fieldmask="0xF0" shifter="4" />
+                <bitfield key="0x00" fieldname="Inside Door Handles Enabled" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Outside Door Handles Enabled" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Lock Timeout Minutes" type="BYTE" />
             <param key="0x03" name="Lock Timeout Seconds" type="BYTE" />
@@ -2777,8 +2814,8 @@
                 <bitfield key="0x01" fieldname="Outside Door Handles Mode" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Door Condition" type="BYTE" />
-            <param key="0x03" name="Lock Timeout Minutes" type="BYTE" />
-            <param key="0x04" name="Lock Timeout Seconds" type="BYTE" />
+            <param key="0x03" name="Remaining Lock Time Minutes" type="BYTE" />
+            <param key="0x04" name="Remaining Lock Time Seconds" type="BYTE" />
         </cmd>
         <cmd key="0x01" name="DOOR_LOCK_OPERATION_SET" help="Door Lock Operation Set" support_mode="RX">
             <param key="0x00" name="Door Lock Mode" type="CONST">
@@ -2788,8 +2825,7 @@
                 <const key="0x03" flagname="Door Unsecured for inside Door Handles with timeout" flagmask="0x11" />
                 <const key="0x04" flagname="Door Unsecured for outside Door Handles" flagmask="0x20" />
                 <const key="0x05" flagname="Door Unsecured for outside Door Handles with timeout" flagmask="0x21" />
-                <const key="0x06" flagname="Door/Lock State Unknown" flagmask="0xFE" />
-                <const key="0x07" flagname="Door Secured" flagmask="0xFF" />
+                <const key="0x06" flagname="Door Secured" flagmask="0xFF" />
             </param>
         </cmd>
     </cmd_class>
@@ -2801,8 +2837,8 @@
                 <const key="0x01" flagname="Timed operation" flagmask="0x02" />
             </param>
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
-                <bitfield key="0x00" fieldname="Inside Door Handles State" fieldmask="0x0F" />
-                <bitfield key="0x01" fieldname="Outside Door Handles State" fieldmask="0xF0" shifter="4" />
+                <bitfield key="0x00" fieldname="Inside Door Handles Enabled" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Outside Door Handles Enabled" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Lock Timeout Minutes" type="BYTE" />
             <param key="0x03" name="Lock Timeout Seconds" type="BYTE" />
@@ -2813,8 +2849,8 @@
                 <const key="0x01" flagname="Timed operation" flagmask="0x02" />
             </param>
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
-                <bitfield key="0x00" fieldname="Inside Door Handles State" fieldmask="0x0F" />
-                <bitfield key="0x01" fieldname="Outside Door Handles State" fieldmask="0xF0" shifter="4" />
+                <bitfield key="0x00" fieldname="Inside Door Handles Enabled" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Outside Door Handles Enabled" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Lock Timeout Minutes" type="BYTE" />
             <param key="0x03" name="Lock Timeout Seconds" type="BYTE" />
@@ -2836,8 +2872,8 @@
                 <bitfield key="0x01" fieldname="Outside Door Handles Mode" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Door Condition" type="BYTE" />
-            <param key="0x03" name="Lock Timeout Minutes" type="BYTE" />
-            <param key="0x04" name="Lock Timeout Seconds" type="BYTE" />
+            <param key="0x03" name="Remaining Lock Time Minutes" type="BYTE" />
+            <param key="0x04" name="Remaining Lock Time Seconds" type="BYTE" />
             <param key="0x05" name="Target Door Lock Mode" type="CONST">
                 <const key="0x00" flagname="Door Unsecured" flagmask="0x00" />
                 <const key="0x01" flagname="Door Unsecured with timeout" flagmask="0x01" />
@@ -2862,8 +2898,7 @@
                 <const key="0x03" flagname="Door Unsecured for inside Door Handles with timeout" flagmask="0x11" />
                 <const key="0x04" flagname="Door Unsecured for outside Door Handles" flagmask="0x20" />
                 <const key="0x05" flagname="Door Unsecured for outside Door Handles with timeout" flagmask="0x21" />
-                <const key="0x06" flagname="Door/Lock State Unknown" flagmask="0xFE" />
-                <const key="0x07" flagname="Door Secured" flagmask="0xFF" />
+                <const key="0x06" flagname="Door Secured" flagmask="0xFF" />
             </param>
         </cmd>
     </cmd_class>
@@ -2875,8 +2910,8 @@
                 <const key="0x01" flagname="Timed operation" flagmask="0x02" />
             </param>
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
-                <bitfield key="0x00" fieldname="Inside Door Handles State" fieldmask="0x0F" />
-                <bitfield key="0x01" fieldname="Outside Door Handles State" fieldmask="0xF0" shifter="4" />
+                <bitfield key="0x00" fieldname="Inside Door Handles Enabled" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Outside Door Handles Enabled" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Lock Timeout Minutes" type="BYTE" />
             <param key="0x03" name="Lock Timeout Seconds" type="BYTE" />
@@ -2894,8 +2929,8 @@
                 <const key="0x01" flagname="Timed operation" flagmask="0x02" />
             </param>
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
-                <bitfield key="0x00" fieldname="Inside Door Handles State" fieldmask="0x0F" />
-                <bitfield key="0x01" fieldname="Outside Door Handles State" fieldmask="0xF0" shifter="4" />
+                <bitfield key="0x00" fieldname="Inside Door Handles Enabled" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Outside Door Handles Enabled" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Lock Timeout Minutes" type="BYTE" />
             <param key="0x03" name="Lock Timeout Seconds" type="BYTE" />
@@ -2916,7 +2951,7 @@
                 <const key="0x03" flagname="Door Unsecured for inside Door Handles with timeout" flagmask="0x11" />
                 <const key="0x04" flagname="Door Unsecured for outside Door Handles" flagmask="0x20" />
                 <const key="0x05" flagname="Door Unsecured for outside Door Handles with timeout" flagmask="0x21" />
-                <const key="0x06" flagname="Door/Lock State Unknown" flagmask="0xFE" />
+                <const key="0x06" flagname="Door Mode Unknown" flagmask="0xFE" />
                 <const key="0x07" flagname="Door Secured" flagmask="0xFF" />
             </param>
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
@@ -2924,8 +2959,8 @@
                 <bitfield key="0x01" fieldname="Outside Door Handles Mode" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Door Condition" type="BYTE" />
-            <param key="0x03" name="Lock Timeout Minutes" type="BYTE" />
-            <param key="0x04" name="Lock Timeout Seconds" type="BYTE" />
+            <param key="0x03" name="Remaining Lock Time Minutes" type="BYTE" />
+            <param key="0x04" name="Remaining Lock Time Seconds" type="BYTE" />
             <param key="0x05" name="Target Door Lock Mode" type="CONST">
                 <const key="0x00" flagname="Door Unsecured" flagmask="0x00" />
                 <const key="0x01" flagname="Door Unsecured with timeout" flagmask="0x01" />
@@ -2933,7 +2968,7 @@
                 <const key="0x03" flagname="Door Unsecured for inside Door Handles with timeout" flagmask="0x11" />
                 <const key="0x04" flagname="Door Unsecured for outside Door Handles" flagmask="0x20" />
                 <const key="0x05" flagname="Door Unsecured for outside Door Handles with timeout" flagmask="0x21" />
-                <const key="0x06" flagname="Door/Lock State Unknown" flagmask="0xFE" />
+                <const key="0x06" flagname="Door Mode Unknown" flagmask="0xFE" />
                 <const key="0x07" flagname="Door Secured" flagmask="0xFF" />
             </param>
             <param key="0x06" name="Duration" type="CONST">
@@ -2950,8 +2985,7 @@
                 <const key="0x03" flagname="Door Unsecured for inside Door Handles with timeout" flagmask="0x11" />
                 <const key="0x04" flagname="Door Unsecured for outside Door Handles" flagmask="0x20" />
                 <const key="0x05" flagname="Door Unsecured for outside Door Handles with timeout" flagmask="0x21" />
-                <const key="0x06" flagname="Door/Lock State Unknown" flagmask="0xFE" />
-                <const key="0x07" flagname="Door Secured" flagmask="0xFF" />
+                <const key="0x06" flagname="Door Secured" flagmask="0xFF" />
             </param>
         </cmd>
         <cmd key="0x07" name="DOOR_LOCK_CAPABILITIES_GET" help="Door Lock Capabilities Get" support_mode="RX" />
@@ -3074,7 +3108,7 @@
             </param>
             <param key="0x01" name="Report number 2" type="BYTE" />
             <param key="0x02" name="Data" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x03" name="Checksum" type="WORD" />
         </cmd>
@@ -3126,7 +3160,7 @@
             </param>
             <param key="0x01" name="Report number 2" type="BYTE" />
             <param key="0x02" name="Data" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x03" name="Checksum" type="WORD" />
         </cmd>
@@ -3184,7 +3218,7 @@
             </param>
             <param key="0x01" name="Report number 2" type="BYTE" />
             <param key="0x02" name="Data" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x03" name="Checksum" type="WORD" />
         </cmd>
@@ -3271,7 +3305,7 @@
             </param>
             <param key="0x01" name="Report number 2" type="BYTE" />
             <param key="0x02" name="Data" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x03" name="Checksum" type="WORD" />
         </cmd>
@@ -3385,7 +3419,7 @@
             </param>
             <param key="0x01" name="Report number 2" type="BYTE" />
             <param key="0x02" name="Data" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x03" name="Checksum" type="WORD" />
         </cmd>
@@ -3502,7 +3536,7 @@
             </param>
             <param key="0x01" name="Report number 2" type="BYTE" />
             <param key="0x02" name="Data" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x03" name="Checksum" type="WORD" />
         </cmd>
@@ -3528,6 +3562,133 @@
                 <const key="0x05" flagname="Another firmware image" flagmask="0x05" />
                 <const key="0x06" flagname="Insufficient battery level" flagmask="0x06" />
                 <const key="0x07" flagname="Valid combination" flagmask="0xFF" />
+            </param>
+        </cmd>
+        <cmd key="0x07" name="FIRMWARE_UPDATE_MD_STATUS_REPORT" help="Firmware Update Md Status Report" support_mode="TX">
+            <param key="0x00" name="Status" type="CONST">
+                <const key="0x00" flagname="unable to receive without checksum error" flagmask="0x00" />
+                <const key="0x01" flagname="unable to receive" flagmask="0x01" />
+                <const key="0x02" flagname="does not match the Manufacturer ID" flagmask="0x02" />
+                <const key="0x03" flagname="does not match the Firmware ID" flagmask="0x03" />
+                <const key="0x04" flagname="does not match the Firmware Target" flagmask="0x04" />
+                <const key="0x05" flagname="Invalid file header information" flagmask="0x05" />
+                <const key="0x06" flagname="Invalid file header format" flagmask="0x06" />
+                <const key="0x07" flagname="Insufficient memory" flagmask="0x07" />
+                <const key="0x08" flagname="does not match the Hardware version" flagmask="0x08" />
+                <const key="0x09" flagname="successfully, waiting for activation" flagmask="0xFD" />
+                <const key="0x0A" flagname="successfully stored" flagmask="0xFE" />
+                <const key="0x0B" flagname="successfully" flagmask="0xFF" />
+            </param>
+            <param key="0x01" name="WaitTime" type="WORD" />
+        </cmd>
+        <cmd key="0x08" name="FIRMWARE_UPDATE_ACTIVATION_SET" help="Firmware Update Activation Set Command" support_mode="RX">
+            <param key="0x00" name="Manufacturer ID" type="WORD" />
+            <param key="0x01" name="Firmware ID" type="WORD" />
+            <param key="0x02" name="Checksum" type="WORD" />
+            <param key="0x03" name="Firmware Target" type="BYTE" />
+            <param key="0x04" name="Hardware Version" type="BYTE" />
+        </cmd>
+        <cmd key="0x09" name="FIRMWARE_UPDATE_ACTIVATION_STATUS_REPORT" help="Firmware Update Activation Status Report" support_mode="TX">
+            <param key="0x00" name="Manufacturer ID" type="WORD" />
+            <param key="0x01" name="Firmware ID" type="WORD" />
+            <param key="0x02" name="Checksum" type="WORD" />
+            <param key="0x03" name="Firmware Target" type="BYTE" />
+            <param key="0x04" name="Firmware Update Status" type="CONST">
+                <const key="0x00" flagname="Invalid combination" flagmask="0x00" />
+                <const key="0x01" flagname="Error activating the firmware" flagmask="0x01" />
+                <const key="0x02" flagname="Firmware update completed successfully" flagmask="0xFF" />
+            </param>
+            <param key="0x05" name="Hardware Version" type="BYTE" />
+        </cmd>
+        <cmd key="0x0A" name="FIRMWARE_UPDATE_MD_PREPARE_GET" help="Firmware Update MD Prepare Get" support_mode="RX">
+            <param key="0x00" name="Manufacturer ID" type="WORD" />
+            <param key="0x01" name="Firmware ID" type="WORD" />
+            <param key="0x02" name="Firmware Target" type="BYTE" />
+            <param key="0x03" name="Fragment Size" type="WORD" />
+            <param key="0x04" name="Hardware Version" type="BYTE" />
+        </cmd>
+        <cmd key="0x0B" name="FIRMWARE_UPDATE_MD_PREPARE_REPORT" help="Firmware Update MD Prepare Report" support_mode="TX">
+            <param key="0x00" name="Status" type="CONST">
+                <const key="0x00" flagname="Invalid combination" flagmask="0x00" />
+                <const key="0x01" flagname="Requires authentication" flagmask="0x01" />
+                <const key="0x02" flagname="Invalid Fragment Size" flagmask="0x02" />
+                <const key="0x03" flagname="Not downloadable" flagmask="0x03" />
+                <const key="0x04" flagname="Invalid Hardware Version" flagmask="0x04" />
+                <const key="0x05" flagname="Valid combination" flagmask="0xFF" />
+            </param>
+            <param key="0x01" name="Firmware Checksum" type="WORD" />
+        </cmd>
+    </cmd_class>
+    <cmd_class key="0x7A" version="8" name="COMMAND_CLASS_FIRMWARE_UPDATE_MD" help="Command Class Firmware Update Meta Data">
+        <cmd key="0x01" name="FIRMWARE_MD_GET" help="Firmware Md Get" support_mode="RX" />
+        <cmd key="0x02" name="FIRMWARE_MD_REPORT" help="Firmware Md Report" support_mode="TX">
+            <param key="0x00" name="Manufacturer ID" type="WORD" />
+            <param key="0x01" name="Firmware 0 ID" type="WORD" />
+            <param key="0x02" name="Firmware 0 Checksum" type="WORD" />
+            <param key="0x03" name="Firmware Upgradable" type="BYTE" />
+            <param key="0x04" name="Number of Firmware Targets" type="BYTE" />
+            <param key="0x05" name="Max Fragment Size" type="WORD" />
+            <variant_group key="0x06" name="vg1" paramOffs="0x04" sizemask="0xFF" sizeoffs="0x00">
+                <param key="0x00" name="Firmware ID" type="WORD" />
+            </variant_group>
+            <param key="0x07" name="Hardware Version" type="BYTE" />
+            <param key="0x08" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="CC" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Activation" flagmask="0x02" />
+                <bitflag key="0x02" flagname="Non-secure" flagmask="0x04" />
+                <bitflag key="0x03" flagname="Resume" flagmask="0x08" />
+                <bitfield key="0x04" fieldname="Reserved1" fieldmask="0xF0" shifter="4" />
+            </param>
+        </cmd>
+        <cmd key="0x05" name="FIRMWARE_UPDATE_MD_GET" help="Firmware Update Md Get" support_mode="TX">
+            <param key="0x00" name="Number of Reports" type="BYTE" />
+            <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Report number 1" fieldmask="0x7F" />
+                <bitflag key="0x01" flagname="Res" flagmask="0x80" />
+            </param>
+            <param key="0x02" name="Report number 2" type="BYTE" />
+        </cmd>
+        <cmd key="0x06" name="FIRMWARE_UPDATE_MD_REPORT" help="Firmware Update Md Report" support_mode="RX">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Report number 1" fieldmask="0x7F" />
+                <bitflag key="0x01" flagname="Last" flagmask="0x80" />
+            </param>
+            <param key="0x01" name="Report number 2" type="BYTE" />
+            <param key="0x02" name="Data" type="VARIANT">
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
+            </param>
+            <param key="0x03" name="Checksum" type="WORD" />
+        </cmd>
+        <cmd key="0x03" name="FIRMWARE_UPDATE_MD_REQUEST_GET" help="Firmware Update Md Request Get" support_mode="RX">
+            <param key="0x00" name="Manufacturer ID" type="WORD" />
+            <param key="0x01" name="Firmware ID" type="WORD" />
+            <param key="0x02" name="Checksum" type="WORD" />
+            <param key="0x03" name="Firmware Target" type="BYTE" />
+            <param key="0x04" name="Fragment Size" type="WORD" />
+            <param key="0x05" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Activation" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Non-secure" flagmask="0x02" />
+                <bitflag key="0x02" flagname="Resume" flagmask="0x04" />
+                <bitfield key="0x03" fieldname="Reserved" fieldmask="0xF8" shifter="3" />
+            </param>
+            <param key="0x06" name="Hardware Version" type="BYTE" />
+        </cmd>
+        <cmd key="0x04" name="FIRMWARE_UPDATE_MD_REQUEST_REPORT" help="Firmware Update Md Request Report" support_mode="TX">
+            <param key="0x00" name="Status" type="CONST">
+                <const key="0x00" flagname="Invalid combination" flagmask="0x00" />
+                <const key="0x01" flagname="Requires authentication" flagmask="0x01" />
+                <const key="0x02" flagname="Invalid Fragment Size" flagmask="0x02" />
+                <const key="0x03" flagname="Not upgradable" flagmask="0x03" />
+                <const key="0x04" flagname="Invalid Hardware Version" flagmask="0x04" />
+                <const key="0x05" flagname="Another firmware image" flagmask="0x05" />
+                <const key="0x06" flagname="Insufficient battery level" flagmask="0x06" />
+                <const key="0x07" flagname="Valid combination" flagmask="0xFF" />
+            </param>
+            <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Reserved" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Non-secure" flagmask="0x02" />
+                <bitflag key="0x02" flagname="Resume" flagmask="0x04" />
+                <bitfield key="0x03" fieldname="Reserved1" fieldmask="0xF8" shifter="3" />
             </param>
         </cmd>
         <cmd key="0x07" name="FIRMWARE_UPDATE_MD_STATUS_REPORT" help="Firmware Update Md Status Report" support_mode="TX">
@@ -4952,7 +5113,7 @@
                 <param key="0x01" name="Historical Value" type="DWORD" />
             </variant_group>
         </cmd>
-        <cmd key="0x06" name="METER_TBL_REPORT" help="Meter Tbl Report" support_mode="TX">
+        <cmd key="0x06" name="METER_TBL_TABLE_CAPABILITY_REPORT" help="Meter Tbl Table Capability Report" support_mode="TX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
                 <bitfield key="0x00" fieldname="Meter Type" fieldmask="0x3F" />
                 <bitfield key="0x01" fieldname="Rate Type" fieldmask="0xC0" shifter="6" />
@@ -5096,7 +5257,7 @@
                 <param key="0x01" name="Historical Value" type="DWORD" />
             </variant_group>
         </cmd>
-        <cmd key="0x06" name="METER_TBL_REPORT" help="Meter Tbl Report" support_mode="TX">
+        <cmd key="0x06" name="METER_TBL_TABLE_CAPABILITY_REPORT" help="Meter Tbl Table Capability Report" support_mode="TX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
                 <bitfield key="0x00" fieldname="Meter Type" fieldmask="0x3F" />
                 <bitfield key="0x01" fieldname="Rate Type" fieldmask="0xC0" shifter="6" />
@@ -5240,7 +5401,7 @@
                 <param key="0x01" name="Historical Value" type="DWORD" />
             </variant_group>
         </cmd>
-        <cmd key="0x06" name="METER_TBL_REPORT" help="Meter Tbl Report" support_mode="TX">
+        <cmd key="0x06" name="METER_TBL_TABLE_CAPABILITY_REPORT" help="Meter Tbl Table Capability Report" support_mode="TX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
                 <bitfield key="0x00" fieldname="Meter Type" fieldmask="0x3F" />
                 <bitfield key="0x01" fieldname="Rate Type" fieldmask="0xC0" shifter="6" />
@@ -5610,11 +5771,18 @@
                     <fieldenum value="Heating meter" />
                     <fieldenum value="Cooling meter" />
                 </fieldenum>
-                <bitfield key="0x01" fieldname="Size" fieldmask="0xE0" shifter="5" />
+                <bitfield key="0x01" fieldname="Rate Type" fieldmask="0x60" shifter="5" />
+                <bitflag key="0x02" flagname="Scale bit 2" flagmask="0x80" />
             </param>
-            <param key="0x01" name="Meter Value" type="VARIANT">
-                <variant paramoffs="0" sizemask="0xE0" sizeoffs="5" />
+            <param key="0x01" name="Properties2" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Size" fieldmask="0x07" />
+                <bitfield key="0x01" fieldname="Scale bits 10" fieldmask="0x18" shifter="3" />
+                <bitfield key="0x02" fieldname="Precision" fieldmask="0xE0" shifter="5" />
             </param>
+            <param key="0x02" name="Meter Value" type="VARIANT">
+                <variant paramoffs="1" sizemask="0x07" />
+            </param>
+            <param key="0x03" name="Scale 2" type="BYTE" />
         </cmd>
         <cmd key="0x03" name="METER_SUPPORTED_GET" help="Meter Supported Get" support_mode="RX" />
         <cmd key="0x04" name="METER_SUPPORTED_REPORT" help="Meter Supported Report" support_mode="TX">
@@ -5660,7 +5828,7 @@
             </param>
         </cmd>
     </cmd_class>
-    <cmd_class key="0x8E" version="2" name="COMMAND_CLASS_MULTI_CHANNEL_ASSOCIATION" help="Command Class Multi Channel Association">
+    <cmd_class key="0x8E" version="2" name="COMMAND_CLASS_MULTI_CHANNEL_ASSOCIATION" help="Command Class Multi Channel Association" comment="[OBSOLETED]">
         <cmd key="0x02" name="MULTI_CHANNEL_ASSOCIATION_GET" help="Multi Channel Association Get" support_mode="RX">
             <param key="0x00" name="Grouping Identifier" type="BYTE" />
         </cmd>
@@ -5837,6 +6005,65 @@
             </variant_group>
         </cmd>
     </cmd_class>
+    <cmd_class key="0x8E" version="5" name="COMMAND_CLASS_MULTI_CHANNEL_ASSOCIATION" help="Command Class Multi Channel Association">
+        <cmd key="0x02" name="MULTI_CHANNEL_ASSOCIATION_GET" help="Multi Channel Association Get" support_mode="RX">
+            <param key="0x00" name="Grouping Identifier" type="BYTE" />
+        </cmd>
+        <cmd key="0x05" name="MULTI_CHANNEL_ASSOCIATION_GROUPINGS_GET" help="Multi Channel Association Groupings Get" support_mode="RX" />
+        <cmd key="0x06" name="MULTI_CHANNEL_ASSOCIATION_GROUPINGS_REPORT" help="Multi Channel Association Groupings Report" support_mode="TX">
+            <param key="0x00" name="Supported Groupings" type="BYTE" />
+        </cmd>
+        <cmd key="0x04" name="MULTI_CHANNEL_ASSOCIATION_REMOVE" help="Multi Channel Association Remove" support_mode="RX">
+            <param key="0x00" name="Grouping Identifier" type="BYTE" />
+            <param key="0x01" name="Node ID" type="VARIANT" encaptype="NODE_NUMBER">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+            <param key="0x02" name="Marker" type="MARKER" comment="This marker identifier is used to separate between nodes without and with end points attached. This field can be omitted in case no Multi Channel node follows.">
+                <const key="0x00" flagname="Marker" flagmask="0x00" />
+            </param>
+            <variant_group key="0x03" name="vg" paramOffs="0xFF" sizemask="0x00" sizeoffs="0x00">
+                <param key="0x00" name="Multi Channel Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+                <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                    <bitfield key="0x00" fieldname="End Point" fieldmask="0x7F" />
+                    <bitflag key="0x01" flagname="Bit address" flagmask="0x80" />
+                </param>
+            </variant_group>
+        </cmd>
+        <cmd key="0x03" name="MULTI_CHANNEL_ASSOCIATION_REPORT" help="Multi Channel Association Report" support_mode="TX">
+            <param key="0x00" name="Grouping Identifier" type="BYTE" />
+            <param key="0x01" name="Max Nodes Supported" type="BYTE" />
+            <param key="0x02" name="Reports to Follow" type="BYTE" />
+            <param key="0x03" name="Node ID" type="VARIANT" encaptype="NODE_NUMBER">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+            <param key="0x04" name="Marker" type="MARKER" comment="This marker identifier is used to separate between nodes without and with end points attached. This field can be omitted in case no Multi Channel node follows.">
+                <const key="0x00" flagname="Marker" flagmask="0x00" />
+            </param>
+            <variant_group key="0x05" name="vg" paramOffs="0xFF" sizemask="0x00" sizeoffs="0x00">
+                <param key="0x00" name="Multi Channel Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+                <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                    <bitfield key="0x00" fieldname="End Point" fieldmask="0x7F" />
+                    <bitflag key="0x01" flagname="Bit address" flagmask="0x80" />
+                </param>
+            </variant_group>
+        </cmd>
+        <cmd key="0x01" name="MULTI_CHANNEL_ASSOCIATION_SET" help="Multi Channel Association Set" support_mode="RX">
+            <param key="0x00" name="Grouping Identifier" type="BYTE" />
+            <param key="0x01" name="Node ID" type="VARIANT" encaptype="NODE_NUMBER">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+            <param key="0x02" name="Marker" type="MARKER" comment="This marker identifier is used to separate between nodes without and with end points attached. This field can be omitted in case no Multi Channel node follows.">
+                <const key="0x00" flagname="Marker" flagmask="0x00" />
+            </param>
+            <variant_group key="0x03" name="vg" paramOffs="0xFF" sizemask="0x00" sizeoffs="0x00">
+                <param key="0x00" name="Multi Channel Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+                <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                    <bitfield key="0x00" fieldname="End Point" fieldmask="0x7F" />
+                    <bitflag key="0x01" flagname="Bit address" flagmask="0x80" />
+                </param>
+            </variant_group>
+        </cmd>
+    </cmd_class>
     <cmd_class key="0x60" version="2" name="COMMAND_CLASS_MULTI_CHANNEL" help="Command Class Multi Channel" comment="[OBSOLETED]">
         <cmd key="0x09" name="MULTI_CHANNEL_CAPABILITY_GET" help="Multi Channel Capability Get" support_mode="RX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
@@ -5919,7 +6146,7 @@
             </param>
         </cmd>
     </cmd_class>
-    <cmd_class key="0x60" version="3" name="COMMAND_CLASS_MULTI_CHANNEL" help="Command Class Multi Channel">
+    <cmd_class key="0x60" version="3" name="COMMAND_CLASS_MULTI_CHANNEL" help="Command Class Multi Channel" comment="[OBSOLETED]">
         <cmd key="0x09" name="MULTI_CHANNEL_CAPABILITY_GET" help="Multi Channel Capability Get" support_mode="RX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
                 <bitfield key="0x00" fieldname="End Point" fieldmask="0x7F" />
@@ -6147,7 +6374,7 @@
             <param key="0x04" name="Marker" type="MARKER" comment="This marker identifier is used to separate between nodes without and with end points attached. This field can be omitted in case no Multi Channel node follows.">
                 <const key="0x00" flagname="Marker" flagmask="0x00" />
             </param>
-            <variant_group key="0x05" name="vg" paramOffs="0x00" sizemask="0xFF" sizeoffs="0x00">
+            <variant_group key="0x05" name="vg" paramOffs="0xFF" sizemask="0x00" sizeoffs="0x00">
                 <param key="0x00" name="Multi Instance Node ID" type="BYTE" encaptype="NODE_NUMBER" />
                 <param key="0x01" name="Instance" type="BYTE" />
             </variant_group>
@@ -6318,7 +6545,7 @@
             <param key="0x04" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
             <param key="0x05" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" />
             <param key="0x06" name="Command Class" type="VARIANT" encaptype="CMD_CLASS_REF">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="2" sizemask="0xFF" />
             </param>
         </cmd>
         <cmd key="0x09" name="NM_MULTI_CHANNEL_AGGREGATED_MEMBERS_GET" help="Multi Channel Aggregated Members Get" support_mode="RX">
@@ -6337,7 +6564,7 @@
                 <bitflag key="0x01" flagname="Res1" flagmask="0x80" />
             </param>
             <param key="0x03" name="Number of Members" type="BYTE" />
-            <variant_group key="0x04" name="vg1" paramOffs="0xFF" sizemask="0x00" sizeoffs="0x00">
+            <variant_group key="0x04" name="vg1" paramOffs="0x03" sizemask="0xFF" sizeoffs="0x00">
                 <param key="0x00" name="Properties1" type="STRUCT_BYTE">
                     <bitfield key="0x00" fieldname="Member Endpoint" fieldmask="0x7F" />
                     <bitflag key="0x01" flagname="Res2" flagmask="0x80" />
@@ -6430,7 +6657,7 @@
             <param key="0x04" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
             <param key="0x05" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" />
             <param key="0x06" name="Command Class" type="VARIANT" encaptype="CMD_CLASS_REF">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="2" sizemask="0xFF" />
             </param>
         </cmd>
         <cmd key="0x09" name="NM_MULTI_CHANNEL_AGGREGATED_MEMBERS_GET" help="Multi Channel Aggregated Members Get" support_mode="RX">
@@ -6449,7 +6676,7 @@
                 <bitflag key="0x01" flagname="Res1" flagmask="0x80" />
             </param>
             <param key="0x03" name="Number of Members" type="BYTE" />
-            <variant_group key="0x04" name="vg1" paramOffs="0xFF" sizemask="0x00" sizeoffs="0x00">
+            <variant_group key="0x04" name="vg1" paramOffs="0x03" sizemask="0xFF" sizeoffs="0x00">
                 <param key="0x00" name="Properties1" type="STRUCT_BYTE">
                     <bitfield key="0x00" fieldname="Member Endpoint" fieldmask="0x7F" />
                     <bitflag key="0x01" flagname="Res2" flagmask="0x80" />
@@ -6516,8 +6743,8 @@
                 <bitmask key="0x00" paramoffs="255" lenmask="0x00" len="29" />
             </param>
             <param key="0x04" name="Extended Node List Length" type="WORD" />
-            <param key="0x05" name="Extended Node List" type="VARIANT">
-                <variant paramoffs="4" sizemask="0xFF" />
+            <param key="0x05" name="Extended Node List" type="BITMASK">
+                <bitmask key="0x00" paramoffs="4" lenmask="0xFFFF" />
             </param>
         </cmd>
         <cmd key="0x05" name="NM_MULTI_CHANNEL_END_POINT_GET" help="Multi Channel End Point Get" support_mode="RX">
@@ -6559,7 +6786,7 @@
             <param key="0x04" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
             <param key="0x05" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" />
             <param key="0x06" name="Command Class" type="VARIANT" encaptype="CMD_CLASS_REF">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="2" sizemask="0xFF" />
             </param>
             <param key="0x07" name="Extended NodeID" type="WORD" />
         </cmd>
@@ -6580,7 +6807,7 @@
                 <bitflag key="0x01" flagname="Res1" flagmask="0x80" />
             </param>
             <param key="0x03" name="Number of Members" type="BYTE" />
-            <variant_group key="0x04" name="vg1" paramOffs="0xFF" sizemask="0x00" sizeoffs="0x00">
+            <variant_group key="0x04" name="vg1" paramOffs="0x03" sizemask="0xFF" sizeoffs="0x00">
                 <param key="0x00" name="Properties1" type="STRUCT_BYTE">
                     <bitfield key="0x00" fieldname="Member Endpoint" fieldmask="0x7F" />
                     <bitflag key="0x01" flagname="Res2" flagmask="0x80" />
@@ -6597,8 +6824,8 @@
                 <arrayattrib key="0x00" len="29" />
             </param>
             <param key="0x02" name="Extended Failed Node List Length" type="WORD" />
-            <param key="0x03" name="Extended Failed Node List" type="VARIANT">
-                <variant paramoffs="2" sizemask="0xFF" />
+            <param key="0x03" name="Extended Failed Node List" type="BITMASK">
+                <bitmask key="0x00" paramoffs="2" lenmask="0xFFFF" />
             </param>
         </cmd>
     </cmd_class>
@@ -6769,7 +6996,7 @@
             <param key="0x02" name="Mode" type="BYTE">
                 <bitflag key="0x01" flagname="NODE_ADD_ANY" flagmask="0x01" />
                 <bitflag key="0x02" flagname="NODE_ADD_CONTROLLER" flagmask="0x02" />
-                <bitflag key="0x03" flagname="NODE_ADD_SLAVE" flagmask="0x03" />
+                <bitflag key="0x03" flagname="NODE_ADD_END_NODE" flagmask="0x03" />
                 <bitflag key="0x04" flagname="NODE_ADD_EXISTING" flagmask="0x04" />
                 <bitflag key="0x05" flagname="NODE_ADD_STOP" flagmask="0x05" />
                 <bitflag key="0x06" flagname="NODE_ADD_STOP_FAILED" flagmask="0x06" />
@@ -6817,7 +7044,7 @@
             <param key="0x02" name="Mode" type="BYTE">
                 <bitflag key="0x01" flagname="NODE_REMOVE_ANY" flagmask="0x01" />
                 <bitflag key="0x02" flagname="NODE_REMOVE_CONTROLLER" flagmask="0x02" />
-                <bitflag key="0x03" flagname="NODE_REMOVE_SLAVE" flagmask="0x03" />
+                <bitflag key="0x03" flagname="NODE_REMOVE_END_NODE" flagmask="0x03" />
                 <bitflag key="0x04" flagname="NODE_REMOVE_STOP" flagmask="0x05" />
             </param>
         </cmd>
@@ -6915,7 +7142,7 @@
             <param key="0x02" name="Mode" type="BYTE">
                 <bitflag key="0x01" flagname="NODE_ADD_ANY" flagmask="0x01" />
                 <bitflag key="0x02" flagname="NODE_ADD_CONTROLLER" flagmask="0x02" />
-                <bitflag key="0x03" flagname="NODE_ADD_SLAVE" flagmask="0x03" />
+                <bitflag key="0x03" flagname="NODE_ADD_END_NODE" flagmask="0x03" />
                 <bitflag key="0x04" flagname="NODE_ADD_EXISTING" flagmask="0x04" />
                 <bitflag key="0x05" flagname="NODE_ADD_STOP" flagmask="0x05" />
                 <bitflag key="0x06" flagname="NODE_ADD_STOP_FAILED" flagmask="0x06" />
@@ -6966,7 +7193,7 @@
             <param key="0x02" name="Mode" type="BYTE">
                 <bitflag key="0x01" flagname="NODE_REMOVE_ANY" flagmask="0x01" />
                 <bitflag key="0x02" flagname="NODE_REMOVE_CONTROLLER" flagmask="0x02" />
-                <bitflag key="0x03" flagname="NODE_REMOVE_SLAVE" flagmask="0x03" />
+                <bitflag key="0x03" flagname="NODE_REMOVE_END_NODE" flagmask="0x03" />
                 <bitflag key="0x04" flagname="NODE_REMOVE_STOP" flagmask="0x05" />
             </param>
         </cmd>
@@ -7104,7 +7331,7 @@
             <param key="0x02" name="Mode" type="BYTE">
                 <bitflag key="0x01" flagname="NODE_ADD_ANY" flagmask="0x01" />
                 <bitflag key="0x02" flagname="NODE_ADD_CONTROLLER" flagmask="0x02" />
-                <bitflag key="0x03" flagname="NODE_ADD_SLAVE" flagmask="0x03" />
+                <bitflag key="0x03" flagname="NODE_ADD_END_NODE" flagmask="0x03" />
                 <bitflag key="0x04" flagname="NODE_ADD_EXISTING" flagmask="0x04" />
                 <bitflag key="0x05" flagname="NODE_ADD_STOP" flagmask="0x05" />
                 <bitflag key="0x06" flagname="NODE_ADD_STOP_FAILED" flagmask="0x06" />
@@ -7162,7 +7389,7 @@
             <param key="0x02" name="Mode" type="BYTE">
                 <bitflag key="0x01" flagname="NODE_REMOVE_ANY" flagmask="0x01" />
                 <bitflag key="0x02" flagname="NODE_REMOVE_CONTROLLER" flagmask="0x02" />
-                <bitflag key="0x03" flagname="NODE_REMOVE_SLAVE" flagmask="0x03" />
+                <bitflag key="0x03" flagname="NODE_REMOVE_END_NODE" flagmask="0x03" />
                 <bitflag key="0x04" flagname="NODE_REMOVE_STOP" flagmask="0x05" />
             </param>
         </cmd>
@@ -7279,7 +7506,7 @@
                 <variant paramoffs="1" sizemask="0x0F" />
             </param>
         </cmd>
-        <cmd key="0x15" name="SMART_START_JOIN_STARTED_REPORT" help="Smart Start Join Started" support_mode="TX">
+        <cmd key="0x15" name="SMART_START_JOIN_STARTED_REPORT" help="SmartStart Join Started" support_mode="TX">
             <param key="0x00" name="Seq No" type="BYTE" />
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
                 <bitfield key="0x00" fieldname="DSK Length" fieldmask="0x1F" />
@@ -7322,7 +7549,7 @@
             <param key="0x02" name="Mode" type="BYTE">
                 <bitflag key="0x01" flagname="NODE_ADD_ANY" flagmask="0x01" />
                 <bitflag key="0x02" flagname="NODE_ADD_CONTROLLER" flagmask="0x02" />
-                <bitflag key="0x03" flagname="NODE_ADD_SLAVE" flagmask="0x03" />
+                <bitflag key="0x03" flagname="NODE_ADD_END_NODE" flagmask="0x03" />
                 <bitflag key="0x04" flagname="NODE_ADD_EXISTING" flagmask="0x04" />
                 <bitflag key="0x05" flagname="NODE_ADD_STOP" flagmask="0x05" />
                 <bitflag key="0x06" flagname="NODE_ADD_STOP_FAILED" flagmask="0x06" />
@@ -7380,7 +7607,7 @@
             <param key="0x02" name="Mode" type="BYTE">
                 <bitflag key="0x01" flagname="NODE_REMOVE_ANY" flagmask="0x01" />
                 <bitflag key="0x02" flagname="NODE_REMOVE_CONTROLLER" flagmask="0x02" />
-                <bitflag key="0x03" flagname="NODE_REMOVE_SLAVE" flagmask="0x03" />
+                <bitflag key="0x03" flagname="NODE_REMOVE_END_NODE" flagmask="0x03" />
                 <bitflag key="0x04" flagname="NODE_REMOVE_STOP" flagmask="0x05" />
             </param>
         </cmd>
@@ -7498,7 +7725,7 @@
                 <variant paramoffs="1" sizemask="0x0F" />
             </param>
         </cmd>
-        <cmd key="0x15" name="SMART_START_JOIN_STARTED_REPORT" help="Smart Start Join Started" support_mode="TX">
+        <cmd key="0x15" name="SMART_START_JOIN_STARTED_REPORT" help="SmartStart Join Started" support_mode="TX">
             <param key="0x00" name="Seq No" type="BYTE" />
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
                 <bitfield key="0x00" fieldname="DSK Length" fieldmask="0x1F" />
@@ -7535,7 +7762,7 @@
             <param key="0x07" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
             <param key="0x08" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" />
             <param key="0x09" name="Command Class" type="VARIANT" encaptype="CMD_CLASS_REF">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x0A" name="Granted Keys" type="BYTE" />
             <param key="0x0B" name="KEX Fail Type" type="BYTE" />
@@ -7692,7 +7919,7 @@
             </param>
         </cmd>
     </cmd_class>
-    <cmd_class key="0x88" version="1" name="COMMAND_CLASS_PROPRIETARY" help="Command Class Proprietary" comment="[DEPRECATED]">
+    <cmd_class key="0x88" version="1" name="COMMAND_CLASS_PROPRIETARY" help="Command Class Proprietary" comment="[OBSOLETED]">
         <cmd key="0x02" name="PROPRIETARY_GET" help="Proprietary Get" support_mode="RX">
             <param key="0x00" name="Data" type="VARIANT">
                 <variant paramoffs="255" sizemask="0x00" />
@@ -8313,6 +8540,234 @@
             <param key="0x07" name="Duration Minute" type="BYTE" />
         </cmd>
     </cmd_class>
+    <cmd_class key="0x4E" version="4" name="COMMAND_CLASS_SCHEDULE_ENTRY_LOCK" help="Command Class Schedule Entry Lock" comment="Never certified.">
+        <cmd key="0x02" name="SCHEDULE_ENTRY_LOCK_ENABLE_ALL_SET" help="Schedule Entry Lock Enable All Set" support_mode="RX">
+            <param key="0x00" name="Enabled" type="BYTE">
+                <bitflag key="0x01" flagname="disabled" flagmask="0x00" />
+                <bitflag key="0x02" flagname="enabled" flagmask="0x01" />
+            </param>
+        </cmd>
+        <cmd key="0x01" name="SCHEDULE_ENTRY_LOCK_ENABLE_SET" help="Schedule Entry Lock Enable Set" support_mode="RX">
+            <param key="0x00" name="User Identifier" type="BYTE" />
+            <param key="0x01" name="Enabled" type="BYTE">
+                <bitflag key="0x01" flagname="disabled" flagmask="0x00" />
+                <bitflag key="0x02" flagname="enabled" flagmask="0x01" />
+            </param>
+        </cmd>
+        <cmd key="0x0B" name="SCHEDULE_ENTRY_LOCK_TIME_OFFSET_GET" help="Schedule Entry Lock Time Offset Get" support_mode="RX" />
+        <cmd key="0x0C" name="SCHEDULE_ENTRY_LOCK_TIME_OFFSET_REPORT" help="Schedule Entry Lock Time Offset Report" support_mode="TX">
+            <param key="0x00" name="Level" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Hour TZO" fieldmask="0x7F" />
+                <bitflag key="0x01" flagname="Sign TZO" flagmask="0x80" />
+            </param>
+            <param key="0x01" name="Minute TZO" type="BYTE" />
+            <param key="0x02" name="Level2" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Minute Offset DST" fieldmask="0x7F" />
+                <bitflag key="0x01" flagname="Sign Offset DST" flagmask="0x80" />
+            </param>
+        </cmd>
+        <cmd key="0x0D" name="SCHEDULE_ENTRY_LOCK_TIME_OFFSET_SET" help="Schedule Entry Lock Time Offset Set" support_mode="RX">
+            <param key="0x00" name="Level" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Hour TZO" fieldmask="0x7F" />
+                <bitflag key="0x01" flagname="Sign TZO" flagmask="0x80" />
+            </param>
+            <param key="0x01" name="Minute TZO" type="BYTE" />
+            <param key="0x02" name="Level2" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Minute Offset DST" fieldmask="0x7F" />
+                <bitflag key="0x01" flagname="Sign Offset DST" flagmask="0x80" />
+            </param>
+        </cmd>
+        <cmd key="0x04" name="SCHEDULE_ENTRY_LOCK_WEEK_DAY_GET" help="Schedule Entry Lock Week Day Get" support_mode="RX">
+            <param key="0x00" name="User Identifier" type="BYTE" />
+            <param key="0x01" name="Schedule Slot ID" type="BYTE" />
+        </cmd>
+        <cmd key="0x05" name="SCHEDULE_ENTRY_LOCK_WEEK_DAY_REPORT" help="Schedule Entry Lock Week Day Report" support_mode="TX">
+            <param key="0x00" name="User Identifier" type="BYTE" />
+            <param key="0x01" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x02" name="Day of Week" type="BYTE" />
+            <param key="0x03" name="Start Hour" type="BYTE" />
+            <param key="0x04" name="Start Minute" type="BYTE" />
+            <param key="0x05" name="Stop Hour" type="BYTE" />
+            <param key="0x06" name="Stop Minute" type="BYTE" />
+        </cmd>
+        <cmd key="0x03" name="SCHEDULE_ENTRY_LOCK_WEEK_DAY_SET" help="Schedule Entry Lock Week Day Set" support_mode="RX">
+            <param key="0x00" name="Set Action" type="BYTE">
+                <bitflag key="0x01" flagname="Erase" flagmask="0x00" />
+                <bitflag key="0x02" flagname="Modify" flagmask="0x01" />
+            </param>
+            <param key="0x01" name="User Identifier" type="BYTE" />
+            <param key="0x02" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x03" name="Day of Week" type="BYTE" />
+            <param key="0x04" name="Start Hour" type="BYTE" />
+            <param key="0x05" name="Start Minute" type="BYTE" />
+            <param key="0x06" name="Stop Hour" type="BYTE" />
+            <param key="0x07" name="Stop Minute" type="BYTE" />
+        </cmd>
+        <cmd key="0x07" name="SCHEDULE_ENTRY_LOCK_YEAR_DAY_GET" help="Schedule Entry Lock Year Day Get" support_mode="RX">
+            <param key="0x00" name="User Identifier" type="BYTE" />
+            <param key="0x01" name="Schedule Slot ID" type="BYTE" />
+        </cmd>
+        <cmd key="0x08" name="SCHEDULE_ENTRY_LOCK_YEAR_DAY_REPORT" help="Schedule Entry Lock Year Day Report" support_mode="TX">
+            <param key="0x00" name="User Identifier" type="BYTE" />
+            <param key="0x01" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x02" name="Start Year" type="BYTE" />
+            <param key="0x03" name="Start Month" type="BYTE" />
+            <param key="0x04" name="Start Day" type="BYTE" />
+            <param key="0x05" name="Start Hour" type="BYTE" />
+            <param key="0x06" name="Start Minute" type="BYTE" />
+            <param key="0x07" name="Stop Year" type="BYTE" />
+            <param key="0x08" name="Stop Month" type="BYTE" />
+            <param key="0x09" name="Stop Day" type="BYTE" />
+            <param key="0x0A" name="Stop Hour" type="BYTE" />
+            <param key="0x0B" name="Stop Minute" type="BYTE" />
+        </cmd>
+        <cmd key="0x06" name="SCHEDULE_ENTRY_LOCK_YEAR_DAY_SET" help="Schedule Entry Lock Year Day Set" support_mode="RX">
+            <param key="0x00" name="Set Action" type="BYTE">
+                <bitflag key="0x01" flagname="Erase" flagmask="0x00" />
+                <bitflag key="0x02" flagname="Modify" flagmask="0x01" />
+            </param>
+            <param key="0x01" name="User Identifier" type="BYTE" />
+            <param key="0x02" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x03" name="Start Year" type="BYTE" />
+            <param key="0x04" name="Start Month" type="BYTE" />
+            <param key="0x05" name="Start Day" type="BYTE" />
+            <param key="0x06" name="Start Hour" type="BYTE" />
+            <param key="0x07" name="Start Minute" type="BYTE" />
+            <param key="0x08" name="Stop Year" type="BYTE" />
+            <param key="0x09" name="Stop Month" type="BYTE" />
+            <param key="0x0A" name="Stop Day" type="BYTE" />
+            <param key="0x0B" name="Stop Hour" type="BYTE" />
+            <param key="0x0C" name="Stop Minute" type="BYTE" />
+        </cmd>
+        <cmd key="0x09" name="SCHEDULE_ENTRY_TYPE_SUPPORTED_GET" help="Schedule Entry Type Supported Get" support_mode="RX" />
+        <cmd key="0x0A" name="SCHEDULE_ENTRY_TYPE_SUPPORTED_REPORT" help="Schedule Entry Type Supported Report" support_mode="TX">
+            <param key="0x00" name="Number of Slots Week Day" type="BYTE" />
+            <param key="0x01" name="Number of Slots Year Day" type="BYTE" />
+            <param key="0x02" name="Number of Slots Daily Repeating" type="BYTE" />
+        </cmd>
+        <cmd key="0x0E" name="SCHEDULE_ENTRY_LOCK_DAILY_REPEATING_GET" help="Schedule Entry Lock Daily Repeating Get" support_mode="RX">
+            <param key="0x00" name="User Identifier" type="BYTE" />
+            <param key="0x01" name="Schedule Slot ID" type="BYTE" />
+        </cmd>
+        <cmd key="0x0F" name="SCHEDULE_ENTRY_LOCK_DAILY_REPEATING_REPORT" help="Schedule Entry Lock Daily Repeating Report" support_mode="TX">
+            <param key="0x00" name="User Identifier" type="BYTE" />
+            <param key="0x01" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x02" name="Week Day Bitmask" type="BYTE" />
+            <param key="0x03" name="Start Hour" type="BYTE" />
+            <param key="0x04" name="Start Minute" type="BYTE" />
+            <param key="0x05" name="Duration Hour" type="BYTE" />
+            <param key="0x06" name="Duration Minute" type="BYTE" />
+        </cmd>
+        <cmd key="0x10" name="SCHEDULE_ENTRY_LOCK_DAILY_REPEATING_SET" help="Schedule Entry Lock Daily Repeating Set" support_mode="RX">
+            <param key="0x00" name="Set Action" type="BYTE">
+                <bitflag key="0x01" flagname="Erase" flagmask="0x00" />
+                <bitflag key="0x02" flagname="Modify" flagmask="0x01" />
+            </param>
+            <param key="0x01" name="User Identifier" type="BYTE" />
+            <param key="0x02" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x03" name="Week Day Bitmask" type="BYTE" />
+            <param key="0x04" name="Start Hour" type="BYTE" />
+            <param key="0x05" name="Start Minute" type="BYTE" />
+            <param key="0x06" name="Duration Hour" type="BYTE" />
+            <param key="0x07" name="Duration Minute" type="BYTE" />
+        </cmd>
+        <cmd key="0x11" name="EXTENDED_SCHEDULE_ENTRY_LOCK_ENABLE_SET" help="Extended Schedule Entry Lock Enable Set Command" support_mode="TX">
+            <param key="0x00" name="User Identifier (MSB)" type="BYTE" />
+            <param key="0x01" name="User Identifier (LSB)" type="BYTE" />
+            <param key="0x02" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Enabled" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
+            </param>
+        </cmd>
+        <cmd key="0x12" name="EXTENDED_SCHEDULE_ENTRY_LOCK_WEEK_DAY_SCHEDULE_SET" help="Extended Schedule Entry Lock Week Day Schedule Set" support_mode="RX">
+            <param key="0x00" name="Set Action" type="BYTE" />
+            <param key="0x01" name="User Identifier (MSB)" type="BYTE" />
+            <param key="0x02" name="User Identifier (LSB)" type="BYTE" />
+            <param key="0x03" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x04" name="Day of Week" type="BYTE" />
+            <param key="0x05" name="Start Hour" type="BYTE" />
+            <param key="0x06" name="Start Minute" type="BYTE" />
+            <param key="0x07" name="Stop Hour" type="BYTE" />
+            <param key="0x08" name="Stop Minute" type="BYTE" />
+        </cmd>
+        <cmd key="0x13" name="EXTENDED_SCHEDULE_ENTRY_LOCK_WEEK_DAY_SCHEDULE_GET" help="Extended Schedule Entry Lock Week Day Schedule Get" support_mode="RX">
+            <param key="0x00" name="User Identifier (MSB)" type="BYTE" />
+            <param key="0x01" name="User Identifier (LSB)" type="BYTE" />
+            <param key="0x02" name="Schedule Slot ID" type="BYTE" />
+        </cmd>
+        <cmd key="0x14" name="EXTENDED_SCHEDULE_ENTRY_LOCK_WEEK_DAY_SCHEDULE_REPORT" help="Extended Schedule Entry Lock Week Day Schedule Report" support_mode="TX">
+            <param key="0x00" name="User Identifier (MSB)" type="BYTE" />
+            <param key="0x01" name="User Identifier (LSB)" type="BYTE" />
+            <param key="0x02" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x03" name="Day of Week" type="BYTE" />
+            <param key="0x04" name="Start Hour" type="BYTE" />
+            <param key="0x05" name="Start Minute" type="BYTE" />
+            <param key="0x06" name="Stop Hour" type="BYTE" />
+            <param key="0x07" name="Stop Minute" type="BYTE" />
+        </cmd>
+        <cmd key="0x15" name="EXTENDED_SCHEDULE_ENTRY_LOCK_YEAR_DAY_SCHEDULE_SET" help="Extended Schedule Entry Lock Year Day Schedule Set" support_mode="RX">
+            <param key="0x00" name="Set Action" type="BYTE" />
+            <param key="0x01" name="User Identifier (MSB)" type="BYTE" />
+            <param key="0x02" name="User Identifier (LSB)" type="BYTE" />
+            <param key="0x03" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x04" name="Start Year" type="BYTE" />
+            <param key="0x05" name="Start Month" type="BYTE" />
+            <param key="0x06" name="Start Day" type="BYTE" />
+            <param key="0x07" name="Start Hour" type="BYTE" />
+            <param key="0x08" name="Start Minute" type="BYTE" />
+            <param key="0x09" name="Stop Year" type="BYTE" />
+            <param key="0x0A" name="Stop Month" type="BYTE" />
+            <param key="0x0B" name="Stop Day" type="BYTE" />
+            <param key="0x0C" name="Stop Hour" type="BYTE" />
+            <param key="0x0D" name="Stop Minute" type="BYTE" />
+        </cmd>
+        <cmd key="0x16" name="EXTENDED_SCHEDULE_ENTRY_LOCK_YEAR_DAY_SCHEDULE_GET" help="Extended Schedule Entry Lock Year Day Schedule Get" support_mode="RX">
+            <param key="0x00" name="User Identifier (MSB)" type="BYTE" />
+            <param key="0x01" name="User Identifier (LSB)" type="BYTE" />
+            <param key="0x02" name="Schedule Slot ID" type="BYTE" />
+        </cmd>
+        <cmd key="0x17" name="EXTENDED_SCHEDULE_ENTRY_LOCK_YEAR_DAY_SCHEDULE_REPORT" help="Extended Schedule Entry Lock Year Day Schedule Report" support_mode="TX">
+            <param key="0x00" name="User Identifier (MSB)" type="BYTE" />
+            <param key="0x01" name="User Identifier (LSB)" type="BYTE" />
+            <param key="0x02" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x03" name="Start Year" type="BYTE" />
+            <param key="0x04" name="Start Month" type="BYTE" />
+            <param key="0x05" name="Start Day" type="BYTE" />
+            <param key="0x06" name="Start Hour" type="BYTE" />
+            <param key="0x07" name="Start Minute" type="BYTE" />
+            <param key="0x08" name="Stop Year" type="BYTE" />
+            <param key="0x09" name="Stop Month" type="BYTE" />
+            <param key="0x0A" name="Stop Day" type="BYTE" />
+            <param key="0x0B" name="Stop Hour" type="BYTE" />
+            <param key="0x0C" name="Stop Minute" type="BYTE" />
+        </cmd>
+        <cmd key="0x18" name="EXTENDED_SCHEDULE_ENTRY_LOCK_DAILY_REPEATING_SET" help="Extended Schedule Entry Lock Daily Repeating Set" support_mode="RX">
+            <param key="0x00" name="Set Action" type="BYTE" />
+            <param key="0x01" name="User Identifier (MSB)" type="BYTE" />
+            <param key="0x02" name="User Identifier (LSB)" type="BYTE" />
+            <param key="0x03" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x04" name="Week Day Bitmask" type="BYTE" />
+            <param key="0x05" name="Start Hour" type="BYTE" />
+            <param key="0x06" name="Start Minute" type="BYTE" />
+            <param key="0x07" name="Duration Hour" type="BYTE" />
+            <param key="0x08" name="Duration Minute" type="BYTE" />
+        </cmd>
+        <cmd key="0x19" name="EXTENDED_SCHEDULE_ENTRY_LOCK_DAILY_REPEATING_GET" help="Extended Schedule Entry Lock Daily Repeating Get" support_mode="RX">
+            <param key="0x00" name="User Identifier (MSB)" type="BYTE" />
+            <param key="0x01" name="User Identifier (LSB)" type="BYTE" />
+            <param key="0x02" name="Schedule Slot ID" type="BYTE" />
+        </cmd>
+        <cmd key="0x1A" name="EXTENDED_SCHEDULE_ENTRY_LOCK_DAILY_REPEATING_REPORT" help="Extended Schedule Entry Lock Daily Repeating Report" support_mode="TX">
+            <param key="0x00" name="User Identifier (MSB)" type="BYTE" />
+            <param key="0x01" name="User Identifier (LSB)" type="BYTE" />
+            <param key="0x02" name="Schedule Slot ID" type="BYTE" />
+            <param key="0x03" name="Week Day Bitmask" type="BYTE" />
+            <param key="0x04" name="Start Hour" type="BYTE" />
+            <param key="0x05" name="Start Minute" type="BYTE" />
+            <param key="0x06" name="Duration Hour" type="BYTE" />
+            <param key="0x07" name="Duration Minute" type="BYTE" />
+        </cmd>
+    </cmd_class>
     <cmd_class key="0x93" version="1" name="COMMAND_CLASS_SCREEN_ATTRIBUTES" help="Command Class Screen Attributes">
         <cmd key="0x01" name="SCREEN_ATTRIBUTES_GET" help="Screen Attributes Get" support_mode="RX" />
         <cmd key="0x02" name="SCREEN_ATTRIBUTES_REPORT" help="Screen Attributes Report" support_mode="TX">
@@ -8546,7 +9001,7 @@
                 <bitfield key="0x03" fieldname="Reserved" fieldmask="0xC0" shifter="6" />
             </param>
             <param key="0x02" name="Command byte" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-9" />
             </param>
             <param key="0x03" name="Receivers nonce Identifier" type="BYTE" />
             <param key="0x04" name="Message Authentication Code byte" type="ARRAY">
@@ -8564,7 +9019,7 @@
                 <bitfield key="0x03" fieldname="Reserved" fieldmask="0xC0" shifter="6" />
             </param>
             <param key="0x02" name="Command byte" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-9" />
             </param>
             <param key="0x03" name="Receivers nonce Identifier" type="BYTE" />
             <param key="0x04" name="Message Authentication Code byte" type="ARRAY">
@@ -11141,14 +11596,15 @@
         <cmd key="0x02" name="SWITCH_BINARY_GET" help="Switch Binary Get" support_mode="RX" />
         <cmd key="0x03" name="SWITCH_BINARY_REPORT" help="Switch Binary Report" support_mode="TX">
             <param key="0x00" name="Value" type="BYTE">
-                <bitflag key="0x01" flagname="off/disable" flagmask="0x00" />
-                <bitflag key="0x02" flagname="on/enable" flagmask="0xFF" />
+                <bitflag key="0x01" flagname="Off (0%)" flagmask="0x00" />
+                <bitflag key="0x02" flagname="Unknown" flagmask="0xFE" />
+                <bitflag key="0x03" flagname="On (100%)" flagmask="0xFF" />
             </param>
         </cmd>
         <cmd key="0x01" name="SWITCH_BINARY_SET" help="Switch Binary Set" support_mode="RX">
             <param key="0x00" name="Switch Value" type="BYTE">
-                <bitflag key="0x01" flagname="off/disable" flagmask="0x00" />
-                <bitflag key="0x02" flagname="on/enable" flagmask="0xFF" />
+                <bitflag key="0x01" flagname="Off (0%)" flagmask="0x00" />
+                <bitflag key="0x02" flagname="On (100%)" flagmask="0xFF" />
             </param>
         </cmd>
     </cmd_class>
@@ -11156,12 +11612,13 @@
         <cmd key="0x02" name="SWITCH_BINARY_GET" help="Switch Binary Get" support_mode="RX" />
         <cmd key="0x03" name="SWITCH_BINARY_REPORT" help="Switch Binary Report" support_mode="TX">
             <param key="0x00" name="Current Value" type="CONST">
-                <const key="0x00" flagname="off/disable" flagmask="0x00" />
-                <const key="0x01" flagname="on/enable" flagmask="0xFF" />
+                <const key="0x00" flagname="Off (0%)" flagmask="0x00" />
+                <const key="0x01" flagname="Unknown" flagmask="0xFE" />
+                <const key="0x02" flagname="On (100%)" flagmask="0xFF" />
             </param>
             <param key="0x01" name="Target Value" type="CONST">
-                <const key="0x00" flagname="off/disable" flagmask="0x00" />
-                <const key="0x01" flagname="on/enable" flagmask="0xFF" />
+                <const key="0x00" flagname="Off (0%)" flagmask="0x00" />
+                <const key="0x01" flagname="On (100%)" flagmask="0xFF" />
             </param>
             <param key="0x02" name="Duration" type="CONST">
                 <const key="0x00" flagname="Already at the Target Value" flagmask="0x00" />
@@ -11171,8 +11628,8 @@
         </cmd>
         <cmd key="0x01" name="SWITCH_BINARY_SET" help="Switch Binary Set" support_mode="RX">
             <param key="0x00" name="Target Value" type="CONST">
-                <const key="0x00" flagname="off/disable" flagmask="0x00" />
-                <const key="0x01" flagname="on/enable" flagmask="0xFF" />
+                <const key="0x00" flagname="Off (0%)" flagmask="0x00" />
+                <const key="0x01" flagname="On (100%)" flagmask="0xFF" />
             </param>
             <param key="0x01" name="Duration" type="CONST">
                 <const key="0x00" flagname="Instantly" flagmask="0x00" />
@@ -12682,7 +13139,7 @@
                 <variant paramoffs="3" sizemask="0xFF" />
             </param>
             <param key="0x05" name="Payload" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x06" name="Frame Check Sequence" type="WORD" />
         </cmd>
@@ -12728,7 +13185,7 @@
                 <variant paramoffs="4" sizemask="0xFF" />
             </param>
             <param key="0x06" name="Payload" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x07" name="Frame Check Sequence" type="WORD" />
         </cmd>
@@ -12744,7 +13201,7 @@
                 <bitfield key="0x01" fieldname="Reserved" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x03" name="Payload" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x04" name="Checksum" type="WORD" />
         </cmd>
@@ -12760,7 +13217,7 @@
             </param>
             <param key="0x03" name="datagram_offset_2" type="BYTE" />
             <param key="0x04" name="Payload" type="VARIANT">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="255" sizemask="0x00" sizechange="-2" />
             </param>
             <param key="0x05" name="Checksum" type="WORD" />
         </cmd>
@@ -12890,8 +13347,8 @@
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
                 <bitfield key="0x00" fieldname="Supported User ID Status Bit Mask Length" fieldmask="0x1F" />
                 <bitflag key="0x01" flagname="Reserved1" flagmask="0x20" />
-                <bitflag key="0x02" flagname="MCD Support" flagmask="0x40" />
-                <bitflag key="0x03" flagname="MC Support" flagmask="0x80" />
+                <bitflag key="0x02" flagname="ACD Support" flagmask="0x40" />
+                <bitflag key="0x03" flagname="AC Support" flagmask="0x80" />
             </param>
             <param key="0x01" name="Supported User ID Status Bit Mask" type="VARIANT">
                 <variant paramoffs="0" sizemask="0x1F" />
@@ -12930,22 +13387,22 @@
                 <const key="0x03" flagname="Locked Out mode" flagmask="0x03" />
             </param>
         </cmd>
-        <cmd key="0x0E" name="MASTER_CODE_SET" help="Master Code Set" support_mode="RX">
+        <cmd key="0x0E" name="ADMIN_CODE_SET" help="Admin Code Set" support_mode="RX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
-                <bitfield key="0x00" fieldname="Master Code Length" fieldmask="0x0F" />
+                <bitfield key="0x00" fieldname="Admin Code Length" fieldmask="0x0F" />
                 <bitfield key="0x01" fieldname="Reserved" fieldmask="0xF0" shifter="4" />
             </param>
-            <param key="0x01" name="Master Code" type="VARIANT">
+            <param key="0x01" name="Admin Code" type="VARIANT">
                 <variant paramoffs="0" sizemask="0x0F" />
             </param>
         </cmd>
-        <cmd key="0x0F" name="MASTER_CODE_GET" help="Master Code Get" support_mode="RX" />
-        <cmd key="0x10" name="MASTER_CODE_REPORT" help="Master Code Report" support_mode="TX">
+        <cmd key="0x0F" name="ADMIN_CODE_GET" help="Admin Code Get" support_mode="RX" />
+        <cmd key="0x10" name="ADMIN_CODE_REPORT" help="Admin Code Report" support_mode="TX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
-                <bitfield key="0x00" fieldname="Master Code Length" fieldmask="0x0F" />
+                <bitfield key="0x00" fieldname="Admin Code Length" fieldmask="0x0F" />
                 <bitfield key="0x01" fieldname="Reserved" fieldmask="0xF0" shifter="4" />
             </param>
-            <param key="0x01" name="Master Code" type="VARIANT">
+            <param key="0x01" name="Admin Code" type="VARIANT">
                 <variant paramoffs="0" sizemask="0x0F" />
             </param>
         </cmd>
@@ -12954,7 +13411,7 @@
             <param key="0x00" name="User Code Checksum" type="WORD" />
         </cmd>
     </cmd_class>
-    <cmd_class key="0x86" version="1" name="COMMAND_CLASS_VERSION" help="Command Class Version">
+    <cmd_class key="0x86" version="1" name="COMMAND_CLASS_VERSION" help="Command Class Version" comment="[OBSOLETED]">
         <cmd key="0x13" name="VERSION_COMMAND_CLASS_GET" help="Version Command Class Get" support_mode="RX">
             <param key="0x00" name="Requested Command Class" type="BYTE" encaptype="CMD_CLASS_REF" />
         </cmd>
@@ -13096,9 +13553,34 @@
         <cmd key="0x07" name="WAKE_UP_NOTIFICATION" help="Wake Up Notification" support_mode="TX" />
     </cmd_class>
     <cmd_class key="0x02" version="1" name="COMMAND_CLASS_ZENSOR_NET" help="Command Class Zensor Net">
-        <cmd key="0x02" name="BIND_ACCEPT" help="Bind Accept" />
-        <cmd key="0x03" name="BIND_COMPLETE" help="Bind Complete" />
-        <cmd key="0x01" name="BIND_REQUEST" help="Bind Request" />
+        <cmd key="0x02" name="BIND_ACCEPT" help="Bind Accept">
+            <param key="0x00" name="Zensor Net ID" type="WORD" />
+            <param key="0x01" name="Source Zensor ID" type="BYTE" />
+            <param key="0x02" name="Destination Zensor ID" type="BYTE" />
+            <param key="0x03" name="Destination Zensor Net ID" type="WORD" />
+            <param key="0x04" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Accept" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Broadcast ID" fieldmask="0x1E" shifter="1" />
+                <bitfield key="0x02" fieldname="Reserved" fieldmask="0xE0" shifter="5" />
+            </param>
+            <param key="0x05" name="Assign Zensor ID" type="BYTE" />
+        </cmd>
+        <cmd key="0x03" name="BIND_COMPLETE" help="Bind Complete">
+            <param key="0x00" name="Zensor Net ID" type="WORD" />
+            <param key="0x01" name="Source Zensor ID" type="BYTE" />
+            <param key="0x02" name="Destination Zensor ID" type="BYTE" />
+        </cmd>
+        <cmd key="0x01" name="BIND_REQUEST" help="Bind Request">
+            <param key="0x00" name="Zensor Net ID" type="WORD" />
+            <param key="0x01" name="Source Zensor ID" type="BYTE" />
+            <param key="0x02" name="Destination Zensor ID" type="BYTE" />
+            <param key="0x03" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Bind" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Unbind" flagmask="0x02" />
+                <bitfield key="0x02" fieldname="Reserved" fieldmask="0xFC" shifter="2" />
+            </param>
+            <param key="0x04" name="Zensor Capabilities" type="BYTE" />
+        </cmd>
     </cmd_class>
     <cmd_class key="0x4F" version="1" name="COMMAND_CLASS_ZIP_6LOWPAN" help="Command Class Z/IP 6lowpan">
         <cmd key="0xC0" name="LOWPAN_FIRST_FRAGMENT" help="Lowpan First Fragment" cmd_mask="0xF8">
@@ -13273,20 +13755,194 @@
         </cmd>
     </cmd_class>
     <cmd_class key="0x01" version="1" name="ZWAVE_CMD_CLASS" help="Z-Wave protocol Command Class">
-        <cmd key="0x17" name="ACCEPT_LOST" help="Accept Lost" comment="SDS10264-2" />
-        <cmd key="0x03" name="ASSIGN_ID" help="Assign Id" comment="SDS10264-2" />
-        <cmd key="0x0C" name="ASSIGN_RETURN_ROUTE" help="Assign Return Route" comment="SDS10264-2" />
-        <cmd key="0x14" name="CMD_ASSIGN_SUC_RETURN_ROUTE" help="Assign SUC Return Route" />
+        <cmd key="0x17" name="ACCEPT_LOST" help="Accept Lost" comment="SDS10264-2">
+            <param key="0x00" name="Accept Status" type="BYTE">
+                <bitflag key="0x01" flagname="Request failed" flagmask="0x04" />
+                <bitflag key="0x02" flagname="Request accepted" flagmask="0x05" />
+            </param>
+        </cmd>
+        <cmd key="0x03" name="ASSIGN_ID" help="Assign Id" comment="SDS10264-2">
+            <param key="0x00" name="New Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+            <param key="0x01" name="New Home ID" type="DWORD" />
+        </cmd>
+        <cmd key="0x0C" name="ASSIGN_RETURN_ROUTE" help="Assign Return Route" comment="SDS10264-2">
+            <param key="0x00" name="NodeID" type="BYTE" encaptype="NODE_NUMBER" />
+            <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Number of Hops" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Route Number" fieldmask="0xF0" shifter="4" />
+            </param>
+            <param key="0x02" name="Repeaters" type="VARIANT" encaptype="NODE_NUMBER">
+                <variant paramoffs="1" sizemask="0x0F" />
+            </param>
+            <param key="0x03" name="Properties2" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Reserved1" flagmask="0x01" />
+                <fieldenum key="0x01" fieldname="Destination Wake Up" fieldmask="0x06" shifter="1">
+                    <fieldenum value="No Wake Up (AL node)" />
+                    <fieldenum value="Wake Up in 250 ms interval (FL Node)" />
+                    <fieldenum value="Wake Up in 1000 ms interval (FL Node)" />
+                </fieldenum>
+                <fieldenum key="0x02" fieldname="Destination Speed" fieldmask="0x38" shifter="3">
+                    <fieldenum value="Reserved000" />
+                    <fieldenum value="9.6 kbps" />
+                    <fieldenum value="40 kbps" />
+                    <fieldenum value="Reserved011" />
+                    <fieldenum value="100 kbps" />
+                </fieldenum>
+                <bitfield key="0x03" fieldname="Reserved2" fieldmask="0xC0" shifter="6" />
+            </param>
+        </cmd>
+        <cmd key="0x14" name="CMD_ASSIGN_SUC_RETURN_ROUTE" help="Assign SUC Return Route">
+            <param key="0x00" name="NodeID" type="BYTE" encaptype="NODE_NUMBER" />
+            <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Number of Hops" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Route Number" fieldmask="0xF0" shifter="4" />
+            </param>
+            <param key="0x02" name="Repeaters" type="VARIANT" encaptype="NODE_NUMBER">
+                <variant paramoffs="1" sizemask="0x0F" />
+            </param>
+            <param key="0x03" name="Properties2" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Reserved1" flagmask="0x01" />
+                <fieldenum key="0x01" fieldname="Destination Wake Up" fieldmask="0x06" shifter="1">
+                    <fieldenum value="No Wake Up (AL node)" />
+                    <fieldenum value="Wake Up in 250 ms interval (FL Node)" />
+                    <fieldenum value="Wake Up in 1000 ms interval (FL Node)" />
+                </fieldenum>
+                <fieldenum key="0x02" fieldname="Destination Speed" fieldmask="0x38" shifter="3">
+                    <fieldenum value="Reserved000" />
+                    <fieldenum value="9.6 kbps" />
+                    <fieldenum value="40 kbps" />
+                    <fieldenum value="Reserved011" />
+                    <fieldenum value="100 kbps" />
+                </fieldenum>
+                <bitfield key="0x03" fieldname="Reserved2" fieldmask="0xC0" shifter="6" />
+            </param>
+        </cmd>
         <cmd key="0x10" name="CMD_AUTOMATIC_CONTROLLER_UPDATE_START" help="Automatic Controller Update Start" />
-        <cmd key="0x1F" name="CMD_NODES_EXIST" help="Cmd Nodes Exist" />
-        <cmd key="0x20" name="CMD_NODES_EXIST_REPLY" help="Cmd Nodes Exist Reply" />
-        <cmd key="0x22" name="CMD_SET_NWI_MODE" help="Cmd Set Nwi Mode" />
-        <cmd key="0x07" name="COMMAND_COMPLETE" help="Command Complete" comment="SDS10264-2" />
-        <cmd key="0x04" name="FIND_NODES_IN_RANGE" help="Find Nodes In Range" comment="SDS10264-2" />
-        <cmd key="0x05" name="GET_NODES_IN_RANGE" help="Get Nodes In Range" comment="SDS10264-2" />
-        <cmd key="0x16" name="LOST" help="Lost" comment="SDS10264-2" />
-        <cmd key="0x0D" name="NEW_NODE_REGISTERED" help="New Node Registered" comment="SDS10264-2" />
-        <cmd key="0x0E" name="NEW_RANGE_REGISTERED" help="New Range Registered" comment="SDS10264-2" />
+        <cmd key="0x1F" name="CMD_NODES_EXIST" help="Cmd Nodes Exist">
+            <param key="0x00" name="Node Mask Type" type="CONST" comment="The type of nodes which are present in nodeMask">
+                <const key="0x00" flagname="ALL" flagmask="0x00" />
+                <const key="0x01" flagname="REPEATER" flagmask="0x01" />
+                <const key="0x02" flagname="LISTENING" flagmask="0x02" />
+                <const key="0x03" flagname="WAKEUP_1000MS" flagmask="0x03" />
+                <const key="0x04" flagname="WAKEUP_250MS" flagmask="0x04" />
+            </param>
+            <param key="0x01" name="Num Node Mask" type="BYTE" comment="The number of bytes in the nodeMask" />
+            <param key="0x02" name="Node Mask" type="BITMASK" comment="The first mask byte in the frame">
+                <bitmask key="0x00" paramoffs="255" lenmask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x20" name="CMD_NODES_EXIST_REPLY" help="Cmd Nodes Exist Reply">
+            <param key="0x00" name="Node Mask Type" type="CONST" comment="The type of nodes which are to be present ">
+                <const key="0x00" flagname="ALL" flagmask="0x00" />
+                <const key="0x01" flagname="REPEATER" flagmask="0x01" />
+                <const key="0x02" flagname="LISTENING" flagmask="0x02" />
+                <const key="0x03" flagname="WAKEUP_1000MS" flagmask="0x03" />
+                <const key="0x04" flagname="WAKEUP_250MS" flagmask="0x04" />
+            </param>
+            <param key="0x01" name="Status" type="CONST" comment="The result of the Nodes Exist frame received">
+                <const key="0x00" flagname="UNKNOWN_TYPE" flagmask="0x00" />
+                <const key="0x01" flagname="DONE" flagmask="0x01" />
+            </param>
+        </cmd>
+        <cmd key="0x22" name="CMD_SET_NWI_MODE" help="Cmd Set Nwi Mode">
+            <param key="0x00" name="Mode" type="CONST" comment="The NWI Mode to be set">
+                <const key="0x00" flagname="IDLE" flagmask="0x00" />
+                <const key="0x01" flagname="REPEAT" flagmask="0x01" />
+            </param>
+            <param key="0x01" name="Timeout" type="BYTE" comment="Timeout on how long node should be in NWI mode">
+                <bitflag key="0x01" flagname="TIMEOUT_DEFAULT" flagmask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x07" name="COMMAND_COMPLETE" help="Command Complete" comment="SDS10264-2">
+            <param key="0x00" name="Sequence Number" type="BYTE" />
+        </cmd>
+        <cmd key="0x04" name="FIND_NODES_IN_RANGE" help="Find Nodes In Range" comment="SDS10264-2">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Number of Mask Bytes" fieldmask="0x1F" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0x60" shifter="5" />
+                <bitflag key="0x02" flagname="Speed Present" flagmask="0x80" />
+            </param>
+            <param key="0x01" name="Mask Byte(s)" type="BITMASK">
+                <bitmask key="0x00" paramoffs="0" lenmask="0x1F" />
+            </param>
+            <param key="0x02" name="Wake Up Time (optional Rx)" type="CONST">
+                <const key="0x00" flagname="No wakeup beam needed" flagmask="0x00" />
+                <const key="0x01" flagname="1000ms wakeup beam" flagmask="0x01" />
+                <const key="0x02" flagname="250ms wakeup beam" flagmask="0x02" />
+            </param>
+            <param key="0x03" name="Properties2" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="Data Rate (optional Rx)" fieldmask="0x07">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="9.6 kbps" />
+                    <fieldenum value="40 kbps" />
+                    <fieldenum value="100 kbps" />
+                </fieldenum>
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xF8" shifter="3" />
+            </param>
+        </cmd>
+        <cmd key="0x05" name="GET_NODES_IN_RANGE" help="Get Nodes In Range" comment="SDS10264-2">
+            <param key="0x00" name="Wake Up Time (optional Rx)" type="CONST">
+                <const key="0x00" flagname="No wakeup beam needed" flagmask="0x00" />
+                <const key="0x01" flagname="1000ms wakeup beam" flagmask="0x01" />
+                <const key="0x02" flagname="250ms wakeup beam" flagmask="0x02" />
+            </param>
+        </cmd>
+        <cmd key="0x16" name="LOST" help="Lost" comment="SDS10264-2">
+            <param key="0x00" name="Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+        </cmd>
+        <cmd key="0x0D" name="NEW_NODE_REGISTERED" help="New Node Registered" comment="SDS10264-2">
+            <param key="0x00" name="Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+            <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="Protocol Version" fieldmask="0x07">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Z-Wave Version 2.0" />
+                    <fieldenum value="Z-Wave version ZDK 5.0x, ZDK 4.2x" />
+                    <fieldenum value="Z-Wave version ZDK 4.5x and ZDK 6.0x" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                </fieldenum>
+                <fieldenum key="0x01" fieldname="Max baud rate" fieldmask="0x38" shifter="3">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="9.6 kbps" />
+                    <fieldenum value="40 kbps" />
+                </fieldenum>
+                <bitflag key="0x02" flagname="Routing" flagmask="0x40" />
+                <bitflag key="0x03" flagname="Listening" flagmask="0x80" />
+            </param>
+            <param key="0x02" name="Properties2" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Security" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Controller" flagmask="0x02" />
+                <bitflag key="0x02" flagname="Specific Device" flagmask="0x04" />
+                <bitflag key="0x03" flagname="Routing End Node" flagmask="0x08" />
+                <bitflag key="0x04" flagname="Beam capability" flagmask="0x10" />
+                <bitflag key="0x05" flagname="Sensor 250ms" flagmask="0x20" />
+                <bitflag key="0x06" flagname="Sensor 1000ms" flagmask="0x40" />
+                <bitflag key="0x07" flagname="Optional functionality" flagmask="0x80" />
+            </param>
+            <param key="0x03" name="Properties3" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Speed Extension - 100 kbps" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Speed Extension - Reserved" fieldmask="0x06" shifter="1" />
+                <bitfield key="0x02" fieldname="Reserved2" fieldmask="0xF8" shifter="3" />
+            </param>
+            <param key="0x04" name="Basic Device Class" type="BYTE" encaptype="BAS_DEV_REF" optionaloffs="0x02" optionalmask="0x02" />
+            <param key="0x05" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
+            <param key="0x06" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" optionaloffs="0x02" optionalmask="0x04" />
+            <param key="0x07" name="Command Classes" type="VARIANT" encaptype="CMD_CLASS_REF">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x0E" name="NEW_RANGE_REGISTERED" help="New Range Registered" comment="SDS10264-2">
+            <param key="0x00" name="Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+            <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Number of Mask Bytes" fieldmask="0x1F" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xE0" shifter="5" />
+            </param>
+            <param key="0x02" name="Mask Byte(s)" type="BITMASK">
+                <bitmask key="0x00" paramoffs="1" lenmask="0x1F" />
+            </param>
+        </cmd>
         <cmd key="0x01" name="NODE_INFO" help="Node Info" support_mode="RX" comment="SDS10264-2">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
                 <fieldenum key="0x00" fieldname="Protocol Version" fieldmask="0x07">
@@ -13311,65 +13967,335 @@
                 <bitflag key="0x00" flagname="Security" flagmask="0x01" />
                 <bitflag key="0x01" flagname="Controller" flagmask="0x02" />
                 <bitflag key="0x02" flagname="Specific Device" flagmask="0x04" />
-                <bitflag key="0x03" flagname="Routing Slave" flagmask="0x08" />
+                <bitflag key="0x03" flagname="Routing End Node" flagmask="0x08" />
                 <bitflag key="0x04" flagname="Beam capability" flagmask="0x10" />
                 <bitflag key="0x05" flagname="Sensor 250ms" flagmask="0x20" />
                 <bitflag key="0x06" flagname="Sensor 1000ms" flagmask="0x40" />
-                <bitflag key="0x07" flagname="Optional Functionality" flagmask="0x80" />
+                <bitflag key="0x07" flagname="Optional functionality" flagmask="0x80" />
             </param>
             <param key="0x02" name="Properties3" type="STRUCT_BYTE">
-                <fieldenum key="0x00" fieldname="Speed Extension" fieldmask="0x07">
-                    <fieldenum value="Reserved" />
-                    <fieldenum value="100 kbps" />
-                    <fieldenum value="200 kbps" />
-                </fieldenum>
-                <bitfield key="0x01" fieldname="Reserved2" fieldmask="0xF8" shifter="3" />
+                <bitflag key="0x00" flagname="Speed Extension - 100 kbps" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Speed Extension - Reserved" fieldmask="0x06" shifter="1" />
+                <bitfield key="0x02" fieldname="Reserved2" fieldmask="0xF8" shifter="3" />
             </param>
             <param key="0x03" name="Basic Device Class" type="BYTE" encaptype="BAS_DEV_REF" optionaloffs="0x01" optionalmask="0x02" />
             <param key="0x04" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
-            <param key="0x05" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" />
+            <param key="0x05" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" optionaloffs="0x01" optionalmask="0x04" />
             <param key="0x06" name="Command Classes" type="VARIANT" encaptype="CMD_CLASS_REF">
                 <variant paramoffs="255" sizemask="0x00" />
             </param>
         </cmd>
-        <cmd key="0x06" name="NODE_RANGE_INFO" help="Node Range Info" comment="SDS10264-2" />
+        <cmd key="0x06" name="NODE_RANGE_INFO" help="Node Range Info" comment="SDS10264-2">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Number of Mask Bytes" fieldmask="0x1F" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xE0" shifter="5" />
+            </param>
+            <param key="0x01" name="Mask Byte(s)" type="BITMASK">
+                <bitmask key="0x00" paramoffs="0" lenmask="0x1F" />
+            </param>
+            <param key="0x02" name="Wake Up Time" type="CONST">
+                <const key="0x00" flagname="No wakeup beam needed" flagmask="0x00" />
+                <const key="0x01" flagname="1000ms wakeup beam" flagmask="0x01" />
+                <const key="0x02" flagname="250ms wakeup beam" flagmask="0x02" />
+            </param>
+        </cmd>
         <cmd key="0x00" name="ZWAVE_CMD_NOP" help="NOP" />
-        <cmd key="0x18" name="CMD_NOP_POWER" help="NOP Power" />
+        <cmd key="0x18" name="CMD_NOP_POWER" help="NOP Power">
+            <param key="0x00" name="Tx Power Register (Obsolete)" type="CONST">
+                <const key="0x00" flagname="Not used" flagmask="0x00" />
+                <const key="0x01" flagname="No dampening of Tx power" flagmask="0xF0" />
+                <const key="0x02" flagname="-1 dBm" flagmask="0xC8" />
+                <const key="0x03" flagname="-2 dBm" flagmask="0xA7" />
+                <const key="0x04" flagname="-3 dBm" flagmask="0x91" />
+                <const key="0x05" flagname="-4 dBm" flagmask="0x77" />
+                <const key="0x06" flagname="-5 dBm" flagmask="0x67" />
+                <const key="0x07" flagname="-6 dBm" flagmask="0x60" />
+                <const key="0x08" flagname="-7 dBm" flagmask="0x46" />
+                <const key="0x09" flagname="-8 dBm" flagmask="0x38" />
+                <const key="0x0A" flagname="-9 dBm" flagmask="0x35" />
+                <const key="0x0B" flagname="-10 dBm" flagmask="0x32" />
+                <const key="0x0C" flagname="-11 dBm" flagmask="0x30" />
+                <const key="0x0D" flagname="-12 dBm" flagmask="0x24" />
+                <const key="0x0E" flagname="-13 dBm" flagmask="0x22" />
+                <const key="0x0F" flagname="-14 dBm" flagmask="0x20" />
+            </param>
+            <param key="0x01" name="Tx Power Dampening" type="CONST">
+                <const key="0x00" flagname="No dampening of Tx power" flagmask="0x00" />
+                <const key="0x01" flagname="-1 dBm" flagmask="0x01" />
+                <const key="0x02" flagname="-2 dBm" flagmask="0x02" />
+                <const key="0x03" flagname="-3 dBm" flagmask="0x03" />
+                <const key="0x04" flagname="-4 dBm" flagmask="0x04" />
+                <const key="0x05" flagname="-5 dBm" flagmask="0x05" />
+                <const key="0x06" flagname="-6 dBm" flagmask="0x06" />
+                <const key="0x07" flagname="-7 dBm" flagmask="0x07" />
+                <const key="0x08" flagname="-8 dBm" flagmask="0x08" />
+                <const key="0x09" flagname="-9 dBm" flagmask="0x09" />
+                <const key="0x0A" flagname="-10 dBm" flagmask="0x0A" />
+                <const key="0x0B" flagname="-11 dBm" flagmask="0x0B" />
+                <const key="0x0C" flagname="-12 dBm" flagmask="0x0C" />
+                <const key="0x0D" flagname="-13 dBm" flagmask="0x0D" />
+                <const key="0x0E" flagname="-14 dBm" flagmask="0x0E" />
+            </param>
+        </cmd>
         <cmd key="0x02" name="REQUEST_NODE_INFO" help="Request Node Info" comment="SDS10264-2" />
-        <cmd key="0x19" name="ZWAVE_CMD_RESERVE_NODE_IDS" help="Reserve Node ID" />
-        <cmd key="0x1A" name="CMD_RESERVED_IDS" help="Reserved ID" />
-        <cmd key="0x12" name="CMD_SET_SUC" help="Set SUC" />
-        <cmd key="0x13" name="CMD_SET_SUC_ACK" help="Set SUC ACK" />
-        <cmd key="0x15" name="CMD_STATIC_ROUTE_REQUEST" help="Static Route Request" />
-        <cmd key="0x11" name="CMD_SUC_NODE_ID" help="SUC Node ID" />
-        <cmd key="0x0B" name="TRANSFER_END" help="Transfer End" support_mode="TX_RX" comment="SDS10264-2" />
-        <cmd key="0x0F" name="TRANSFER_NEW_PRIMARY_COMPLETE" help="Transfer New Primary Complete" comment="SDS10264-2" />
-        <cmd key="0x09" name="TRANSFER_NODE_INFO" help="Transfer Node Info" comment="SDS10264-2" />
-        <cmd key="0x08" name="TRANSFER_PRESENTATION" help="Transfer Presentation" comment="SDS10264-2" />
-        <cmd key="0x0A" name="TRANSFER_RANGE_INFO" help="Transfer Range Info" comment="SDS10264-2" />
-        <cmd key="0x23" name="EXCLUDE_REQUEST" help="Exclude Request" comment="INS13044" />
-        <cmd key="0x24" name="ASSIGN_RETURN_ROUTE_PRIORITY" help="Assign Return Route Priority" />
-        <cmd key="0x25" name="ASSIGN_SUC_RETURN_ROUTE_PRIORITY" help="Assign SUC Return Route Priority" />
-        <cmd key="0x26" name="INCLUDED_NODE_INFO" help="Included Node Info" comment="INS10264" />
-        <cmd key="0x27" name="SMART_START_PRIME" help="Smart Start Prime" comment="INS10264" />
-        <cmd key="0x28" name="SMART_START_INCLUDE" help="Smart Start Include" comment="INS10264" />
+        <cmd key="0x19" name="ZWAVE_CMD_RESERVE_NODE_IDS" help="Reserve Node ID">
+            <param key="0x00" name="Number of nodes" type="BYTE" />
+        </cmd>
+        <cmd key="0x1A" name="CMD_RESERVED_IDS" help="Reserved ID">
+            <param key="0x00" name="Number of nodes" type="BYTE" />
+            <param key="0x01" name="Node ID" type="VARIANT" encaptype="NODE_NUMBER">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x12" name="CMD_SET_SUC" help="Set SUC">
+            <param key="0x00" name="State" type="BYTE">
+                <bitflag key="0x01" flagname="Disable" flagmask="0x00" />
+                <bitflag key="0x02" flagname="Enable" flagmask="0x01" />
+            </param>
+            <param key="0x01" name="SUC Capability" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Server Running" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
+            </param>
+        </cmd>
+        <cmd key="0x13" name="CMD_SET_SUC_ACK" help="Set SUC ACK">
+            <param key="0x00" name="Result" type="BYTE">
+                <bitflag key="0x01" flagname="Rejected" flagmask="0x00" />
+                <bitflag key="0x02" flagname="Accepted" flagmask="0x80" />
+            </param>
+            <param key="0x01" name="SUC Capability" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Server Running" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
+            </param>
+        </cmd>
+        <cmd key="0x15" name="CMD_STATIC_ROUTE_REQUEST" help="Static Route Request">
+            <param key="0x00" name="Dest Node ID" type="ARRAY" encaptype="NODE_NUMBER">
+                <arrayattrib key="0x00" len="5" />
+            </param>
+        </cmd>
+        <cmd key="0x11" name="CMD_SUC_NODE_ID" help="SUC Node ID">
+            <param key="0x00" name="SUC Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+            <param key="0x01" name="SUC Capability" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Server Running" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
+            </param>
+        </cmd>
+        <cmd key="0x0B" name="TRANSFER_END" help="Transfer End" support_mode="TX_RX" comment="SDS10264-2">
+            <param key="0x00" name="Status" type="CONST">
+                <const key="0x00" flagname="Transfer failed" flagmask="0x00" />
+                <const key="0x01" flagname="Transfer OK" flagmask="0x01" />
+                <const key="0x02" flagname="Transfer update done" flagmask="0x02" />
+                <const key="0x03" flagname="Transfer update aborted" flagmask="0x03" />
+                <const key="0x04" flagname="Transfer update wait" flagmask="0x04" />
+                <const key="0x05" flagname="Transfer update disabled" flagmask="0x05" />
+                <const key="0x06" flagname="Transfer update overflow" flagmask="0x06" />
+            </param>
+        </cmd>
+        <cmd key="0x0F" name="TRANSFER_NEW_PRIMARY_COMPLETE" help="Transfer New Primary Controller Complete">
+            <param key="0x00" name="Controller Type" type="BYTE" encaptype="GEN_DEV_REF" />
+        </cmd>
+        <cmd key="0x09" name="TRANSFER_NODE_INFO" help="Transfer Node Info" comment="SDS10264-2">
+            <param key="0x00" name="Sequence Number" type="BYTE" />
+            <param key="0x01" name="Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+            <param key="0x02" name="Properties1" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="Protocol Version" fieldmask="0x07">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Z-Wave Version 2.0" />
+                    <fieldenum value="Z-Wave version ZDK 5.0x, ZDK 4.2x" />
+                    <fieldenum value="Z-Wave version ZDK 4.5x and ZDK 6.0x" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                </fieldenum>
+                <fieldenum key="0x01" fieldname="Max baud rate" fieldmask="0x38" shifter="3">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="9.6 kbps" />
+                    <fieldenum value="40 kbps" />
+                </fieldenum>
+                <bitflag key="0x02" flagname="Routing" flagmask="0x40" />
+                <bitflag key="0x03" flagname="Listening" flagmask="0x80" />
+            </param>
+            <param key="0x03" name="Properties2" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Security" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Controller" flagmask="0x02" />
+                <bitflag key="0x02" flagname="Specific Device" flagmask="0x04" />
+                <bitflag key="0x03" flagname="Routing End Node" flagmask="0x08" />
+                <bitflag key="0x04" flagname="Beam capability" flagmask="0x10" />
+                <bitflag key="0x05" flagname="Sensor 250ms" flagmask="0x20" />
+                <bitflag key="0x06" flagname="Sensor 1000ms" flagmask="0x40" />
+                <bitflag key="0x07" flagname="Optional functionality" flagmask="0x80" />
+            </param>
+            <param key="0x04" name="Properties3" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Speed Extension - 100 kbps" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Speed Extension - Reserved" fieldmask="0x06" shifter="1" />
+                <bitfield key="0x02" fieldname="Reserved2" fieldmask="0xF8" shifter="3" />
+            </param>
+            <param key="0x05" name="Basic Device Class" type="BYTE" encaptype="BAS_DEV_REF" optionaloffs="0x03" optionalmask="0x02" />
+            <param key="0x06" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
+            <param key="0x07" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" optionaloffs="0x03" optionalmask="0x04" />
+        </cmd>
+        <cmd key="0x08" name="TRANSFER_PRESENTATION" help="Transfer Presentation" comment="SDS10264-2">
+            <param key="0x00" name="Option" type="BYTE" comment="Command option bitmask">
+                <bitflag key="0x01" flagname="NWI Support" flagmask="0x01" />
+                <bitflag key="0x02" flagname="Exclusion" flagmask="0x02" />
+                <bitflag key="0x03" flagname="Inclusion" flagmask="0x04" />
+            </param>
+        </cmd>
+        <cmd key="0x0A" name="TRANSFER_RANGE_INFO" help="Transfer Range Info" comment="SDS10264-2">
+            <param key="0x00" name="Sequence Number" type="BYTE" />
+            <param key="0x01" name="Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+            <param key="0x02" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Number of Mask Bytes" fieldmask="0x1F" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xE0" shifter="5" />
+            </param>
+            <param key="0x03" name="Mask Byte(s)" type="BITMASK">
+                <bitmask key="0x00" paramoffs="2" lenmask="0x1F" />
+            </param>
+        </cmd>
+        <cmd key="0x23" name="EXCLUDE_REQUEST" help="Exclude Request" comment="INS13044">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="Protocol Version" fieldmask="0x07">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Z-Wave Version 2.0" />
+                    <fieldenum value="Z-Wave version ZDK 5.0x, ZDK 4.2x" />
+                    <fieldenum value="Z-Wave version ZDK 4.5x and ZDK 6.0x" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                </fieldenum>
+                <fieldenum key="0x01" fieldname="Max baud rate" fieldmask="0x38" shifter="3">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="9.6 kbps" />
+                    <fieldenum value="40 kbps" />
+                </fieldenum>
+                <bitflag key="0x02" flagname="Routing" flagmask="0x40" />
+                <bitflag key="0x03" flagname="Listening" flagmask="0x80" />
+            </param>
+            <param key="0x01" name="Properties2" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Security" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Controller" flagmask="0x02" />
+                <bitflag key="0x02" flagname="Specific Device" flagmask="0x04" />
+                <bitflag key="0x03" flagname="Routing End Node" flagmask="0x08" />
+                <bitflag key="0x04" flagname="Beam capability" flagmask="0x10" />
+                <bitflag key="0x05" flagname="Sensor 250ms" flagmask="0x20" />
+                <bitflag key="0x06" flagname="Sensor 1000ms" flagmask="0x40" />
+                <bitflag key="0x07" flagname="Optional functionality" flagmask="0x80" />
+            </param>
+            <param key="0x02" name="Properties3" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Speed Extension - 100 kbps" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Speed Extension - Reserved" fieldmask="0x06" shifter="1" />
+                <bitfield key="0x02" fieldname="Reserved2" fieldmask="0xF8" shifter="3" />
+            </param>
+            <param key="0x03" name="Basic Device Class" type="BYTE" encaptype="BAS_DEV_REF" optionaloffs="0x01" optionalmask="0x02" />
+            <param key="0x04" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
+            <param key="0x05" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" optionaloffs="0x01" optionalmask="0x04" />
+            <param key="0x06" name="Command Classes" type="VARIANT" encaptype="CMD_CLASS_REF">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x24" name="ASSIGN_RETURN_ROUTE_PRIORITY" help="Assign Return Route Priority">
+            <param key="0x00" name="Destination Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+            <param key="0x01" name="Priority Route" type="BYTE" />
+        </cmd>
+        <cmd key="0x25" name="ASSIGN_SUC_RETURN_ROUTE_PRIORITY" help="Assign SUC Return Route Priority">
+            <param key="0x00" name="Destination Node ID" type="BYTE" encaptype="NODE_NUMBER" />
+            <param key="0x01" name="Priority Route" type="BYTE" />
+        </cmd>
+        <cmd key="0x26" name="INCLUDED_NODE_INFO" help="Included Node Info" comment="INS10264">
+            <param key="0x00" name="NWI Home ID" type="DWORD" />
+        </cmd>
+        <cmd key="0x27" name="SMART_START_PRIME" help="SmartStart Prime" comment="INS10264">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="Protocol Version" fieldmask="0x07">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Z-Wave Version 2.0" />
+                    <fieldenum value="Z-Wave version ZDK 5.0x, ZDK 4.2x" />
+                    <fieldenum value="Z-Wave version ZDK 4.5x and ZDK 6.0x" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                </fieldenum>
+                <fieldenum key="0x01" fieldname="Max baud rate" fieldmask="0x38" shifter="3">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="9.6 kbps" />
+                    <fieldenum value="40 kbps" />
+                </fieldenum>
+                <bitflag key="0x02" flagname="Routing" flagmask="0x40" />
+                <bitflag key="0x03" flagname="Listening" flagmask="0x80" />
+            </param>
+            <param key="0x01" name="Properties2" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Security" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Controller" flagmask="0x02" />
+                <bitflag key="0x02" flagname="Specific Device" flagmask="0x04" />
+                <bitflag key="0x03" flagname="Routing End Node" flagmask="0x08" />
+                <bitflag key="0x04" flagname="Beam capability" flagmask="0x10" />
+                <bitflag key="0x05" flagname="Sensor 250ms" flagmask="0x20" />
+                <bitflag key="0x06" flagname="Sensor 1000ms" flagmask="0x40" />
+                <bitflag key="0x07" flagname="Optional functionality" flagmask="0x80" />
+            </param>
+            <param key="0x02" name="Properties3" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Speed Extension - 100 kbps" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Speed Extension - Reserved" fieldmask="0x06" shifter="1" />
+                <bitfield key="0x02" fieldname="Reserved2" fieldmask="0xF8" shifter="3" />
+            </param>
+            <param key="0x03" name="Basic Device Class" type="BYTE" encaptype="BAS_DEV_REF" optionaloffs="0x01" optionalmask="0x02" />
+            <param key="0x04" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
+            <param key="0x05" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" optionaloffs="0x01" optionalmask="0x04" />
+            <param key="0x06" name="Command Classes" type="VARIANT" encaptype="CMD_CLASS_REF">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x28" name="SMART_START_INCLUDE" help="SmartStart Include" comment="INS10264">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="Protocol Version" fieldmask="0x07">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Z-Wave Version 2.0" />
+                    <fieldenum value="Z-Wave version ZDK 5.0x, ZDK 4.2x" />
+                    <fieldenum value="Z-Wave version ZDK 4.5x and ZDK 6.0x" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                </fieldenum>
+                <fieldenum key="0x01" fieldname="Max baud rate" fieldmask="0x38" shifter="3">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="9.6 kbps" />
+                    <fieldenum value="40 kbps" />
+                </fieldenum>
+                <bitflag key="0x02" flagname="Routing" flagmask="0x40" />
+                <bitflag key="0x03" flagname="Listening" flagmask="0x80" />
+            </param>
+            <param key="0x01" name="Properties2" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Security" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Controller" flagmask="0x02" />
+                <bitflag key="0x02" flagname="Specific Device" flagmask="0x04" />
+                <bitflag key="0x03" flagname="Routing End Node" flagmask="0x08" />
+                <bitflag key="0x04" flagname="Beam capability" flagmask="0x10" />
+                <bitflag key="0x05" flagname="Sensor 250ms" flagmask="0x20" />
+                <bitflag key="0x06" flagname="Sensor 1000ms" flagmask="0x40" />
+                <bitflag key="0x07" flagname="Optional functionality" flagmask="0x80" />
+            </param>
+            <param key="0x02" name="Properties3" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Speed Extension - 100 kbps" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Speed Extension - Reserved" fieldmask="0x06" shifter="1" />
+                <bitfield key="0x02" fieldname="Reserved2" fieldmask="0xF8" shifter="3" />
+            </param>
+            <param key="0x03" name="Basic Device Class" type="BYTE" encaptype="BAS_DEV_REF" optionaloffs="0x01" optionalmask="0x02" />
+            <param key="0x04" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
+            <param key="0x05" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" optionaloffs="0x01" optionalmask="0x04" />
+            <param key="0x06" name="Command Classes" type="VARIANT" encaptype="CMD_CLASS_REF">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+        </cmd>
     </cmd_class>
-    <cmd_class key="0x04" version="1" name="ZWAVE_CMD_CLASS_LR" help="Z-Wave protocol Command Class (LR)">
-        <cmd key="0x17" name="ACCEPT_LOST" help="Accept Lost" comment="SDS10264-2" />
-        <cmd key="0x03" name="ASSIGN_ID" help="Assign Id" comment="SDS10264-2" />
-        <cmd key="0x0C" name="ASSIGN_RETURN_ROUTE" help="Assign Return Route" comment="SDS10264-2" />
-        <cmd key="0x14" name="CMD_ASSIGN_SUC_RETURN_ROUTE" help="Assign SUC Return Route" />
-        <cmd key="0x10" name="CMD_AUTOMATIC_CONTROLLER_UPDATE_START" help="Automatic Controller Update Start" />
-        <cmd key="0x1F" name="CMD_NODES_EXIST" help="Cmd Nodes Exist" />
-        <cmd key="0x20" name="CMD_NODES_EXIST_REPLY" help="Cmd Nodes Exist Reply" />
-        <cmd key="0x22" name="CMD_SET_NWI_MODE" help="Cmd Set Nwi Mode" />
-        <cmd key="0x07" name="COMMAND_COMPLETE" help="Command Complete" comment="SDS10264-2" />
-        <cmd key="0x04" name="FIND_NODES_IN_RANGE" help="Find Nodes In Range" comment="SDS10264-2" />
-        <cmd key="0x05" name="GET_NODES_IN_RANGE" help="Get Nodes In Range" comment="SDS10264-2" />
-        <cmd key="0x16" name="LOST" help="Lost" comment="SDS10264-2" />
-        <cmd key="0x0D" name="NEW_NODE_REGISTERED" help="New Node Registered" comment="SDS10264-2" />
-        <cmd key="0x0E" name="NEW_RANGE_REGISTERED" help="New Range Registered" comment="SDS10264-2" />
-        <cmd key="0x01" name="NODE_INFO" help="Node Info" support_mode="RX" comment="SDS10264-2">
+    <cmd_class key="0x04" version="1" name="COMMAND_CLASS_ZWAVE_LONG_RANGE" help="Command Class Z-Wave Long Range">
+        <cmd key="0x03" name="ZWAVE_LR_CMD_ASSIGN_IDS" help="Assign IDs" comment="INS14722-2">
+            <param key="0x00" name="New Node ID" type="WORD" />
+            <param key="0x01" name="New Home ID" type="DWORD" />
+        </cmd>
+        <cmd key="0x01" name="ZWAVE_LR_CMD_NODE_INFO_FRAME" help="Node Info" support_mode="RX" comment="INS14722-2">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
                 <fieldenum key="0x00" fieldname="Protocol Version" fieldmask="0x07">
                     <fieldenum value="Reserved" />
@@ -13393,11 +14319,11 @@
                 <bitflag key="0x00" flagname="Security" flagmask="0x01" />
                 <bitflag key="0x01" flagname="Controller" flagmask="0x02" />
                 <bitflag key="0x02" flagname="Specific Device" flagmask="0x04" />
-                <bitflag key="0x03" flagname="Routing Slave" flagmask="0x08" />
+                <bitflag key="0x03" flagname="Routing End Node" flagmask="0x08" />
                 <bitflag key="0x04" flagname="Beam capability" flagmask="0x10" />
                 <bitflag key="0x05" flagname="Sensor 250ms" flagmask="0x20" />
                 <bitflag key="0x06" flagname="Sensor 1000ms" flagmask="0x40" />
-                <bitflag key="0x07" flagname="Optional Functionality" flagmask="0x80" />
+                <bitflag key="0x07" flagname="Optional functionality" flagmask="0x80" />
             </param>
             <param key="0x02" name="Properties3" type="STRUCT_BYTE">
                 <fieldenum key="0x00" fieldname="Speed Extension" fieldmask="0x07">
@@ -13407,34 +14333,104 @@
                 </fieldenum>
                 <bitfield key="0x01" fieldname="Reserved2" fieldmask="0xF8" shifter="3" />
             </param>
-            <param key="0x03" name="Basic Device Class" type="BYTE" encaptype="BAS_DEV_REF" optionaloffs="0x01" optionalmask="0x02" />
-            <param key="0x04" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
-            <param key="0x05" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" />
+            <param key="0x03" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
+            <param key="0x04" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" />
+            <param key="0x05" name="Command Class List Length" type="BYTE" />
             <param key="0x06" name="Command Classes" type="VARIANT" encaptype="CMD_CLASS_REF">
-                <variant paramoffs="255" sizemask="0x00" />
+                <variant paramoffs="5" sizemask="0xFF" />
             </param>
         </cmd>
-        <cmd key="0x06" name="NODE_RANGE_INFO" help="Node Range Info" comment="SDS10264-2" />
-        <cmd key="0x00" name="ZWAVE_CMD_NOP" help="NOP" />
-        <cmd key="0x18" name="CMD_NOP_POWER" help="NOP Power" />
-        <cmd key="0x02" name="REQUEST_NODE_INFO" help="Request Node Info" comment="SDS10264-2" />
-        <cmd key="0x19" name="ZWAVE_CMD_RESERVE_NODE_IDS" help="Reserve Node ID" />
-        <cmd key="0x1A" name="CMD_RESERVED_IDS" help="Reserved ID" />
-        <cmd key="0x12" name="CMD_SET_SUC" help="Set SUC" />
-        <cmd key="0x13" name="CMD_SET_SUC_ACK" help="Set SUC ACK" />
-        <cmd key="0x15" name="CMD_STATIC_ROUTE_REQUEST" help="Static Route Request" />
-        <cmd key="0x11" name="CMD_SUC_NODE_ID" help="SUC Node ID" />
-        <cmd key="0x0B" name="TRANSFER_END" help="Transfer End" support_mode="TX_RX" comment="SDS10264-2" />
-        <cmd key="0x0F" name="TRANSFER_NEW_PRIMARY_COMPLETE" help="Transfer New Primary Complete" comment="SDS10264-2" />
-        <cmd key="0x09" name="TRANSFER_NODE_INFO" help="Transfer Node Info" comment="SDS10264-2" />
-        <cmd key="0x08" name="TRANSFER_PRESENTATION" help="Transfer Presentation" comment="SDS10264-2" />
-        <cmd key="0x0A" name="TRANSFER_RANGE_INFO" help="Transfer Range Info" comment="SDS10264-2" />
-        <cmd key="0x23" name="EXCLUDE_REQUEST" help="Exclude Request" comment="INS13044" />
-        <cmd key="0x24" name="ASSIGN_RETURN_ROUTE_PRIORITY" help="Assign Return Route Priority" />
-        <cmd key="0x25" name="ASSIGN_SUC_RETURN_ROUTE_PRIORITY" help="Assign SUC Return Route Priority" />
-        <cmd key="0x26" name="INCLUDED_NODE_INFO" help="Included Node Info" comment="INS10264" />
-        <cmd key="0x27" name="SMART_START_PRIME" help="Smart Start Prime" comment="INS10264" />
-        <cmd key="0x28" name="SMART_START_INCLUDE" help="Smart Start Include" comment="INS10264" />
+        <cmd key="0x00" name="ZWAVE_LR_CMD_NO_OPERATION" help="NOP" comment="INS14722-2" />
+        <cmd key="0x02" name="ZWAVE_LR_CMD_REQUEST_NODE_INFO" help="Request Node Info" comment="INS14722-2" />
+        <cmd key="0x23" name="ZWAVE_LR_CMD_EXCLUDE_REQUEST" help="Exclude Request" comment="INS14722-2" />
+        <cmd key="0x26" name="ZWAVE_LR_CMD_INCLUDED_NODE_INFO" help="SmartStart Included Node Info" comment="INS14722-2">
+            <param key="0x00" name="NWI Home ID" type="DWORD" />
+        </cmd>
+        <cmd key="0x27" name="ZWAVE_LR_CMD_SMARTSTART_PRIME" help="SmartStart Prime" comment="INS14722-2">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="Protocol Version" fieldmask="0x07">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Z-Wave Version 2.0" />
+                    <fieldenum value="Z-Wave version ZDK 5.0x, ZDK 4.2x" />
+                    <fieldenum value="Z-Wave version ZDK 4.5x and ZDK 6.0x" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                </fieldenum>
+                <fieldenum key="0x01" fieldname="Max baud rate" fieldmask="0x38" shifter="3">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="9.6 kbps" />
+                    <fieldenum value="40 kbps" />
+                </fieldenum>
+                <bitflag key="0x02" flagname="Routing" flagmask="0x40" />
+                <bitflag key="0x03" flagname="Listening" flagmask="0x80" />
+            </param>
+            <param key="0x01" name="Properties2" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Security" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Controller" flagmask="0x02" />
+                <bitflag key="0x02" flagname="Specific Device" flagmask="0x04" />
+                <bitflag key="0x03" flagname="Routing End Node" flagmask="0x08" />
+                <bitflag key="0x04" flagname="Beam capability" flagmask="0x10" />
+                <bitflag key="0x05" flagname="Sensor 250ms" flagmask="0x20" />
+                <bitflag key="0x06" flagname="Sensor 1000ms" flagmask="0x40" />
+                <bitflag key="0x07" flagname="Optional functionality" flagmask="0x80" />
+            </param>
+            <param key="0x02" name="Reserved" type="BYTE" />
+            <param key="0x03" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
+            <param key="0x04" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" />
+            <param key="0x05" name="Command Class List Length" type="BYTE" />
+            <param key="0x06" name="Command Classes" type="VARIANT" encaptype="CMD_CLASS_REF">
+                <variant paramoffs="5" sizemask="0xFF" />
+            </param>
+        </cmd>
+        <cmd key="0x28" name="ZWAVE_LR_CMD_SMARTSTART_INCLUDE" help="SmartStart Inclusion Request" comment="INS14722-2">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="Protocol Version" fieldmask="0x07">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Z-Wave Version 2.0" />
+                    <fieldenum value="Z-Wave version ZDK 5.0x, ZDK 4.2x" />
+                    <fieldenum value="Z-Wave version ZDK 4.5x and ZDK 6.0x" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="Reserved" />
+                </fieldenum>
+                <fieldenum key="0x01" fieldname="Max baud rate" fieldmask="0x38" shifter="3">
+                    <fieldenum value="Reserved" />
+                    <fieldenum value="9.6 kbps" />
+                    <fieldenum value="40 kbps" />
+                </fieldenum>
+                <bitflag key="0x02" flagname="Routing" flagmask="0x40" />
+                <bitflag key="0x03" flagname="Listening" flagmask="0x80" />
+            </param>
+            <param key="0x01" name="Properties2" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Security" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Controller" flagmask="0x02" />
+                <bitflag key="0x02" flagname="Specific Device" flagmask="0x04" />
+                <bitflag key="0x03" flagname="Routing End Node" flagmask="0x08" />
+                <bitflag key="0x04" flagname="Beam capability" flagmask="0x10" />
+                <bitflag key="0x05" flagname="Sensor 250ms" flagmask="0x20" />
+                <bitflag key="0x06" flagname="Sensor 1000ms" flagmask="0x40" />
+                <bitflag key="0x07" flagname="Optional functionality" flagmask="0x80" />
+            </param>
+            <param key="0x02" name="Reserved" type="BYTE" />
+            <param key="0x03" name="Generic Device Class" type="BYTE" encaptype="GEN_DEV_REF" />
+            <param key="0x04" name="Specific Device Class" type="BYTE" encaptype="SPEC_DEV_REF" />
+            <param key="0x05" name="Command Class List Length" type="BYTE" />
+            <param key="0x06" name="Command Classes" type="VARIANT" encaptype="CMD_CLASS_REF">
+                <variant paramoffs="5" sizemask="0xFF" />
+            </param>
+        </cmd>
+        <cmd key="0x29" name="ZWAVE_LR_CMD_EXCLUDE_REQUEST_CONFIRMATION" help="Exclude Request Confirmation">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Requesting NodeID MSB" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Reserved1" fieldmask="0xF0" shifter="4" />
+            </param>
+            <param key="0x01" name="Requesting NodeID LSB" type="BYTE" />
+            <param key="0x02" name="Requesting HomeID" type="DWORD" />
+        </cmd>
+        <cmd key="0x2A" name="ZWAVE_LR_CMD_NON_SECURE_INCLUSION_STEP_COMPLETE" help="Non Secure Inclusion Step Complete" comment="INS14722-2" />
     </cmd_class>
     <cmd_class key="0x57" version="1" name="COMMAND_CLASS_APPLICATION_CAPABILITY" help="Command Class Application Capability" comment="[OBSOLETED]">
         <cmd key="0x01" name="COMMAND_COMMAND_CLASS_NOT_SUPPORTED" help="Command Command Class Not Supported" support_mode="TX">
@@ -13503,7 +14499,10 @@
                 <param key="0x00" name="Color Component ID" type="BYTE" />
                 <param key="0x01" name="Value" type="BYTE" />
             </variant_group>
-            <param key="0x02" name="Duration" type="BYTE" />
+            <param key="0x02" name="Duration" type="BYTE">
+                <bitflag key="0x01" flagname="Instantly" flagmask="0x00" />
+                <bitflag key="0x02" flagname="Default" flagmask="0xFF" />
+            </param>
         </cmd>
         <cmd key="0x06" name="SWITCH_COLOR_START_LEVEL_CHANGE" help="Color Switch Start Level Change" support_mode="RX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
@@ -13531,10 +14530,10 @@
             <param key="0x00" name="Color Component ID" type="BYTE" />
             <param key="0x01" name="Current Value" type="BYTE" />
             <param key="0x02" name="Target Value" type="BYTE" />
-            <param key="0x03" name="Duration" type="CONST">
-                <const key="0x00" flagname="Already at the Target Value" flagmask="0x00" />
-                <const key="0x01" flagname="Unknown duration" flagmask="0xFE" />
-                <const key="0x02" flagname="Reserved" flagmask="0xFF" />
+            <param key="0x03" name="Duration" type="BYTE">
+                <bitflag key="0x00" flagname="Already at the Target Value" flagmask="0x00" />
+                <bitflag key="0x01" flagname="Unknown duration" flagmask="0xFE" />
+                <bitflag key="0x02" flagname="Reserved" flagmask="0xFF" />
             </param>
         </cmd>
         <cmd key="0x05" name="SWITCH_COLOR_SET" help="Color Switch Set" support_mode="RX">
@@ -13546,9 +14545,9 @@
                 <param key="0x00" name="Color Component ID" type="BYTE" />
                 <param key="0x01" name="Value" type="BYTE" />
             </variant_group>
-            <param key="0x02" name="Duration" type="CONST">
-                <const key="0x00" flagname="Instantly" flagmask="0x00" />
-                <const key="0x01" flagname="Default" flagmask="0xFF" />
+            <param key="0x02" name="Duration" type="BYTE">
+                <bitflag key="0x01" flagname="Instantly" flagmask="0x00" />
+                <bitflag key="0x02" flagname="Default" flagmask="0xFF" />
             </param>
         </cmd>
         <cmd key="0x06" name="SWITCH_COLOR_START_LEVEL_CHANGE" help="Color Switch Start Level Change" support_mode="RX">
@@ -14256,52 +15255,76 @@
                 <param key="0x00" name="Grouping Identifier" type="BYTE" />
                 <param key="0x01" name="Mode" type="BYTE" />
                 <param key="0x02" name="Profile1" type="CONST">
-                    <const key="0x00" flagname="Profile General" flagmask="0x00" />
-                    <const key="0x01" flagname="Profile Control" flagmask="0x20" />
-                    <const key="0x02" flagname="Profile Sensor" flagmask="0x31" />
-                    <const key="0x03" flagname="Profile Notification" flagmask="0x71" />
+                    <const key="0x00" flagname="AGI_PROFILE_GENERAL" flagmask="0x00" />
+                    <const key="0x01" flagname="AGI_PROFILE_CONTROL" flagmask="0x20" />
+                    <const key="0x02" flagname="AGI_PROFILE_SENSOR" flagmask="0x31" />
+                    <const key="0x03" flagname="AGI_PROFILE_NOTIFICATION" flagmask="0x71" />
                 </param>
                 <param key="0x03" name="Profile2" type="MULTI_ARRAY">
                     <multi_array>
                         <paramdescloc key="0x00" param="2" paramdesc="255" paramstart="2" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x00" flagname="Profile General NA" flagmask="0x00" />
-                        <bitflag key="0x00" flagname="Profile General Lifeline" flagmask="0x01" />
+                        <bitflag key="0x00" flagname="AGI_GENERAL_NA" flagmask="0x00" />
+                        <bitflag key="0x00" flagname="AGI_GENERAL_LIFELINE" flagmask="0x01" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x20" flagname="Profile Control KEY01" flagmask="0x01" />
-                        <bitflag key="0x20" flagname="Profile Control KEY02" flagmask="0x02" />
-                        <bitflag key="0x20" flagname="Profile Control KEY03" flagmask="0x03" />
-                        <bitflag key="0x20" flagname="Profile Control KEY04" flagmask="0x04" />
-                        <bitflag key="0x20" flagname="Profile Control KEY05" flagmask="0x05" />
-                        <bitflag key="0x20" flagname="Profile Control KEY06" flagmask="0x06" />
-                        <bitflag key="0x20" flagname="Profile Control KEY07" flagmask="0x07" />
-                        <bitflag key="0x20" flagname="Profile Control KEY08" flagmask="0x08" />
-                        <bitflag key="0x20" flagname="Profile Control KEY09" flagmask="0x09" />
-                        <bitflag key="0x20" flagname="Profile Control KEY10" flagmask="0x0A" />
-                        <bitflag key="0x20" flagname="Profile Control KEY11" flagmask="0x0B" />
-                        <bitflag key="0x20" flagname="Profile Control KEY12" flagmask="0x0C" />
-                        <bitflag key="0x20" flagname="Profile Control KEY13" flagmask="0x0D" />
-                        <bitflag key="0x20" flagname="Profile Control KEY14" flagmask="0x0E" />
-                        <bitflag key="0x20" flagname="Profile Control KEY15" flagmask="0x0F" />
-                        <bitflag key="0x20" flagname="Profile Control KEY16" flagmask="0x10" />
-                        <bitflag key="0x20" flagname="Profile Control KEY17" flagmask="0x11" />
-                        <bitflag key="0x20" flagname="Profile Control KEY18" flagmask="0x12" />
-                        <bitflag key="0x20" flagname="Profile Control KEY19" flagmask="0x13" />
-                        <bitflag key="0x20" flagname="Profile Control KEY20" flagmask="0x14" />
-                        <bitflag key="0x20" flagname="Profile Control KEY21" flagmask="0x15" />
-                        <bitflag key="0x20" flagname="Profile Control KEY22" flagmask="0x16" />
-                        <bitflag key="0x20" flagname="Profile Control KEY23" flagmask="0x17" />
-                        <bitflag key="0x20" flagname="Profile Control KEY24" flagmask="0x18" />
-                        <bitflag key="0x20" flagname="Profile Control KEY25" flagmask="0x19" />
-                        <bitflag key="0x20" flagname="Profile Control KEY26" flagmask="0x1A" />
-                        <bitflag key="0x20" flagname="Profile Control KEY27" flagmask="0x1B" />
-                        <bitflag key="0x20" flagname="Profile Control KEY28" flagmask="0x1C" />
-                        <bitflag key="0x20" flagname="Profile Control KEY29" flagmask="0x1D" />
-                        <bitflag key="0x20" flagname="Profile Control KEY30" flagmask="0x1E" />
-                        <bitflag key="0x20" flagname="Profile Control KEY31" flagmask="0x1F" />
-                        <bitflag key="0x20" flagname="Profile Control KEY32" flagmask="0x20" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY01" flagmask="0x01" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY02" flagmask="0x02" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY03" flagmask="0x03" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY04" flagmask="0x04" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY05" flagmask="0x05" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY06" flagmask="0x06" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY07" flagmask="0x07" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY08" flagmask="0x08" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY09" flagmask="0x09" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY10" flagmask="0x0A" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY11" flagmask="0x0B" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY12" flagmask="0x0C" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY13" flagmask="0x0D" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY14" flagmask="0x0E" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY15" flagmask="0x0F" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY16" flagmask="0x10" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY17" flagmask="0x11" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY18" flagmask="0x12" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY19" flagmask="0x13" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY20" flagmask="0x14" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY21" flagmask="0x15" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY22" flagmask="0x16" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY23" flagmask="0x17" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY24" flagmask="0x18" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY25" flagmask="0x19" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY26" flagmask="0x1A" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY27" flagmask="0x1B" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY28" flagmask="0x1C" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY29" flagmask="0x1D" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY30" flagmask="0x1E" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY31" flagmask="0x1F" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY32" flagmask="0x20" />
+                    </multi_array>
+                    <multi_array>
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_SMOKE_ALARM" flagmask="0x01" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_C0_ALARM" flagmask="0x02" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_CO2_ALARM" flagmask="0x03" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HEAT_ALARM" flagmask="0x04" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WATER_ALARM" flagmask="0x05" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_ACCESS_CONTROL" flagmask="0x06" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HOME_SECURITY" flagmask="0x07" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_POWER_MANAGEMENT" flagmask="0x08" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_SYSTEM" flagmask="0x09" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_EMERGENCY_ALARM" flagmask="0x0A" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_CLOCK" flagmask="0x0B" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_APPLIANCE" flagmask="0x0C" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HOME_HEALTH" flagmask="0x0D" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_SIREN" flagmask="0x0E" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WATER_VALVE" flagmask="0x0F" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WEATHER_ALARM" flagmask="0x10" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_IRRIGATION" flagmask="0x11" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_GAS_ALARM" flagmask="0x12" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_PEST_CONTROL" flagmask="0x13" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_LIGHT_SENSOR" flagmask="0x14" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WATER_QUALITY_MONITORING" flagmask="0x15" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HOME_MONITORING" flagmask="0x16" />
                     </multi_array>
                 </param>
                 <param key="0x04" name="Reserved" type="BYTE" />
@@ -14352,66 +15375,86 @@
                 <param key="0x00" name="Grouping Identifier" type="BYTE" />
                 <param key="0x01" name="Mode" type="BYTE" />
                 <param key="0x02" name="Profile1" type="CONST">
-                    <const key="0x00" flagname="Profile General" flagmask="0x00" />
-                    <const key="0x01" flagname="Profile Control" flagmask="0x20" />
-                    <const key="0x02" flagname="Profile Sensor" flagmask="0x31" />
-                    <const key="0x03" flagname="Profile Notification" flagmask="0x71" />
-                    <const key="0x04" flagname="Profile Meter" flagmask="0x32" />
+                    <const key="0x00" flagname="AGI_PROFILE_GENERAL" flagmask="0x00" />
+                    <const key="0x01" flagname="AGI_PROFILE_CONTROL" flagmask="0x20" />
+                    <const key="0x02" flagname="AGI_PROFILE_SENSOR" flagmask="0x31" />
+                    <const key="0x03" flagname="AGI_PROFILE_NOTIFICATION" flagmask="0x71" />
+                    <const key="0x04" flagname="AGI_PROFILE_METER" flagmask="0x32" />
                 </param>
                 <param key="0x03" name="Profile2" type="MULTI_ARRAY">
                     <multi_array>
                         <paramdescloc key="0x00" param="2" paramdesc="255" paramstart="2" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x00" flagname="Profile General NA" flagmask="0x00" />
-                        <bitflag key="0x00" flagname="Profile General Lifeline" flagmask="0x01" />
+                        <bitflag key="0x00" flagname="AGI_GENERAL_NA" flagmask="0x00" />
+                        <bitflag key="0x00" flagname="AGI_GENERAL_LIFELINE" flagmask="0x01" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x20" flagname="Profile Control KEY01" flagmask="0x01" />
-                        <bitflag key="0x20" flagname="Profile Control KEY02" flagmask="0x02" />
-                        <bitflag key="0x20" flagname="Profile Control KEY03" flagmask="0x03" />
-                        <bitflag key="0x20" flagname="Profile Control KEY04" flagmask="0x04" />
-                        <bitflag key="0x20" flagname="Profile Control KEY05" flagmask="0x05" />
-                        <bitflag key="0x20" flagname="Profile Control KEY06" flagmask="0x06" />
-                        <bitflag key="0x20" flagname="Profile Control KEY07" flagmask="0x07" />
-                        <bitflag key="0x20" flagname="Profile Control KEY08" flagmask="0x08" />
-                        <bitflag key="0x20" flagname="Profile Control KEY09" flagmask="0x09" />
-                        <bitflag key="0x20" flagname="Profile Control KEY10" flagmask="0x0A" />
-                        <bitflag key="0x20" flagname="Profile Control KEY11" flagmask="0x0B" />
-                        <bitflag key="0x20" flagname="Profile Control KEY12" flagmask="0x0C" />
-                        <bitflag key="0x20" flagname="Profile Control KEY13" flagmask="0x0D" />
-                        <bitflag key="0x20" flagname="Profile Control KEY14" flagmask="0x0E" />
-                        <bitflag key="0x20" flagname="Profile Control KEY15" flagmask="0x0F" />
-                        <bitflag key="0x20" flagname="Profile Control KEY16" flagmask="0x10" />
-                        <bitflag key="0x20" flagname="Profile Control KEY17" flagmask="0x11" />
-                        <bitflag key="0x20" flagname="Profile Control KEY18" flagmask="0x12" />
-                        <bitflag key="0x20" flagname="Profile Control KEY19" flagmask="0x13" />
-                        <bitflag key="0x20" flagname="Profile Control KEY20" flagmask="0x14" />
-                        <bitflag key="0x20" flagname="Profile Control KEY21" flagmask="0x15" />
-                        <bitflag key="0x20" flagname="Profile Control KEY22" flagmask="0x16" />
-                        <bitflag key="0x20" flagname="Profile Control KEY23" flagmask="0x17" />
-                        <bitflag key="0x20" flagname="Profile Control KEY24" flagmask="0x18" />
-                        <bitflag key="0x20" flagname="Profile Control KEY25" flagmask="0x19" />
-                        <bitflag key="0x20" flagname="Profile Control KEY26" flagmask="0x1A" />
-                        <bitflag key="0x20" flagname="Profile Control KEY27" flagmask="0x1B" />
-                        <bitflag key="0x20" flagname="Profile Control KEY28" flagmask="0x1C" />
-                        <bitflag key="0x20" flagname="Profile Control KEY29" flagmask="0x1D" />
-                        <bitflag key="0x20" flagname="Profile Control KEY30" flagmask="0x1E" />
-                        <bitflag key="0x20" flagname="Profile Control KEY31" flagmask="0x1F" />
-                        <bitflag key="0x20" flagname="Profile Control KEY32" flagmask="0x20" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY01" flagmask="0x01" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY02" flagmask="0x02" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY03" flagmask="0x03" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY04" flagmask="0x04" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY05" flagmask="0x05" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY06" flagmask="0x06" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY07" flagmask="0x07" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY08" flagmask="0x08" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY09" flagmask="0x09" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY10" flagmask="0x0A" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY11" flagmask="0x0B" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY12" flagmask="0x0C" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY13" flagmask="0x0D" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY14" flagmask="0x0E" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY15" flagmask="0x0F" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY16" flagmask="0x10" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY17" flagmask="0x11" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY18" flagmask="0x12" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY19" flagmask="0x13" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY20" flagmask="0x14" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY21" flagmask="0x15" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY22" flagmask="0x16" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY23" flagmask="0x17" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY24" flagmask="0x18" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY25" flagmask="0x19" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY26" flagmask="0x1A" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY27" flagmask="0x1B" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY28" flagmask="0x1C" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY29" flagmask="0x1D" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY30" flagmask="0x1E" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY31" flagmask="0x1F" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY32" flagmask="0x20" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x31" flagname="Profile MULTILEVEL_SENSOR_TYPE_TEMPERATURE" flagmask="0x01" />
-                        <bitflag key="0x31" flagname="Profile MULTILEVEL_SENSOR_TYPE_HUMIDITY" flagmask="0x05" />
+                        <bitflag key="0x31" flagname="MULTILEVEL_SENSOR_TYPE_TEMPERATURE" flagmask="0x01" />
+                        <bitflag key="0x31" flagname="MULTILEVEL_SENSOR_TYPE_HUMIDITY" flagmask="0x05" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x71" flagname="Profile NOTIFICATION_TYPE_SMOKE" flagmask="0x01" />
-                        <bitflag key="0x71" flagname="Profile NOTIFICATION_TYPE_CO2" flagmask="0x03" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_SMOKE_ALARM" flagmask="0x01" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_C0_ALARM" flagmask="0x02" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_CO2_ALARM" flagmask="0x03" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HEAT_ALARM" flagmask="0x04" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WATER_ALARM" flagmask="0x05" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_ACCESS_CONTROL" flagmask="0x06" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HOME_SECURITY" flagmask="0x07" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_POWER_MANAGEMENT" flagmask="0x08" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_SYSTEM" flagmask="0x09" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_EMERGENCY_ALARM" flagmask="0x0A" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_CLOCK" flagmask="0x0B" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_APPLIANCE" flagmask="0x0C" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HOME_HEALTH" flagmask="0x0D" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_SIREN" flagmask="0x0E" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WATER_VALVE" flagmask="0x0F" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WEATHER_ALARM" flagmask="0x10" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_IRRIGATION" flagmask="0x11" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_GAS_ALARM" flagmask="0x12" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_PEST_CONTROL" flagmask="0x13" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_LIGHT_SENSOR" flagmask="0x14" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WATER_QUALITY_MONITORING" flagmask="0x15" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HOME_MONITORING" flagmask="0x16" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x32" flagname="Profile METER_TYPE_ELECTRIC" flagmask="0x01" />
-                        <bitflag key="0x32" flagname="Profile METER_TYPE_GAS" flagmask="0x02" />
-                        <bitflag key="0x32" flagname="Profile METER_TYPE_WATER" flagmask="0x03" />
+                        <bitflag key="0x32" flagname="METER_TYPE_ELECTRIC" flagmask="0x01" />
+                        <bitflag key="0x32" flagname="METER_TYPE_GAS" flagmask="0x02" />
+                        <bitflag key="0x32" flagname="METER_TYPE_WATER" flagmask="0x03" />
                     </multi_array>
                 </param>
                 <param key="0x04" name="Reserved" type="BYTE" />
@@ -14462,101 +15505,121 @@
                 <param key="0x00" name="Grouping Identifier" type="BYTE" />
                 <param key="0x01" name="Mode" type="BYTE" />
                 <param key="0x02" name="Profile1" type="CONST">
-                    <const key="0x00" flagname="Profile General" flagmask="0x00" />
-                    <const key="0x01" flagname="Profile Control" flagmask="0x20" />
-                    <const key="0x02" flagname="Profile Sensor" flagmask="0x31" />
-                    <const key="0x03" flagname="Profile Notification" flagmask="0x71" />
-                    <const key="0x04" flagname="Profile Meter" flagmask="0x32" />
-                    <const key="0x05" flagname="Profile Irrigation" flagmask="0x6B" />
+                    <const key="0x00" flagname="AGI_PROFILE_GENERAL" flagmask="0x00" />
+                    <const key="0x01" flagname="AGI_PROFILE_CONTROL" flagmask="0x20" />
+                    <const key="0x02" flagname="AGI_PROFILE_SENSOR" flagmask="0x31" />
+                    <const key="0x03" flagname="AGI_PROFILE_NOTIFICATION" flagmask="0x71" />
+                    <const key="0x04" flagname="AGI_PROFILE_METER" flagmask="0x32" />
+                    <const key="0x05" flagname="AGI_PROFILE_IRRIGATION" flagmask="0x6B" />
                 </param>
                 <param key="0x03" name="Profile2" type="MULTI_ARRAY">
                     <multi_array>
                         <paramdescloc key="0x00" param="2" paramdesc="255" paramstart="2" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x00" flagname="Profile General NA" flagmask="0x00" />
-                        <bitflag key="0x00" flagname="Profile General Lifeline" flagmask="0x01" />
+                        <bitflag key="0x00" flagname="AGI_GENERAL_NA" flagmask="0x00" />
+                        <bitflag key="0x00" flagname="AGI_GENERAL_LIFELINE" flagmask="0x01" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x20" flagname="Profile Control KEY01" flagmask="0x01" />
-                        <bitflag key="0x20" flagname="Profile Control KEY02" flagmask="0x02" />
-                        <bitflag key="0x20" flagname="Profile Control KEY03" flagmask="0x03" />
-                        <bitflag key="0x20" flagname="Profile Control KEY04" flagmask="0x04" />
-                        <bitflag key="0x20" flagname="Profile Control KEY05" flagmask="0x05" />
-                        <bitflag key="0x20" flagname="Profile Control KEY06" flagmask="0x06" />
-                        <bitflag key="0x20" flagname="Profile Control KEY07" flagmask="0x07" />
-                        <bitflag key="0x20" flagname="Profile Control KEY08" flagmask="0x08" />
-                        <bitflag key="0x20" flagname="Profile Control KEY09" flagmask="0x09" />
-                        <bitflag key="0x20" flagname="Profile Control KEY10" flagmask="0x0A" />
-                        <bitflag key="0x20" flagname="Profile Control KEY11" flagmask="0x0B" />
-                        <bitflag key="0x20" flagname="Profile Control KEY12" flagmask="0x0C" />
-                        <bitflag key="0x20" flagname="Profile Control KEY13" flagmask="0x0D" />
-                        <bitflag key="0x20" flagname="Profile Control KEY14" flagmask="0x0E" />
-                        <bitflag key="0x20" flagname="Profile Control KEY15" flagmask="0x0F" />
-                        <bitflag key="0x20" flagname="Profile Control KEY16" flagmask="0x10" />
-                        <bitflag key="0x20" flagname="Profile Control KEY17" flagmask="0x11" />
-                        <bitflag key="0x20" flagname="Profile Control KEY18" flagmask="0x12" />
-                        <bitflag key="0x20" flagname="Profile Control KEY19" flagmask="0x13" />
-                        <bitflag key="0x20" flagname="Profile Control KEY20" flagmask="0x14" />
-                        <bitflag key="0x20" flagname="Profile Control KEY21" flagmask="0x15" />
-                        <bitflag key="0x20" flagname="Profile Control KEY22" flagmask="0x16" />
-                        <bitflag key="0x20" flagname="Profile Control KEY23" flagmask="0x17" />
-                        <bitflag key="0x20" flagname="Profile Control KEY24" flagmask="0x18" />
-                        <bitflag key="0x20" flagname="Profile Control KEY25" flagmask="0x19" />
-                        <bitflag key="0x20" flagname="Profile Control KEY26" flagmask="0x1A" />
-                        <bitflag key="0x20" flagname="Profile Control KEY27" flagmask="0x1B" />
-                        <bitflag key="0x20" flagname="Profile Control KEY28" flagmask="0x1C" />
-                        <bitflag key="0x20" flagname="Profile Control KEY29" flagmask="0x1D" />
-                        <bitflag key="0x20" flagname="Profile Control KEY30" flagmask="0x1E" />
-                        <bitflag key="0x20" flagname="Profile Control KEY31" flagmask="0x1F" />
-                        <bitflag key="0x20" flagname="Profile Control KEY32" flagmask="0x20" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY01" flagmask="0x01" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY02" flagmask="0x02" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY03" flagmask="0x03" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY04" flagmask="0x04" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY05" flagmask="0x05" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY06" flagmask="0x06" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY07" flagmask="0x07" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY08" flagmask="0x08" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY09" flagmask="0x09" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY10" flagmask="0x0A" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY11" flagmask="0x0B" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY12" flagmask="0x0C" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY13" flagmask="0x0D" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY14" flagmask="0x0E" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY15" flagmask="0x0F" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY16" flagmask="0x10" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY17" flagmask="0x11" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY18" flagmask="0x12" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY19" flagmask="0x13" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY20" flagmask="0x14" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY21" flagmask="0x15" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY22" flagmask="0x16" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY23" flagmask="0x17" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY24" flagmask="0x18" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY25" flagmask="0x19" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY26" flagmask="0x1A" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY27" flagmask="0x1B" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY28" flagmask="0x1C" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY29" flagmask="0x1D" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY30" flagmask="0x1E" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY31" flagmask="0x1F" />
+                        <bitflag key="0x20" flagname="AGI_CONTROL_KEY32" flagmask="0x20" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x31" flagname="Profile MULTILEVEL_SENSOR_TYPE_TEMPERATURE" flagmask="0x01" />
-                        <bitflag key="0x31" flagname="Profile MULTILEVEL_SENSOR_TYPE_HUMIDITY" flagmask="0x05" />
+                        <bitflag key="0x31" flagname="MULTILEVEL_SENSOR_TYPE_TEMPERATURE" flagmask="0x01" />
+                        <bitflag key="0x31" flagname="MULTILEVEL_SENSOR_TYPE_HUMIDITY" flagmask="0x05" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x71" flagname="Profile NOTIFICATION_TYPE_SMOKE" flagmask="0x01" />
-                        <bitflag key="0x71" flagname="Profile NOTIFICATION_TYPE_CO2" flagmask="0x03" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_SMOKE_ALARM" flagmask="0x01" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_C0_ALARM" flagmask="0x02" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_CO2_ALARM" flagmask="0x03" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HEAT_ALARM" flagmask="0x04" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WATER_ALARM" flagmask="0x05" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_ACCESS_CONTROL" flagmask="0x06" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HOME_SECURITY" flagmask="0x07" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_POWER_MANAGEMENT" flagmask="0x08" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_SYSTEM" flagmask="0x09" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_EMERGENCY_ALARM" flagmask="0x0A" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_CLOCK" flagmask="0x0B" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_APPLIANCE" flagmask="0x0C" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HOME_HEALTH" flagmask="0x0D" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_SIREN" flagmask="0x0E" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WATER_VALVE" flagmask="0x0F" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WEATHER_ALARM" flagmask="0x10" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_IRRIGATION" flagmask="0x11" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_GAS_ALARM" flagmask="0x12" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_PEST_CONTROL" flagmask="0x13" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_LIGHT_SENSOR" flagmask="0x14" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_WATER_QUALITY_MONITORING" flagmask="0x15" />
+                        <bitflag key="0x71" flagname="NOTIFICATION_TYPE_HOME_MONITORING" flagmask="0x16" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x32" flagname="Profile METER_TYPE_ELECTRIC" flagmask="0x01" />
-                        <bitflag key="0x32" flagname="Profile METER_TYPE_GAS" flagmask="0x02" />
-                        <bitflag key="0x32" flagname="Profile METER_TYPE_WATER" flagmask="0x03" />
+                        <bitflag key="0x32" flagname="METER_TYPE_ELECTRIC" flagmask="0x01" />
+                        <bitflag key="0x32" flagname="METER_TYPE_GAS" flagmask="0x02" />
+                        <bitflag key="0x32" flagname="METER_TYPE_WATER" flagmask="0x03" />
                     </multi_array>
                     <multi_array>
-                        <bitflag key="0x6B" flagname="Irrigation Channel 01" flagmask="0x01" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 02" flagmask="0x02" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 03" flagmask="0x03" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 04" flagmask="0x04" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 05" flagmask="0x05" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 06" flagmask="0x06" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 07" flagmask="0x07" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 08" flagmask="0x08" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 09" flagmask="0x09" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 10" flagmask="0x0A" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 11" flagmask="0x0B" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 12" flagmask="0x0C" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 13" flagmask="0x0D" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 14" flagmask="0x0E" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 15" flagmask="0x0F" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 16" flagmask="0x10" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 17" flagmask="0x11" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 18" flagmask="0x12" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 19" flagmask="0x13" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 20" flagmask="0x14" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 21" flagmask="0x15" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 22" flagmask="0x16" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 23" flagmask="0x17" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 24" flagmask="0x18" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 25" flagmask="0x19" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 26" flagmask="0x1A" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 27" flagmask="0x1B" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 28" flagmask="0x1C" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 29" flagmask="0x1D" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 30" flagmask="0x1E" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 31" flagmask="0x1F" />
-                        <bitflag key="0x6B" flagname="Irrigation Channel 32" flagmask="0x20" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_01" flagmask="0x01" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_02" flagmask="0x02" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_03" flagmask="0x03" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_04" flagmask="0x04" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_05" flagmask="0x05" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_06" flagmask="0x06" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_07" flagmask="0x07" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_08" flagmask="0x08" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_09" flagmask="0x09" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_10" flagmask="0x0A" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_11" flagmask="0x0B" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_12" flagmask="0x0C" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_13" flagmask="0x0D" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_14" flagmask="0x0E" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_15" flagmask="0x0F" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_16" flagmask="0x10" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_17" flagmask="0x11" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_18" flagmask="0x12" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_19" flagmask="0x13" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_20" flagmask="0x14" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_21" flagmask="0x15" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_22" flagmask="0x16" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_23" flagmask="0x17" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_24" flagmask="0x18" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_25" flagmask="0x19" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_26" flagmask="0x1A" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_27" flagmask="0x1B" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_28" flagmask="0x1C" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_29" flagmask="0x1D" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_30" flagmask="0x1E" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_31" flagmask="0x1F" />
+                        <bitflag key="0x6B" flagname="AGI_IRRIGATION_CHANNEL_32" flagmask="0x20" />
                     </multi_array>
                 </param>
                 <param key="0x04" name="Reserved" type="BYTE" />
@@ -14813,10 +15876,10 @@
                 <const key="0x01" flagname="ROLE_TYPE_CONTROLLER_SUB_STATIC" flagmask="0x01" />
                 <const key="0x02" flagname="ROLE_TYPE_CONTROLLER_PORTABLE" flagmask="0x02" />
                 <const key="0x03" flagname="ROLE_TYPE_CONTROLLER_PORTABLE_REPORTING" flagmask="0x03" />
-                <const key="0x04" flagname="ROLE_TYPE_SLAVE_PORTABLE" flagmask="0x04" />
-                <const key="0x05" flagname="ROLE_TYPE_SLAVE_ALWAYS_ON" flagmask="0x05" />
-                <const key="0x06" flagname="ROLE_TYPE_SLAVE_SLEEPING_REPORTING" flagmask="0x06" />
-                <const key="0x07" flagname="ROLE_TYPE_SLAVE_SLEEPING_LISTENING" flagmask="0x07" />
+                <const key="0x04" flagname="ROLE_TYPE_END_NODE_PORTABLE" flagmask="0x04" />
+                <const key="0x05" flagname="ROLE_TYPE_END_NODE_ALWAYS_ON" flagmask="0x05" />
+                <const key="0x06" flagname="ROLE_TYPE_END_NODE_SLEEPING_REPORTING" flagmask="0x06" />
+                <const key="0x07" flagname="ROLE_TYPE_END_NODE_SLEEPING_LISTENING" flagmask="0x07" />
             </param>
             <param key="0x02" name="Node Type" type="CONST">
                 <const key="0x00" flagname="NODE_TYPE_ZWAVEPLUS_NODE" flagmask="0x00" />
@@ -14836,10 +15899,10 @@
                 <const key="0x01" flagname="ROLE_TYPE_CONTROLLER_SUB_STATIC" flagmask="0x01" />
                 <const key="0x02" flagname="ROLE_TYPE_CONTROLLER_PORTABLE" flagmask="0x02" />
                 <const key="0x03" flagname="ROLE_TYPE_CONTROLLER_PORTABLE_REPORTING" flagmask="0x03" />
-                <const key="0x04" flagname="ROLE_TYPE_SLAVE_PORTABLE" flagmask="0x04" />
-                <const key="0x05" flagname="ROLE_TYPE_SLAVE_ALWAYS_ON" flagmask="0x05" />
-                <const key="0x06" flagname="ROLE_TYPE_SLAVE_SLEEPING_REPORTING" flagmask="0x06" />
-                <const key="0x07" flagname="ROLE_TYPE_SLAVE_SLEEPING_LISTENING" flagmask="0x07" />
+                <const key="0x04" flagname="ROLE_TYPE_END_NODE_PORTABLE" flagmask="0x04" />
+                <const key="0x05" flagname="ROLE_TYPE_END_NODE_ALWAYS_ON" flagmask="0x05" />
+                <const key="0x06" flagname="ROLE_TYPE_END_NODE_SLEEPING_REPORTING" flagmask="0x06" />
+                <const key="0x07" flagname="ROLE_TYPE_END_NODE_SLEEPING_LISTENING" flagmask="0x07" />
             </param>
             <param key="0x02" name="Node Type" type="CONST">
                 <const key="0x00" flagname="NODE_TYPE_ZWAVEPLUS_NODE" flagmask="0x00" />
@@ -14978,6 +16041,7 @@
                 <arrayattrib key="0x00" len="16" />
             </param>
         </cmd>
+        <cmd key="0x05" name="GATEWAY_UNREGISTER" help="Gateway Unregister" support_mode="RX" />
     </cmd_class>
     <cmd_class key="0x65" version="1" name="COMMAND_CLASS_DMX" help="Command Class DMX">
         <cmd key="0x01" name="DMX_ADDRESS_SET" help="DMX Address Set">
@@ -15041,7 +16105,7 @@
                 <bitflag key="0x01" flagname="Visual Notification" flagmask="0x02" />
             </param>
         </cmd>
-        <cmd key="0x06" name="BARRIER_OPERATOR_SIGNAL_SET" help="Barrier Operator Signal Set" support_mode="RX">
+        <cmd key="0x06" name="BARRIER_OPERATOR_EVENT_SIGNAL_SET" help="Barrier Operator Event Signal Set" support_mode="RX">
             <param key="0x00" name="Subsystem Type" type="BYTE">
                 <bitflag key="0x01" flagname="NOT SUPPORTED" flagmask="0x00" />
                 <bitflag key="0x02" flagname="Audible Notification" flagmask="0x01" />
@@ -15052,14 +16116,14 @@
                 <const key="0x01" flagname="ON" flagmask="0xFF" />
             </param>
         </cmd>
-        <cmd key="0x07" name="BARRIER_OPERATOR_SIGNAL_GET" help="Barrier Operator Signal Get" support_mode="RX">
+        <cmd key="0x07" name="BARRIER_OPERATOR_EVENT_SIGNALING_GET" help="Barrier Operator Event Signaling Get" support_mode="RX">
             <param key="0x00" name="Subsystem Type" type="BYTE">
                 <bitflag key="0x01" flagname="NOT SUPPORTED" flagmask="0x00" />
                 <bitflag key="0x02" flagname="Audible Notification" flagmask="0x01" />
                 <bitflag key="0x03" flagname="Visual Notification" flagmask="0x02" />
             </param>
         </cmd>
-        <cmd key="0x08" name="BARRIER_OPERATOR_SIGNAL_REPORT" help="Barrier Operator Signal Report" support_mode="TX">
+        <cmd key="0x08" name="BARRIER_OPERATOR_EVENT_SIGNALING_REPORT" help="Barrier Operator Event Signaling Report" support_mode="TX">
             <param key="0x00" name="Subsystem Type" type="BYTE">
                 <bitflag key="0x01" flagname="NOT SUPPORTED" flagmask="0x00" />
                 <bitflag key="0x02" flagname="Audible Notification" flagmask="0x01" />
@@ -15422,7 +16486,7 @@
         <cmd key="0x04" name="MAILBOX_QUEUE" help="Mailbox Queue" support_mode="TX_RX">
             <param key="0x00" name="Sequence Number" type="BYTE" />
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
-                <fieldenum key="0x00" fieldname="Mode" fieldmask="0x03">
+                <fieldenum key="0x00" fieldname="Operation" fieldmask="0x07">
                     <fieldenum value="Push" />
                     <fieldenum value="Pop" />
                     <fieldenum value="Waiting" />
@@ -15431,8 +16495,8 @@
                     <fieldenum value="NACK" />
                     <fieldenum value="Queue Full" />
                 </fieldenum>
-                <bitflag key="0x01" flagname="Last" flagmask="0x04" />
-                <bitfield key="0x02" fieldname="Reserved" fieldmask="0xF8" shifter="3" />
+                <bitflag key="0x01" flagname="Last" flagmask="0x08" />
+                <bitfield key="0x02" fieldname="Reserved" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Queue Handle" type="BYTE" />
             <param key="0x03" name="Mailbox Entry" type="VARIANT">
@@ -15484,7 +16548,7 @@
         <cmd key="0x04" name="MAILBOX_QUEUE" help="Mailbox Queue" support_mode="TX_RX">
             <param key="0x00" name="Sequence Number" type="BYTE" />
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
-                <fieldenum key="0x00" fieldname="Mode" fieldmask="0x03">
+                <fieldenum key="0x00" fieldname="Operation" fieldmask="0x07">
                     <fieldenum value="Push" />
                     <fieldenum value="Pop" />
                     <fieldenum value="Waiting" />
@@ -15493,8 +16557,8 @@
                     <fieldenum value="NACK" />
                     <fieldenum value="Queue Full" />
                 </fieldenum>
-                <bitflag key="0x01" flagname="Last" flagmask="0x04" />
-                <bitfield key="0x02" fieldname="Reserved" fieldmask="0xF8" shifter="3" />
+                <bitflag key="0x01" flagname="Last" flagmask="0x08" />
+                <bitfield key="0x02" fieldname="Reserved" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x02" name="Queue Handle" type="BYTE" />
             <param key="0x03" name="Mailbox Entry" type="VARIANT">
@@ -15688,7 +16752,7 @@
                 <bitflag key="0x01" flagname="MOS" flagmask="0x02" />
                 <bitfield key="0x02" fieldname="Reserved" fieldmask="0xFC" shifter="2" />
             </param>
-            <param key="0x02" name="Receivers Entropy Input" type="ARRAY">
+            <param key="0x02" name="Receivers Entropy Input" type="ARRAY" optionaloffs="0x01" optionalmask="0x01">
                 <arrayattrib key="0x00" len="16" />
             </param>
         </cmd>
@@ -15819,11 +16883,178 @@
             </param>
         </cmd>
     </cmd_class>
+    <cmd_class key="0x9F" version="2" name="COMMAND_CLASS_SECURITY_2" help="Command Class Security 2">
+        <cmd key="0x01" name="SECURITY_2_NONCE_GET" help="S2 Nonce Get" support_mode="RX">
+            <param key="0x00" name="Sequence Number" type="BYTE" />
+        </cmd>
+        <cmd key="0x02" name="SECURITY_2_NONCE_REPORT" help="S2 Nonce Report" support_mode="TX">
+            <param key="0x00" name="Sequence Number" type="BYTE" />
+            <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="SOS" flagmask="0x01" />
+                <bitflag key="0x01" flagname="MOS" flagmask="0x02" />
+                <bitfield key="0x02" fieldname="Reserved" fieldmask="0xFC" shifter="2" />
+            </param>
+            <param key="0x02" name="Receivers Entropy Input" type="ARRAY" optionaloffs="0x01" optionalmask="0x01">
+                <arrayattrib key="0x00" len="16" />
+            </param>
+        </cmd>
+        <cmd key="0x03" name="SECURITY_2_MESSAGE_ENCAPSULATION" help="S2 Message Encapsulation" support_mode="TX_RX">
+            <param key="0x00" name="Sequence Number" type="BYTE" />
+            <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Extension" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Encrypted Extension" flagmask="0x02" />
+                <bitfield key="0x02" fieldname="Reserved" fieldmask="0xFC" shifter="2" />
+            </param>
+            <variant_group key="0x02" name="vg1" paramOffs="0xFF" sizemask="0x00" sizeoffs="0x00" optionaloffs="0x01" optionalmask="0x01" moretofollowoffs="0x01" moretofollowmask="0x80">
+                <param key="0x00" name="Extension Length" type="BYTE" />
+                <param key="0x01" name="Properties1" type="STRUCT_BYTE">
+                    <bitfield key="0x00" fieldname="Type" fieldmask="0x3F" />
+                    <bitflag key="0x01" flagname="Critical" flagmask="0x40" />
+                    <bitflag key="0x02" flagname="More to follow" flagmask="0x80" />
+                </param>
+                <param key="0x02" name="Extension" type="VARIANT">
+                    <variant paramoffs="0" sizemask="0xFF" sizechange="-2" />
+                </param>
+            </variant_group>
+            <param key="0x03" name="CCM Ciphertext Object" type="VARIANT">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x04" name="KEX_GET" help="KEX Get" support_mode="RX" />
+        <cmd key="0x05" name="KEX_REPORT" help="KEX Report" support_mode="TX">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Echo" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Request CSA" flagmask="0x02" />
+                <bitflag key="0x02" flagname="NLS support" flagmask="0x04" />
+                <bitfield key="0x03" fieldname="Reserved" fieldmask="0xF8" shifter="3" />
+            </param>
+            <param key="0x01" name="Supported KEX Schemes" type="BYTE" />
+            <param key="0x02" name="Supported ECDH Profiles" type="BYTE" />
+            <param key="0x03" name="Requested Keys" type="BITMASK">
+                <bitmask key="0x00" paramoffs="255" lenmask="0x00" len="1" />
+                <bitflag key="0x00" flagname="Unauthenticated" flagmask="0x00" />
+                <bitflag key="0x01" flagname="Authenticated" flagmask="0x01" />
+                <bitflag key="0x02" flagname="Access" flagmask="0x02" />
+                <bitflag key="0x03" flagname="Reserved3" flagmask="0x03" />
+                <bitflag key="0x04" flagname="Reserved4" flagmask="0x04" />
+                <bitflag key="0x05" flagname="Reserved5" flagmask="0x05" />
+                <bitflag key="0x06" flagname="Reserved6" flagmask="0x06" />
+                <bitflag key="0x07" flagname="S0" flagmask="0x07" />
+            </param>
+        </cmd>
+        <cmd key="0x06" name="KEX_SET" help="KEX Set" support_mode="RX">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Echo" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Request CSA" flagmask="0x02" />
+                <bitfield key="0x02" fieldname="Reserved" fieldmask="0xFC" shifter="2" />
+            </param>
+            <param key="0x01" name="Selected KEX Scheme" type="BYTE" />
+            <param key="0x02" name="Selected ECDH Profile" type="BYTE" />
+            <param key="0x03" name="Granted Keys" type="BITMASK">
+                <bitmask key="0x00" paramoffs="255" lenmask="0x00" len="1" />
+                <bitflag key="0x00" flagname="Unauthenticated" flagmask="0x00" />
+                <bitflag key="0x01" flagname="Authenticated" flagmask="0x01" />
+                <bitflag key="0x02" flagname="Access" flagmask="0x02" />
+                <bitflag key="0x03" flagname="Reserved3" flagmask="0x03" />
+                <bitflag key="0x04" flagname="Reserved4" flagmask="0x04" />
+                <bitflag key="0x05" flagname="Reserved5" flagmask="0x05" />
+                <bitflag key="0x06" flagname="Reserved6" flagmask="0x06" />
+                <bitflag key="0x07" flagname="S0" flagmask="0x07" />
+            </param>
+        </cmd>
+        <cmd key="0x07" name="KEX_FAIL" help="KEX Fail" support_mode="TX_RX">
+            <param key="0x00" name="KEX Fail Type" type="CONST">
+                <const key="0x00" flagname="KEX_KEY" flagmask="0x01" />
+                <const key="0x01" flagname="KEX_SCHEME" flagmask="0x02" />
+                <const key="0x02" flagname="KEX_CURVES" flagmask="0x03" />
+                <const key="0x03" flagname="DECRYPT" flagmask="0x05" />
+                <const key="0x04" flagname="CANCEL" flagmask="0x06" />
+                <const key="0x05" flagname="AUTH" flagmask="0x07" />
+                <const key="0x06" flagname="KEY_GET" flagmask="0x08" />
+                <const key="0x07" flagname="KEY_VERIFY" flagmask="0x09" />
+                <const key="0x08" flagname="KEY_REPORT" flagmask="0x0A" />
+            </param>
+        </cmd>
+        <cmd key="0x08" name="PUBLIC_KEY_REPORT" help="Public Key Report" support_mode="TX_RX">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Including Node" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
+            </param>
+            <param key="0x01" name="ECDH Public Key" type="VARIANT">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x09" name="SECURITY_2_NETWORK_KEY_GET" help="S2 Network Key Get" support_mode="TX">
+            <param key="0x00" name="Requested Key" type="BYTE">
+                <bitflag key="0x01" flagname="Unauthenticated" flagmask="0x00" />
+                <bitflag key="0x02" flagname="Authenticated" flagmask="0x01" />
+                <bitflag key="0x03" flagname="Access" flagmask="0x02" />
+                <bitflag key="0x04" flagname="Reserved3" flagmask="0x03" />
+                <bitflag key="0x05" flagname="Reserved4" flagmask="0x04" />
+                <bitflag key="0x06" flagname="Reserved5" flagmask="0x05" />
+                <bitflag key="0x07" flagname="Reserved6" flagmask="0x06" />
+                <bitflag key="0x08" flagname="S0" flagmask="0x07" />
+            </param>
+        </cmd>
+        <cmd key="0x0A" name="SECURITY_2_NETWORK_KEY_REPORT" help="S2 Network Key Report" support_mode="RX">
+            <param key="0x00" name="Granted Key" type="BYTE">
+                <bitflag key="0x01" flagname="Unauthenticated" flagmask="0x00" />
+                <bitflag key="0x02" flagname="Authenticated" flagmask="0x01" />
+                <bitflag key="0x03" flagname="Access" flagmask="0x02" />
+                <bitflag key="0x04" flagname="Reserved3" flagmask="0x03" />
+                <bitflag key="0x05" flagname="Reserved4" flagmask="0x04" />
+                <bitflag key="0x06" flagname="Reserved5" flagmask="0x05" />
+                <bitflag key="0x07" flagname="Reserved6" flagmask="0x06" />
+                <bitflag key="0x08" flagname="S0" flagmask="0x07" />
+            </param>
+            <param key="0x01" name="Network Key" type="ARRAY">
+                <arrayattrib key="0x00" len="16" />
+            </param>
+        </cmd>
+        <cmd key="0x0B" name="SECURITY_2_NETWORK_KEY_VERIFY" help="S2 Network Key Verify" support_mode="TX" />
+        <cmd key="0x0C" name="SECURITY_2_TRANSFER_END" help="S2 Transfer End" support_mode="TX_RX">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Key Request Complete" flagmask="0x01" />
+                <bitflag key="0x01" flagname="Key Verified" flagmask="0x02" />
+                <bitfield key="0x02" fieldname="Reserved" fieldmask="0xFC" shifter="2" />
+            </param>
+        </cmd>
+        <cmd key="0x0D" name="SECURITY_2_COMMANDS_SUPPORTED_GET" help="S2 Commands Supported Get" support_mode="RX" />
+        <cmd key="0x0E" name="SECURITY_2_COMMANDS_SUPPORTED_REPORT" help="S2 Commands Supported Report" support_mode="TX">
+            <param key="0x00" name="Command Class" type="VARIANT" encaptype="CMD_CLASS_REF">
+                <variant paramoffs="255" sizemask="0x00" />
+            </param>
+        </cmd>
+        <cmd key="0x0F" name="NLS_NODE_LIST_GET" help="NLS Node List Get" support_mode="RX">
+            <param key="0x00" name="Request" type="BYTE" />
+        </cmd>
+        <cmd key="0x10" name="NLS_NODE_LIST_REPORT" help="NLS Node List Report" support_mode="TX">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Last node" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
+            </param>
+            <param key="0x01" name="ID (MSB) of node N" type="BYTE" />
+            <param key="0x02" name="ID (LSB) of node N" type="BYTE" />
+            <param key="0x03" name="Granted keys bitmask of node N" type="BYTE" />
+            <param key="0x04" name="NLS state of node N" type="BYTE" />
+        </cmd>
+        <cmd key="0x11" name="NLS_STATE_GET" help="NLS State Get" support_mode="RX" />
+        <cmd key="0x12" name="NLS_STATE_REPORT" help="NLS State Report" support_mode="TX">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="Capability" flagmask="0x01" />
+                <bitflag key="0x01" flagname="NLS State" flagmask="0x02" />
+                <bitfield key="0x02" fieldname="Reserved" fieldmask="0xFC" shifter="2" />
+            </param>
+        </cmd>
+        <cmd key="0x13" name="NLS_STATE_SET" help="NLS State Set" support_mode="RX">
+            <param key="0x00" name="NLS state" type="BYTE" />
+        </cmd>
+    </cmd_class>
     <cmd_class key="0x6B" version="1" name="COMMAND_CLASS_IRRIGATION" help="Command Class Irrigation">
         <cmd key="0x01" name="IRRIGATION_SYSTEM_INFO_GET" help="Irrigation System Info Get" support_mode="RX" />
         <cmd key="0x02" name="IRRIGATION_SYSTEM_INFO_REPORT" help="Irrigation System Info Report" support_mode="TX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
-                <bitflag key="0x00" flagname="Master Valve" flagmask="0x01" />
+                <bitflag key="0x00" flagname="Main Valve" flagmask="0x01" />
                 <bitfield key="0x01" fieldname="Reserved1" fieldmask="0x06" shifter="1" />
                 <bitfield key="0x02" fieldname="Reserved2" fieldmask="0x18" shifter="3" />
                 <bitfield key="0x03" fieldname="Reserved3" fieldmask="0xE0" shifter="5" />
@@ -15870,13 +17101,13 @@
                 <bitflag key="0x04" flagname="valve errors" flagmask="0x04" />
             </param>
             <param key="0x08" name="Properties3" type="STRUCT_BYTE">
-                <bitflag key="0x00" flagname="Master Valve" flagmask="0x01" />
+                <bitflag key="0x00" flagname="Main Valve" flagmask="0x01" />
                 <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
             </param>
             <param key="0x09" name="Valve ID" type="BYTE" />
         </cmd>
         <cmd key="0x05" name="IRRIGATION_SYSTEM_CONFIG_SET" help="Irrigation System Config Set" support_mode="RX">
-            <param key="0x00" name="Master Valve Delay" type="BYTE" />
+            <param key="0x00" name="Main Valve Delay" type="BYTE" />
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
                 <bitfield key="0x00" fieldname="High Pressure Threshold Size" fieldmask="0x07" />
                 <bitfield key="0x01" fieldname="High Pressure Threshold Scale" fieldmask="0x18" shifter="3" />
@@ -15902,7 +17133,7 @@
         </cmd>
         <cmd key="0x06" name="IRRIGATION_SYSTEM_CONFIG_GET" help="Irrigation System Config Get" support_mode="RX" />
         <cmd key="0x07" name="IRRIGATION_SYSTEM_CONFIG_REPORT" help="Irrigation System Config Report" support_mode="TX">
-            <param key="0x00" name="Master Valve Delay" type="BYTE" />
+            <param key="0x00" name="Main Valve Delay" type="BYTE" />
             <param key="0x01" name="Properties1" type="STRUCT_BYTE">
                 <bitfield key="0x00" fieldname="High Pressure Threshold Size" fieldmask="0x07" />
                 <bitfield key="0x01" fieldname="High Pressure Threshold Scale" fieldmask="0x18" shifter="3" />
@@ -15928,14 +17159,14 @@
         </cmd>
         <cmd key="0x08" name="IRRIGATION_VALVE_INFO_GET" help="Irrigation Valve Info Get" support_mode="RX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
-                <bitflag key="0x00" flagname="Master Valve" flagmask="0x01" />
+                <bitflag key="0x00" flagname="Main Valve" flagmask="0x01" />
                 <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
             </param>
             <param key="0x01" name="Valve ID" type="BYTE" />
         </cmd>
         <cmd key="0x09" name="IRRIGATION_VALVE_INFO_REPORT" help="Irrigation Valve Info Report" support_mode="TX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
-                <bitflag key="0x00" flagname="Master" flagmask="0x01" />
+                <bitflag key="0x00" flagname="Main" flagmask="0x01" />
                 <bitflag key="0x01" flagname="Connected" flagmask="0x02" />
                 <bitfield key="0x02" fieldname="Reserved" fieldmask="0xFC" shifter="2" />
             </param>
@@ -15953,7 +17184,7 @@
         </cmd>
         <cmd key="0x0A" name="IRRIGATION_VALVE_CONFIG_SET" help="Irrigation Valve Config Set" support_mode="RX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
-                <bitflag key="0x00" flagname="Master Valve" flagmask="0x01" />
+                <bitflag key="0x00" flagname="Main Valve" flagmask="0x01" />
                 <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
             </param>
             <param key="0x01" name="Valve ID" type="BYTE" />
@@ -15991,14 +17222,14 @@
         </cmd>
         <cmd key="0x0B" name="IRRIGATION_VALVE_CONFIG_GET" help="Irrigation Valve Config Get" support_mode="RX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
-                <bitflag key="0x00" flagname="Master Valve" flagmask="0x01" />
+                <bitflag key="0x00" flagname="Main Valve" flagmask="0x01" />
                 <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
             </param>
             <param key="0x01" name="Valve ID" type="BYTE" />
         </cmd>
         <cmd key="0x0C" name="IRRIGATION_VALVE_CONFIG_REPORT" help="Irrigation Valve Config Report" support_mode="TX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
-                <bitflag key="0x00" flagname="Master Valve" flagmask="0x01" />
+                <bitflag key="0x00" flagname="Main Valve" flagmask="0x01" />
                 <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
             </param>
             <param key="0x01" name="Valve ID" type="BYTE" />
@@ -16036,7 +17267,7 @@
         </cmd>
         <cmd key="0x0D" name="IRRIGATION_VALVE_RUN" help="Irrigation Valve Run" support_mode="RX">
             <param key="0x00" name="Properties1" type="STRUCT_BYTE">
-                <bitflag key="0x00" flagname="Master Valve" flagmask="0x01" />
+                <bitflag key="0x00" flagname="Main Valve" flagmask="0x01" />
                 <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
             </param>
             <param key="0x01" name="Valve ID" type="BYTE" />
@@ -17325,6 +18556,449 @@
                 <bitfield key="0x01" fieldname="Reserved" fieldmask="0xF0" shifter="4" />
             </param>
             <param key="0x01" name="Magic Code" type="VARIANT">
+                <variant paramoffs="0" sizemask="0x0F" />
+            </param>
+        </cmd>
+    </cmd_class>
+    <cmd_class key="0x83" version="1" name="COMMAND_CLASS_USER_CREDENTIAL" help="Command Class User Credential">
+        <cmd key="0x01" name="USER_CAPABILITIES_GET" help="User Capabilities Get" support_mode="RX" />
+        <cmd key="0x02" name="USER_CAPABILITIES_REPORT" help="User Capabilities Report" support_mode="TX">
+            <param key="0x00" name="Number of supported User Unique Identifiers" type="WORD" />
+            <param key="0x01" name="Supported Credential Rules Bit Mask" type="BITMASK">
+                <bitmask key="0x00" paramoffs="255" lenmask="0x00" len="1" />
+                <bitflag key="0x00" flagname="Reserved" flagmask="0x00" />
+                <bitflag key="0x01" flagname="Single" flagmask="0x01" />
+                <bitflag key="0x02" flagname="Dual" flagmask="0x02" />
+                <bitflag key="0x03" flagname="Triple" flagmask="0x03" />
+            </param>
+            <param key="0x02" name="Max Length of User Name" type="BYTE" />
+            <param key="0x03" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Reserved" fieldmask="0x1F" />
+                <bitflag key="0x01" flagname="User Checksum Support" flagmask="0x20" />
+                <bitflag key="0x02" flagname="All Users Checksum Support" flagmask="0x40" />
+                <bitflag key="0x03" flagname="User Schedule Support" flagmask="0x80" />
+            </param>
+            <param key="0x04" name="Supported User Types Bit Mask Length" type="BYTE" />
+            <variant_group key="0x05" name="vg1" paramOffs="0x04" sizemask="0xFF" sizeoffs="0x00">
+                <param key="0x00" name="Supported User Types Bit Mask" type="BITMASK">
+                    <bitmask key="0x00" paramoffs="255" lenmask="0x00" len="1" />
+                    <bitflag key="0x00" flagname="General User" flagmask="0x00" />
+                    <bitflag key="0x01" flagname="Reserved" flagmask="0x01" />
+                    <bitflag key="0x02" flagname="Reserved2" flagmask="0x02" />
+                    <bitflag key="0x03" flagname="Programming User" flagmask="0x03" />
+                    <bitflag key="0x04" flagname="Non-Access User" flagmask="0x04" />
+                    <bitflag key="0x05" flagname="Duress User" flagmask="0x05" />
+                    <bitflag key="0x06" flagname="Disposable User" flagmask="0x06" />
+                    <bitflag key="0x07" flagname="Expiring User" flagmask="0x07" />
+                    <bitflag key="0x08" flagname="Reserved3" flagmask="0x08" />
+                    <bitflag key="0x09" flagname="Remote Only User" flagmask="0x09" />
+                </param>
+            </variant_group>
+        </cmd>
+        <cmd key="0x03" name="CREDENTIAL_CAPABILITIES_GET" help="Credential Capabilities Get" support_mode="RX" />
+        <cmd key="0x04" name="CREDENTIAL_CAPABILITIES_REPORT" help="Credential Capabilities Report" support_mode="TX">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Reserved" fieldmask="0x1F" />
+                <bitflag key="0x01" flagname="Credential Checksum Support" flagmask="0x80" />
+                <bitflag key="0x02" flagname="Admin Code Support" flagmask="0x40" />
+                <bitflag key="0x03" flagname="Admin Code Deactivation Support" flagmask="0x20" />
+            </param>
+            <param key="0x01" name="Number of Supported Credential Types" type="BYTE" />
+            <variant_group key="0x02" name="vg1 Credential Type" paramOffs="0x01" sizemask="0xFF" sizeoffs="0x00">
+                <param key="0x00" name="Credential Type" type="BYTE" />
+            </variant_group>
+            <variant_group key="0x03" name="vg2 Properties2 per Credential Type" paramOffs="0x01" sizemask="0xFF" sizeoffs="0x00">
+                <param key="0x00" name="Properties2" type="STRUCT_BYTE">
+                    <bitfield key="0x00" fieldname="Reserved2" fieldmask="0x7F" />
+                    <bitflag key="0x01" flagname="CL Support" flagmask="0x80" />
+                </param>
+            </variant_group>
+            <variant_group key="0x04" name="vg3 Number of Supported Credential Slots per Credential Type" paramOffs="0x01" sizemask="0xFF" sizeoffs="0x00">
+                <param key="0x00" name="Number of Supported Credential Slots" type="WORD" />
+            </variant_group>
+            <variant_group key="0x05" name="vg4 Min Length of Credential Data per Credential Type" paramOffs="0x01" sizemask="0xFF" sizeoffs="0x00">
+                <param key="0x00" name="Min Length of Credential Data" type="BYTE" />
+            </variant_group>
+            <variant_group key="0x06" name="vg5 Max Length of Credential Data per Credential Type" paramOffs="0x01" sizemask="0xFF" sizeoffs="0x00">
+                <param key="0x00" name="Max Length of Credential Data" type="BYTE" />
+            </variant_group>
+            <variant_group key="0x07" name="vg6 CL Recommended Timeout per Credential Type" paramOffs="0x01" sizemask="0xFF" sizeoffs="0x00">
+                <param key="0x00" name="CL Recommended Timeout" type="BYTE" />
+            </variant_group>
+            <variant_group key="0x08" name="vg7 CL Number of Steps per Credential Type" paramOffs="0x01" sizemask="0xFF" sizeoffs="0x00">
+                <param key="0x00" name="CL Number of Steps" type="BYTE" />
+            </variant_group>
+            <variant_group key="0x09" name="vg8 Maximum Credential Hash Length per Credential Type" paramOffs="0x01" sizemask="0xFF" sizeoffs="0x00">
+                <param key="0x00" name="Maximum Credential Hash Length" type="BYTE" />
+            </variant_group>
+        </cmd>
+        <cmd key="0x05" name="USER_SET" help="User Set" support_mode="RX">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="Operation Type" fieldmask="0x03">
+                    <fieldenum value="Add" />
+                    <fieldenum value="Modify" />
+                    <fieldenum value="Delete" />
+                </fieldenum>
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFC" shifter="2" />
+            </param>
+            <param key="0x01" name="User Unique Identifier" type="WORD" />
+            <param key="0x02" name="User Type" type="CONST">
+                <const key="0x00" flagname="General User" flagmask="0x00" />
+                <const key="0x01" flagname="Programming User" flagmask="0x03" />
+                <const key="0x02" flagname="Non-Access User" flagmask="0x04" />
+                <const key="0x03" flagname="Duress User" flagmask="0x05" />
+                <const key="0x04" flagname="Disposable User" flagmask="0x06" />
+                <const key="0x05" flagname="Expiring User" flagmask="0x07" />
+                <const key="0x06" flagname="Remote Only User" flagmask="0x09" />
+            </param>
+            <param key="0x03" name="Properties2" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="User Active State" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Reserved2" fieldmask="0xFE" shifter="1" />
+            </param>
+            <param key="0x04" name="Credential Rule" type="BYTE">
+                <bitflag key="0x01" flagname="Single" flagmask="0x01" />
+                <bitflag key="0x02" flagname="Dual" flagmask="0x02" />
+                <bitflag key="0x03" flagname="Triple" flagmask="0x03" />
+            </param>
+            <param key="0x05" name="Expiring Timeout Minutes" type="WORD" />
+            <param key="0x06" name="Properties3" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="User Name Encoding" fieldmask="0x07">
+                    <fieldenum value="Using standard ASCII codes" />
+                    <fieldenum value="Using standard and OEM Extended ASCII codes" />
+                    <fieldenum value="Unicode UTF-16" />
+                </fieldenum>
+                <bitfield key="0x01" fieldname="Reserved3" fieldmask="0xF8" shifter="3" />
+            </param>
+            <param key="0x07" name="User Name Length" type="BYTE" />
+            <param key="0x08" name="User Name" type="VARIANT">
+                <variant paramoffs="7" sizemask="0xFF" />
+            </param>
+        </cmd>
+        <cmd key="0x06" name="USER_GET" help="User Get" support_mode="RX">
+            <param key="0x00" name="User Unique Identifier" type="WORD" />
+        </cmd>
+        <cmd key="0x07" name="USER_REPORT" help="User Report" support_mode="TX">
+            <param key="0x00" name="User Report Type" type="CONST">
+                <const key="0x00" flagname="Added" flagmask="0x00" />
+                <const key="0x01" flagname="Modified" flagmask="0x01" />
+                <const key="0x02" flagname="Deleted" flagmask="0x02" />
+                <const key="0x03" flagname="Unchanged" flagmask="0x03" />
+                <const key="0x04" flagname="Response to Get" flagmask="0x04" />
+                <const key="0x05" flagname="Add Against Occupied" flagmask="0x05" />
+                <const key="0x06" flagname="Modify Against Empty" flagmask="0x06" />
+                <const key="0x07" flagname="Non-Zero Expiring Minutes Invalid" flagmask="0x07" />
+            </param>
+            <param key="0x01" name="Next User Unique Identifier" type="WORD" />
+            <param key="0x02" name="User Modifier Type" type="CONST">
+                <const key="0x00" flagname="DNE" flagmask="0x00" />
+                <const key="0x01" flagname="Unknown" flagmask="0x01" />
+                <const key="0x02" flagname="Z-Wave" flagmask="0x02" />
+                <const key="0x03" flagname="Locally" flagmask="0x03" />
+                <const key="0x04" flagname="Mobile App or other IoT technology" flagmask="0x04" />
+            </param>
+            <param key="0x03" name="User Modifier Node ID" type="WORD" />
+            <param key="0x04" name="User Unique Identifier" type="WORD" />
+            <param key="0x05" name="User Type" type="CONST">
+                <const key="0x00" flagname="General User" flagmask="0x00" />
+                <const key="0x01" flagname="Programming User" flagmask="0x03" />
+                <const key="0x02" flagname="Non-Access User" flagmask="0x04" />
+                <const key="0x03" flagname="Duress User" flagmask="0x05" />
+                <const key="0x04" flagname="Disposable User" flagmask="0x06" />
+                <const key="0x05" flagname="Expiring User" flagmask="0x07" />
+                <const key="0x06" flagname="Remote Only User" flagmask="0x09" />
+            </param>
+            <param key="0x06" name="Properties1" type="STRUCT_BYTE">
+                <bitflag key="0x00" flagname="User Active State" flagmask="0x01" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFE" shifter="1" />
+            </param>
+            <param key="0x07" name="Credential Rule" type="BYTE">
+                <bitflag key="0x01" flagname="Single" flagmask="0x01" />
+                <bitflag key="0x02" flagname="Dual" flagmask="0x02" />
+                <bitflag key="0x03" flagname="Triple" flagmask="0x03" />
+            </param>
+            <param key="0x08" name="Expiring Timeout Minutes" type="WORD" />
+            <param key="0x09" name="Properties2" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="User Name Encoding" fieldmask="0x07">
+                    <fieldenum value="Using standard ASCII codes" />
+                    <fieldenum value="Using standard and OEM Extended ASCII codes" />
+                    <fieldenum value="Unicode UTF-16" />
+                </fieldenum>
+                <bitfield key="0x01" fieldname="Reserved2" fieldmask="0xF8" shifter="3" />
+            </param>
+            <param key="0x0A" name="User Name Length" type="BYTE" />
+            <param key="0x0B" name="User Name" type="VARIANT">
+                <variant paramoffs="10" sizemask="0xFF" />
+            </param>
+        </cmd>
+        <cmd key="0x0A" name="CREDENTIAL_SET" help="Credential Set" support_mode="RX">
+            <param key="0x00" name="User Unique Identifier" type="WORD" />
+            <param key="0x01" name="Credential Type" type="CONST">
+                <const key="0x00" flagname="PIN Code" flagmask="0x01" />
+                <const key="0x01" flagname="Password" flagmask="0x02" />
+                <const key="0x02" flagname="RFID Code" flagmask="0x03" />
+                <const key="0x03" flagname="BLE" flagmask="0x04" />
+                <const key="0x04" flagname="NFC" flagmask="0x05" />
+                <const key="0x05" flagname="UWB" flagmask="0x06" />
+                <const key="0x06" flagname="Eye Biometric" flagmask="0x07" />
+                <const key="0x07" flagname="Face Biometric" flagmask="0x08" />
+                <const key="0x08" flagname="Finger Biometric" flagmask="0x09" />
+                <const key="0x09" flagname="Hand Biometric" flagmask="0x0A" />
+                <const key="0x0A" flagname="Unspecified Biometric" flagmask="0x0B" />
+            </param>
+            <param key="0x02" name="Credential Slot" type="WORD" />
+            <param key="0x03" name="Properties1" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="Operation Type" fieldmask="0x03">
+                    <fieldenum value="Add" />
+                    <fieldenum value="Modify" />
+                    <fieldenum value="Delete" />
+                </fieldenum>
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFC" shifter="2" />
+            </param>
+            <param key="0x04" name="Credential Length" type="BYTE" />
+            <param key="0x05" name="Credential Data" type="VARIANT">
+                <variant paramoffs="4" sizemask="0xFF" />
+            </param>
+        </cmd>
+        <cmd key="0x0B" name="CREDENTIAL_GET" help="Credential Get" support_mode="RX">
+            <param key="0x00" name="User Unique Identifier" type="WORD" />
+            <param key="0x01" name="Credential Type" type="CONST">
+                <const key="0x00" flagname="PIN Code" flagmask="0x01" />
+                <const key="0x01" flagname="Password" flagmask="0x02" />
+                <const key="0x02" flagname="RFID Code" flagmask="0x03" />
+                <const key="0x03" flagname="BLE" flagmask="0x04" />
+                <const key="0x04" flagname="NFC" flagmask="0x05" />
+                <const key="0x05" flagname="UWB" flagmask="0x06" />
+                <const key="0x06" flagname="Eye Biometric" flagmask="0x07" />
+                <const key="0x07" flagname="Face Biometric" flagmask="0x08" />
+                <const key="0x08" flagname="Finger Biometric" flagmask="0x09" />
+                <const key="0x09" flagname="Hand Biometric" flagmask="0x0A" />
+                <const key="0x0A" flagname="Unspecified Biometric" flagmask="0x0B" />
+            </param>
+            <param key="0x02" name="Credential Slot" type="WORD" />
+        </cmd>
+        <cmd key="0x0C" name="CREDENTIAL_REPORT" help="Credential Report" support_mode="TX">
+            <param key="0x00" name="Credential Report Type" type="CONST">
+                <const key="0x00" flagname="Added" flagmask="0x00" />
+                <const key="0x01" flagname="Modified" flagmask="0x01" />
+                <const key="0x02" flagname="Deleted" flagmask="0x02" />
+                <const key="0x03" flagname="Unchanged" flagmask="0x03" />
+                <const key="0x04" flagname="Response to Get" flagmask="0x04" />
+                <const key="0x05" flagname="Add Against Occupied" flagmask="0x05" />
+                <const key="0x06" flagname="Modify Against Empty" flagmask="0x06" />
+                <const key="0x07" flagname="Duplicate" flagmask="0x07" />
+                <const key="0x08" flagname="Manufacturer Security Rules" flagmask="0x08" />
+                <const key="0x09" flagname="Assigned to Different User" flagmask="0x09" />
+                <const key="0x0A" flagname="Duplicate Admin PIN Code" flagmask="0x0A" />
+            </param>
+            <param key="0x01" name="User Unique Identifier" type="WORD" />
+            <param key="0x02" name="Credential Type" type="CONST">
+                <const key="0x00" flagname="PIN Code" flagmask="0x01" />
+                <const key="0x01" flagname="Password" flagmask="0x02" />
+                <const key="0x02" flagname="RFID Code" flagmask="0x03" />
+                <const key="0x03" flagname="BLE" flagmask="0x04" />
+                <const key="0x04" flagname="NFC" flagmask="0x05" />
+                <const key="0x05" flagname="UWB" flagmask="0x06" />
+                <const key="0x06" flagname="Eye Biometric" flagmask="0x07" />
+                <const key="0x07" flagname="Face Biometric" flagmask="0x08" />
+                <const key="0x08" flagname="Finger Biometric" flagmask="0x09" />
+                <const key="0x09" flagname="Hand Biometric" flagmask="0x0A" />
+                <const key="0x0A" flagname="Unspecified Biometric" flagmask="0x0B" />
+            </param>
+            <param key="0x03" name="Credential Slot" type="WORD" />
+            <param key="0x04" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Reserved" fieldmask="0x7F" />
+                <bitflag key="0x01" flagname="CRB" flagmask="0x80" />
+            </param>
+            <param key="0x05" name="Credential Length" type="BYTE" />
+            <param key="0x06" name="Credential Data" type="VARIANT">
+                <variant paramoffs="5" sizemask="0xFF" />
+            </param>
+            <param key="0x07" name="Credential Modifier Type" type="CONST">
+                <const key="0x00" flagname="DNE" flagmask="0x00" />
+                <const key="0x01" flagname="Unknown" flagmask="0x01" />
+                <const key="0x02" flagname="Z-Wave" flagmask="0x02" />
+                <const key="0x03" flagname="Locally" flagmask="0x03" />
+                <const key="0x04" flagname="Mobile App or other IoT technology" flagmask="0x04" />
+            </param>
+            <param key="0x08" name="Credential Modifier Node ID" type="WORD" />
+            <param key="0x09" name="Next Credential Type" type="CONST">
+                <const key="0x00" flagname="None" flagmask="0x00" />
+                <const key="0x01" flagname="PIN Code" flagmask="0x01" />
+                <const key="0x02" flagname="Password" flagmask="0x02" />
+                <const key="0x03" flagname="RFID Code" flagmask="0x03" />
+                <const key="0x04" flagname="BLE" flagmask="0x04" />
+                <const key="0x05" flagname="NFC" flagmask="0x05" />
+                <const key="0x06" flagname="UWB" flagmask="0x06" />
+                <const key="0x07" flagname="Eye Biometric" flagmask="0x07" />
+                <const key="0x08" flagname="Face Biometric" flagmask="0x08" />
+                <const key="0x09" flagname="Finger Biometric" flagmask="0x09" />
+                <const key="0x0A" flagname="Hand Biometric" flagmask="0x0A" />
+                <const key="0x0B" flagname="Unspecified Biometric" flagmask="0x0B" />
+            </param>
+            <param key="0x0A" name="Next Credential Slot" type="WORD" />
+        </cmd>
+        <cmd key="0x0F" name="CREDENTIAL_LEARN_START" help="Credential Learn Start" support_mode="RX">
+            <param key="0x00" name="User Unique Identifier" type="WORD" />
+            <param key="0x01" name="Credential Type" type="CONST">
+                <const key="0x00" flagname="PIN Code" flagmask="0x01" />
+                <const key="0x01" flagname="Password" flagmask="0x02" />
+                <const key="0x02" flagname="RFID Code" flagmask="0x03" />
+                <const key="0x03" flagname="BLE" flagmask="0x04" />
+                <const key="0x04" flagname="NFC" flagmask="0x05" />
+                <const key="0x05" flagname="UWB" flagmask="0x06" />
+                <const key="0x06" flagname="Eye Biometric" flagmask="0x07" />
+                <const key="0x07" flagname="Face Biometric" flagmask="0x08" />
+                <const key="0x08" flagname="Finger Biometric" flagmask="0x09" />
+                <const key="0x09" flagname="Hand Biometric" flagmask="0x0A" />
+                <const key="0x0A" flagname="Unspecified Biometric" flagmask="0x0B" />
+            </param>
+            <param key="0x02" name="Credential Slot" type="WORD" />
+            <param key="0x03" name="Properties1" type="STRUCT_BYTE">
+                <fieldenum key="0x00" fieldname="Operation Type" fieldmask="0x03">
+                    <fieldenum value="CredentialLearnAdd" />
+                    <fieldenum value="CredentialLearnModify" />
+                </fieldenum>
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xFC" shifter="2" />
+            </param>
+            <param key="0x04" name="Credential Learn Timeout" type="BYTE" />
+        </cmd>
+        <cmd key="0x10" name="CREDENTIAL_LEARN_CANCEL" help="Credential Learn Cancel" support_mode="RX" />
+        <cmd key="0x11" name="CREDENTIAL_LEARN_REPORT" help="Credential Learn Status Report" support_mode="TX">
+            <param key="0x00" name="Credential Learn Status" type="CONST">
+                <const key="0x00" flagname="Started" flagmask="0x00" />
+                <const key="0x01" flagname="Success" flagmask="0x01" />
+                <const key="0x02" flagname="Already in Progress" flagmask="0x02" />
+                <const key="0x03" flagname="Ended Not Due to Timeout" flagmask="0x03" />
+                <const key="0x04" flagname="Timeout" flagmask="0x04" />
+                <const key="0x05" flagname="Credential Learn Step Retry" flagmask="0x05" />
+                <const key="0x06" flagname="Invalid Credential Learn Add Operation Type" flagmask="0xFE" />
+                <const key="0x07" flagname="Invalid Credential Learn Modify Operation Type" flagmask="0xFF" />
+            </param>
+            <param key="0x01" name="User Unique Identifier" type="WORD" />
+            <param key="0x02" name="Credential Type" type="CONST">
+                <const key="0x00" flagname="PIN Code" flagmask="0x01" />
+                <const key="0x01" flagname="Password" flagmask="0x02" />
+                <const key="0x02" flagname="RFID Code" flagmask="0x03" />
+                <const key="0x03" flagname="BLE" flagmask="0x04" />
+                <const key="0x04" flagname="NFC" flagmask="0x05" />
+                <const key="0x05" flagname="UWB" flagmask="0x06" />
+                <const key="0x06" flagname="Eye Biometric" flagmask="0x07" />
+                <const key="0x07" flagname="Face Biometric" flagmask="0x08" />
+                <const key="0x08" flagname="Finger Biometric" flagmask="0x09" />
+                <const key="0x09" flagname="Hand Biometric" flagmask="0x0A" />
+                <const key="0x0A" flagname="Unspecified Biometric" flagmask="0x0B" />
+            </param>
+            <param key="0x03" name="Credential Slot" type="WORD" />
+            <param key="0x04" name="Credential Learn Steps Remaining" type="BYTE" />
+        </cmd>
+        <cmd key="0x12" name="USER_CREDENTIAL_ASSOCIATION_SET" help="User Unique Identifier Credential Association Set" support_mode="RX">
+            <param key="0x00" name="Source User Unique Identifier" type="WORD" />
+            <param key="0x01" name="Source Credential Type" type="CONST">
+                <const key="0x00" flagname="PIN Code" flagmask="0x01" />
+                <const key="0x01" flagname="Password" flagmask="0x02" />
+                <const key="0x02" flagname="RFID Code" flagmask="0x03" />
+                <const key="0x03" flagname="BLE" flagmask="0x04" />
+                <const key="0x04" flagname="NFC" flagmask="0x05" />
+                <const key="0x05" flagname="UWB" flagmask="0x06" />
+                <const key="0x06" flagname="Eye Biometric" flagmask="0x07" />
+                <const key="0x07" flagname="Face Biometric" flagmask="0x08" />
+                <const key="0x08" flagname="Finger Biometric" flagmask="0x09" />
+                <const key="0x09" flagname="Hand Biometric" flagmask="0x0A" />
+                <const key="0x0A" flagname="Unspecified Biometric" flagmask="0x0B" />
+            </param>
+            <param key="0x02" name="Source Credential Slot" type="WORD" />
+            <param key="0x03" name="Destination User Unique Identifier" type="WORD" />
+            <param key="0x04" name="Destination Credential Slot" type="WORD" />
+        </cmd>
+        <cmd key="0x13" name="USER_CREDENTIAL_ASSOCIATION_REPORT" help="User Unique Identifier Credential Association Report" support_mode="TX">
+            <param key="0x00" name="Source User Unique Identifier" type="WORD" />
+            <param key="0x01" name="Source Credential Type" type="CONST">
+                <const key="0x00" flagname="PIN Code" flagmask="0x01" />
+                <const key="0x01" flagname="Password" flagmask="0x02" />
+                <const key="0x02" flagname="RFID Code" flagmask="0x03" />
+                <const key="0x03" flagname="BLE" flagmask="0x04" />
+                <const key="0x04" flagname="NFC" flagmask="0x05" />
+                <const key="0x05" flagname="UWB" flagmask="0x06" />
+                <const key="0x06" flagname="Eye Biometric" flagmask="0x07" />
+                <const key="0x07" flagname="Face Biometric" flagmask="0x08" />
+                <const key="0x08" flagname="Finger Biometric" flagmask="0x09" />
+                <const key="0x09" flagname="Hand Biometric" flagmask="0x0A" />
+                <const key="0x0A" flagname="Unspecified Biometric" flagmask="0x0B" />
+            </param>
+            <param key="0x02" name="Source Credential Slot" type="WORD" />
+            <param key="0x03" name="Destination User Unique Identifier" type="WORD" />
+            <param key="0x04" name="Destination Credential Slot" type="WORD" />
+            <param key="0x05" name="User Credential Association Status" type="CONST">
+                <const key="0x00" flagname="Success" flagmask="0x00" />
+                <const key="0x01" flagname="Source User Unique Identifier Invalid" flagmask="0x01" />
+                <const key="0x02" flagname="Source User Unique Identifier Nonexistent" flagmask="0x02" />
+                <const key="0x03" flagname="Source Credential Type Invalid" flagmask="0x03" />
+                <const key="0x04" flagname="Source Credential Slot Invalid" flagmask="0x04" />
+                <const key="0x05" flagname="Source Credential Slot Empty" flagmask="0x05" />
+                <const key="0x06" flagname="Destination User Unique Identifier Invalid" flagmask="0x06" />
+                <const key="0x07" flagname="Destination User Unique Identifier Nonexistent" flagmask="0x07" />
+                <const key="0x08" flagname="Destination Credential Slot Invalid" flagmask="0x08" />
+                <const key="0x09" flagname="Destination Credential Slot Occupied" flagmask="0x09" />
+            </param>
+        </cmd>
+        <cmd key="0x14" name="ALL_USERS_CHECKSUM_GET" help="All Users Checksum Get" support_mode="RX" />
+        <cmd key="0x15" name="ALL_USERS_CHECKSUM_REPORT" help="All Users Checksum Report" support_mode="TX">
+            <param key="0x00" name="All Users Checksum" type="WORD" />
+        </cmd>
+        <cmd key="0x16" name="USER_CHECKSUM_GET" help="User Checksum Get" support_mode="RX">
+            <param key="0x00" name="User Unique Identifier" type="WORD" />
+        </cmd>
+        <cmd key="0x17" name="USER_CHECKSUM_REPORT" help="User Checksum Report" support_mode="TX">
+            <param key="0x00" name="User Unique Identifier" type="WORD" />
+            <param key="0x01" name="User Checksum" type="WORD" />
+        </cmd>
+        <cmd key="0x18" name="CREDENTIAL_CHECKSUM_GET" help="Credential Checksum Get" support_mode="RX">
+            <param key="0x00" name="Credential Type" type="CONST">
+                <const key="0x00" flagname="PIN Code" flagmask="0x01" />
+                <const key="0x01" flagname="Password" flagmask="0x02" />
+                <const key="0x02" flagname="RFID Code" flagmask="0x03" />
+                <const key="0x03" flagname="BLE" flagmask="0x04" />
+                <const key="0x04" flagname="NFC" flagmask="0x05" />
+                <const key="0x05" flagname="UWB" flagmask="0x06" />
+                <const key="0x06" flagname="Eye Biometric" flagmask="0x07" />
+                <const key="0x07" flagname="Face Biometric" flagmask="0x08" />
+                <const key="0x08" flagname="Finger Biometric" flagmask="0x09" />
+                <const key="0x09" flagname="Hand Biometric" flagmask="0x0A" />
+                <const key="0x0A" flagname="Unspecified Biometric" flagmask="0x0B" />
+            </param>
+        </cmd>
+        <cmd key="0x19" name="CREDENTIAL_CHECKSUM_REPORT" help="Credential Checksum Report" support_mode="TX">
+            <param key="0x00" name="Credential Type" type="CONST">
+                <const key="0x00" flagname="PIN Code" flagmask="0x01" />
+                <const key="0x01" flagname="Password" flagmask="0x02" />
+                <const key="0x02" flagname="RFID Code" flagmask="0x03" />
+                <const key="0x03" flagname="BLE" flagmask="0x04" />
+                <const key="0x04" flagname="NFC" flagmask="0x05" />
+                <const key="0x05" flagname="UWB" flagmask="0x06" />
+                <const key="0x06" flagname="Eye Biometric" flagmask="0x07" />
+                <const key="0x07" flagname="Face Biometric" flagmask="0x08" />
+                <const key="0x08" flagname="Finger Biometric" flagmask="0x09" />
+                <const key="0x09" flagname="Hand Biometric" flagmask="0x0A" />
+                <const key="0x0A" flagname="Unspecified Biometric" flagmask="0x0B" />
+            </param>
+            <param key="0x01" name="Credential Checksum" type="WORD" />
+        </cmd>
+        <cmd key="0x1A" name="ADMIN_PIN_CODE_SET" help="Admin PIN Code Set" support_mode="RX">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Admin PIN Code Length" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Reserved" fieldmask="0xF0" shifter="4" />
+            </param>
+            <param key="0x01" name="Admin Code" type="VARIANT">
+                <variant paramoffs="0" sizemask="0x0F" />
+            </param>
+        </cmd>
+        <cmd key="0x1B" name="ADMIN_PIN_CODE_GET" help="Admin PIN Code Get" support_mode="RX" />
+        <cmd key="0x1C" name="ADMIN_PIN_CODE_REPORT" help="Admin PIN Code Report" support_mode="TX">
+            <param key="0x00" name="Properties1" type="STRUCT_BYTE">
+                <bitfield key="0x00" fieldname="Admin PIN Code Length" fieldmask="0x0F" />
+                <bitfield key="0x01" fieldname="Admin PIN Code Operation Result" fieldmask="0xF0" shifter="4" />
+            </param>
+            <param key="0x01" name="Admin Code" type="VARIANT">
                 <variant paramoffs="0" sizemask="0x0F" />
             </param>
         </cmd>

--- a/test/grizzly/virtual_devices_test.exs
+++ b/test/grizzly/virtual_devices_test.exs
@@ -90,12 +90,12 @@ defmodule Grizzly.VirtualDeviceTest do
   end
 
   describe "version get reports" do
-    test "routing slave" do
+    test "routing end node" do
       with_virtual_device(Thermostat, fn id ->
         {:ok, %Report{type: :command, command: command}} = Grizzly.send_command(id, :version_get)
 
         assert command.name == :version_report
-        assert Command.param!(command, :library_type) == :routing_slave
+        assert Command.param!(command, :library_type) == :routing_end_node
       end)
     end
   end

--- a/test/grizzly/zwave/commands/node_add_status_test.exs
+++ b/test/grizzly/zwave/commands/node_add_status_test.exs
@@ -141,7 +141,7 @@ defmodule Grizzly.ZWave.Commands.NodeAddStatusTest do
         node_id: 7,
         seq_number: 37,
         listening?: false,
-        basic_device_class: :routing_slave,
+        basic_device_class: :routing_end_node,
         generic_device_class: :sensor_notification,
         specific_device_class: :notification_sensor,
         command_classes: expected_command_classes


### PR DESCRIPTION
In support of this, update all usages of the term "slave" with "end
node".
