### PR TITLE
Fix acknowledged flag sometimes being incorrectly false

### DIFF
--- a/lib/grizzly/command_handlers/supervision_report.ex
+++ b/lib/grizzly/command_handlers/supervision_report.ex
@@ -53,7 +53,8 @@ defmodule Grizzly.CommandHandlers.SupervisionReport do
       {:grizzly, :report,
        Report.new(:inflight, :supervision_status, state.node_id,
          command: command,
-         command_ref: state.command_ref
+         command_ref: state.command_ref,
+         acknowledged: true
        )}
     )
   end

--- a/lib/grizzly/commands/command.ex
+++ b/lib/grizzly/commands/command.ex
@@ -461,7 +461,8 @@ defmodule Grizzly.Commands.Command do
       command_ref: command.ref,
       transmission_stats: command.transmission_stats,
       type: :ack_response,
-      node_id: command.node_id
+      node_id: command.node_id,
+      acknowledged: command.acknowledged
     }
   end
 
@@ -472,7 +473,8 @@ defmodule Grizzly.Commands.Command do
       transmission_stats: command.transmission_stats,
       type: :command,
       command_ref: command.ref,
-      node_id: command.node_id
+      node_id: command.node_id,
+      acknowledged: command.acknowledged
     }
   end
 end

--- a/test/grizzly/commands/command_runner_test.exs
+++ b/test/grizzly/commands/command_runner_test.exs
@@ -20,7 +20,7 @@ defmodule Grizzly.Commands.CommandRunnerTest do
     ref = CommandRunner.reference(runner)
 
     ack_response = ZIPPacket.make_ack_response(CommandRunner.seq_number(runner))
-    report = Report.new(:complete, :ack_response, 1, command_ref: ref)
+    report = Report.new(:complete, :ack_response, 1, command_ref: ref, acknowledged: true)
 
     assert report == CommandRunner.handle_zip_command(runner, ack_response)
   end

--- a/test/grizzly/commands/command_test.exs
+++ b/test/grizzly/commands/command_test.exs
@@ -50,7 +50,11 @@ defmodule Grizzly.Commands.CommandTest do
 
     ack_response = ZIPPacket.make_ack_response(grizzly_command.seq_number)
 
-    report = Report.new(:complete, :ack_response, 1, command_ref: grizzly_command.ref)
+    report =
+      Report.new(:complete, :ack_response, 1,
+        command_ref: grizzly_command.ref,
+        acknowledged: true
+      )
 
     assert {report, %Command{grizzly_command | status: :complete, acknowledged: true}} ==
              Command.handle_zip_command(grizzly_command, ack_response)

--- a/test/grizzly/connections/command_list_test.exs
+++ b/test/grizzly/connections/command_list_test.exs
@@ -24,7 +24,7 @@ defmodule Grizzly.Connections.CommandListTest do
 
     ack_response = ZIPPacket.make_ack_response(CommandRunner.seq_number(runner))
 
-    report = Report.new(:complete, :ack_response, 1, command_ref: ref)
+    report = Report.new(:complete, :ack_response, 1, command_ref: ref, acknowledged: true)
 
     assert {self(), {report, CommandList.empty()}} ==
              CommandList.response_for_zip_packet(command_list, ack_response)


### PR DESCRIPTION
The acknowledged flag from the `Grizzly.Commands.Command` was not always
being copied into `Grizzly.Report` correctly.
