### PR TITLE
Fix warnings when building docs

### DIFF
--- a/lib/grizzly.ex
+++ b/lib/grizzly.ex
@@ -103,6 +103,8 @@ defmodule Grizzly do
 
   @type handler() :: module() | handler_spec()
 
+  @type connection_mode() :: :sync | :async | :binary
+
   @typedoc """
   Options for `Grizzly.send_command/4`.
 
@@ -130,7 +132,7 @@ defmodule Grizzly do
           | {:transmission_stats, boolean()}
           | {:supervision?, boolean()}
           | {:status_updates?, boolean()}
-          | {:mode, Connection.mode()}
+          | {:mode, connection_mode()}
           | {:more_info, boolean()}
 
   @type command :: atom()

--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -1,5 +1,8 @@
 defmodule Grizzly.Commands.Table do
-  @moduledoc false
+  @moduledoc """
+  Lookup table for sendable Z-Wave commands.
+  """
+
   alias Grizzly.CommandHandlers.AckResponse
 
   # look up support for supported command classes and their default Grizzly

--- a/lib/grizzly/connection.ex
+++ b/lib/grizzly/connection.ex
@@ -9,8 +9,7 @@ defmodule Grizzly.Connection do
   alias Grizzly.ZWave
   alias Grizzly.ZWave.Command
 
-  @type mode() :: :sync | :async | :binary
-  @type opt() :: {:mode, mode()} | {:owner, pid()} | {:unnamed, boolean()}
+  @type opt() :: {:mode, Grizzly.connection_mode()} | {:owner, pid()} | {:unnamed, boolean()}
 
   @doc """
   Open a connection to a node or the Z/IP Gateway

--- a/lib/grizzly/virtual_devices.ex
+++ b/lib/grizzly/virtual_devices.ex
@@ -9,6 +9,7 @@ defmodule Grizzly.VirtualDevices do
   alias Grizzly.VirtualDevicesRegistry
   alias Grizzly.VirtualDevices.{Device, Reports}
   alias Grizzly.ZWave.Command
+  alias Grizzly.ZWave.DeviceClass
 
   @typedoc """
   Options for adding a virtual devices
@@ -37,6 +38,14 @@ defmodule Grizzly.VirtualDevices do
   """
   @type id() :: {:virtual, integer()}
 
+  @type device_entry() :: %{
+          device_impl: Device.t(),
+          device_class: DeviceClass.t(),
+          device_opts: [Device.device_opt()],
+          id: id(),
+          pid: pid()
+        }
+
   @doc """
   Add a new virtual device to the virtual device network
 
@@ -46,7 +55,7 @@ defmodule Grizzly.VirtualDevices do
   If the device takes any options you can pass a tuple of `{device, opts}`.
   """
   @spec add_device(id(), Device.t(), [add_opt()]) ::
-          {:ok, id()} | {:error, {:already_registered, VirtualDevicesRegistry.device_entry()}}
+          {:ok, id()} | {:error, {:already_registered, device_entry()}}
   def add_device(device_id, device_impl, opts \\ []) do
     device_opts = Keyword.drop(opts, [:inclusion_handler])
 

--- a/lib/grizzly/virtual_devices/reports.ex
+++ b/lib/grizzly/virtual_devices/reports.ex
@@ -3,7 +3,7 @@ defmodule Grizzly.VirtualDevices.Reports do
 
   # Helper module for building various general reports for a virtual device
 
-  alias Grizzly.{Report, VirtualDevices, VirtualDevicesRegistry}
+  alias Grizzly.{Report, VirtualDevices}
   alias Grizzly.ZWave.{Command, DeviceClass, DSK}
 
   alias Grizzly.ZWave.Commands.{
@@ -21,7 +21,7 @@ defmodule Grizzly.VirtualDevices.Reports do
   @doc """
   Send the node add status message to the handler
   """
-  @spec send_node_add_status(VirtualDevicesRegistry.device_entry(), Grizzly.handler()) :: :ok
+  @spec send_node_add_status(VirtualDevices.device_entry(), Grizzly.handler()) :: :ok
   def send_node_add_status(device_entry, handler) do
     {handler, handler_opts} = ensure_handler_with_opts(handler)
 
@@ -68,7 +68,7 @@ defmodule Grizzly.VirtualDevices.Reports do
   @doc """
   Build a node info cached report based of a node info get command
   """
-  @spec build_node_info_cache_report(VirtualDevicesRegistry.device_entry(), Command.t()) ::
+  @spec build_node_info_cache_report(VirtualDevices.device_entry(), Command.t()) ::
           Report.t()
   def build_node_info_cache_report(entry, node_info_get) do
     seq_number = Command.param!(node_info_get, :seq_number)
@@ -91,7 +91,7 @@ defmodule Grizzly.VirtualDevices.Reports do
   @doc """
   Build manufacturer specific report for the device entry
   """
-  @spec build_manufacturer_specific_report(VirtualDevicesRegistry.device_entry()) :: Report.t()
+  @spec build_manufacturer_specific_report(VirtualDevices.device_entry()) :: Report.t()
   def build_manufacturer_specific_report(entry) do
     {:ok, manufacturer_report} =
       ManufacturerSpecificReport.new(
@@ -107,7 +107,7 @@ defmodule Grizzly.VirtualDevices.Reports do
   Build version command class get for a command class in the entry's device
   class
   """
-  @spec build_version_command_class_get_report(VirtualDevicesRegistry.device_entry(), Command.t()) ::
+  @spec build_version_command_class_get_report(VirtualDevices.device_entry(), Command.t()) ::
           Report.t()
   def build_version_command_class_get_report(entry, version_command_class_get) do
     command_class = Command.param!(version_command_class_get, :command_class)
@@ -127,7 +127,7 @@ defmodule Grizzly.VirtualDevices.Reports do
   @doc """
   Build the association report from the association get command
   """
-  @spec build_association_report(VirtualDevicesRegistry.device_entry()) :: Report.t()
+  @spec build_association_report(VirtualDevices.device_entry()) :: Report.t()
   def build_association_report(entry) do
     {:ok, report} =
       AssociationReport.new(
@@ -143,7 +143,7 @@ defmodule Grizzly.VirtualDevices.Reports do
   @doc """
   Build a battery report for a battery get command
   """
-  @spec build_battery_report(VirtualDevicesRegistry.device_entry()) :: Report.t()
+  @spec build_battery_report(VirtualDevices.device_entry()) :: Report.t()
   def build_battery_report(entry) do
     {:ok, report} = BatteryReport.new(level: 100)
 
@@ -153,7 +153,7 @@ defmodule Grizzly.VirtualDevices.Reports do
   @doc """
   Build a version report for a version get command
   """
-  @spec build_version_report(VirtualDevicesRegistry.device_entry()) :: Report.t()
+  @spec build_version_report(VirtualDevices.device_entry()) :: Report.t()
   def build_version_report(entry) do
     {:ok, report} =
       VersionReport.new(
@@ -194,7 +194,7 @@ defmodule Grizzly.VirtualDevices.Reports do
   @doc """
   Build an ack response report
   """
-  @spec build_ack_response(VirtualDevicesRegistry.device_entry()) :: Report.t()
+  @spec build_ack_response(VirtualDevices.device_entry()) :: Report.t()
   def build_ack_response(entry) do
     Report.new(:complete, :ack_response, entry.id)
   end
@@ -202,7 +202,7 @@ defmodule Grizzly.VirtualDevices.Reports do
   @doc """
   Build a report that contains a command
   """
-  @spec build_report(VirtualDevicesRegistry.device_entry(), Command.t()) :: Report.t()
+  @spec build_report(VirtualDevices.device_entry(), Command.t()) :: Report.t()
   def build_report(entry, command) do
     Report.new(:complete, :command, entry.id, command: command)
   end

--- a/lib/grizzly/virtual_devices/virtual_devices_registry.ex
+++ b/lib/grizzly/virtual_devices/virtual_devices_registry.ex
@@ -5,16 +5,6 @@ defmodule Grizzly.VirtualDevicesRegistry do
   alias Grizzly.VirtualDevices.Device
   alias Grizzly.ZWave.DeviceClass
 
-  @typedoc """
-  """
-  @type device_entry() :: %{
-          device_impl: Device.t(),
-          device_class: DeviceClass.t(),
-          device_opts: [Device.device_opt()],
-          id: VirtualDevices.id(),
-          pid: pid()
-        }
-
   @type start_opts() :: [
           {:keys, :unique},
           {:name, module()},
@@ -33,7 +23,8 @@ defmodule Grizzly.VirtualDevicesRegistry do
   Register the virtual device
   """
   @spec register(VirtualDevices.id(), Device.t(), DeviceClass.t(), [Device.device_opt()]) ::
-          {:ok, device_entry()} | {:error, {:already_registered, device_entry()}}
+          {:ok, VirtualDevices.device_entry()}
+          | {:error, {:already_registered, VirtualDevices.device_entry()}}
   def register({:virtual, id} = device_id, device_impl, device_class, device_opts)
       when is_integer(id) and id > 0 do
     entry = %{
@@ -63,7 +54,7 @@ defmodule Grizzly.VirtualDevicesRegistry do
   @doc """
   Get a device entry by the virtual device id
   """
-  @spec get(VirtualDevices.id()) :: device_entry() | nil
+  @spec get(VirtualDevices.id()) :: VirtualDevices.device_entry() | nil
   def get(device_id) do
     case Registry.lookup(__MODULE__, device_id) do
       [] ->

--- a/lib/grizzly/zwave/commands/sensor_multilevel_supported_scale_report.ex
+++ b/lib/grizzly/zwave/commands/sensor_multilevel_supported_scale_report.ex
@@ -5,8 +5,8 @@ defmodule Grizzly.ZWave.Commands.SensorMultilevelSupportedScaleReport do
 
   ## Parameters
 
-  * `:sensor_type` - `list  of :temperature or :illuminance or :power or :humidity` etc. (required)
-  * `:supported_scales` - `list  of supported scales, e.g. [0, 1, 3]. (required)
+  * `:sensor_type` - the type of sensor for which the scales are supported. (required)
+  * `:supported_scales` - list of supported scales, e.g. [0, 1, 3]. (required)
   """
 
   @behaviour Grizzly.ZWave.Command

--- a/mix.exs
+++ b/mix.exs
@@ -131,7 +131,7 @@ defmodule Grizzly.MixProject do
           Grizzly.ZWave.IconType,
           Grizzly.ZWave.Notifications,
           Grizzly.ZWave.QRCode,
-          Grizzly.ZWave.Security,
+          ~r/^Grizzly\.ZWave\.Security/,
           ~r/^Grizzly\.ZWave\.SmartStart/,
           Grizzly.Inclusions.ZWaveAdapter,
           Grizzly.ZWaveFirmware,
@@ -150,6 +150,7 @@ defmodule Grizzly.MixProject do
       ],
       nest_modules_by_prefix: [
         Grizzly.CommandHandlers,
+        Grizzly.VirtualDevices,
         Grizzly.ZWave.CommandClasses,
         Grizzly.ZWave.Commands
       ]


### PR DESCRIPTION
Shuffled a couple of typespecs around to avoid referencing private
modules.
