### PR TITLE
Traces record node ids instead of IP addresses

### DIFF
--- a/lib/grizzly/connections/async_connection.ex
+++ b/lib/grizzly/connections/async_connection.ex
@@ -92,7 +92,8 @@ defmodule Grizzly.Connections.AsyncConnection do
 
     transport_opts = [
       ip_address: host,
-      port: grizzly_options.zipgateway_port
+      port: grizzly_options.zipgateway_port,
+      node_id: node_id
     ]
 
     ref = Process.monitor(owner)

--- a/lib/grizzly/connections/binary_connection.ex
+++ b/lib/grizzly/connections/binary_connection.ex
@@ -54,7 +54,8 @@ defmodule Grizzly.Connections.BinaryConnection do
 
     transport_opts = [
       ip_address: host,
-      port: grizzly_options.zipgateway_port
+      port: grizzly_options.zipgateway_port,
+      node_id: node_id
     ]
 
     case Transport.open(transport_impl, transport_opts) do

--- a/lib/grizzly/connections/sync_connection.ex
+++ b/lib/grizzly/connections/sync_connection.ex
@@ -63,7 +63,8 @@ defmodule Grizzly.Connections.SyncConnection do
 
     transport_opts = [
       ip_address: host,
-      port: grizzly_options.zipgateway_port
+      port: grizzly_options.zipgateway_port,
+      node_id: node_id_or_gateway
     ]
 
     case Transport.open(transport_impl, transport_opts) do

--- a/lib/grizzly/trace.ex
+++ b/lib/grizzly/trace.ex
@@ -24,19 +24,19 @@ defmodule Grizzly.Trace do
 
   @type trace_opt :: {:name, atom()} | {:size, pos_integer()} | {:record_keepalives, boolean()}
 
-  @type src() :: String.t()
-  @type dest() :: String.t()
+  @type src() :: Grizzly.node_id() | :grizzly
+  @type dest() :: Grizzly.node_id() | :grizzly
 
   @type log_opt() :: {:src, src()} | {:dest, dest()}
 
-  @type format() :: :text | :term
+  @type format() :: :text | :raw
+
+  @type list_opt() :: {:node_id, Grizzly.node_id()}
 
   @default_size 300
   @default_format :text
 
-  @doc """
-  Start the trace server
-  """
+  @doc "Start the trace server."
   @spec start_link([trace_opt()]) :: GenServer.on_start()
   def start_link(opts \\ []) do
     {name, opts} = Keyword.pop(opts, :name, __MODULE__)
@@ -52,10 +52,6 @@ defmodule Grizzly.Trace do
 
   * `:raw` - Each record is on a new line and is formatted as
     `timestamp source -> destination: binary`.
-
-  * `:term` - The trace is serialized as a list of `Record.t()` structs in
-    Erlang external term format. This is useful if you want to load the trace
-    on another machine.
   """
   @spec format([Record.t()], format()) :: binary()
   def format(records, format \\ @default_format)
@@ -63,38 +59,30 @@ defmodule Grizzly.Trace do
   def format(records, fmt) when fmt in [:text, :raw],
     do: Enum.map_join(records, "\n", &Record.to_string(&1, fmt))
 
-  def format(records, :term), do: :erlang.term_to_binary(records)
-
-  @doc """
-  Dump trace records into a file. See `format/2` for the available formats.
-  """
-  @spec dump(binary(), format()) :: :ok | {:error, atom()}
-  def dump(file, format \\ @default_format) do
-    file_contents = format(list(), format)
+  @doc "Dump trace records into a file using Erlang External Term Format."
+  @spec dump(binary()) :: :ok | {:error, atom()}
+  def dump(file) do
+    file_contents = :erlang.term_to_binary(list(), compressed: 9)
     File.write(file, file_contents)
   end
 
   @doc """
   Write trace records to standard out. See `format/2` for the available formats.
   """
-  @spec print(list(Record.t()), format()) :: :ok
-  def print(records, :term), do: print(records, @default_format)
+  @spec print(list(Record.t()) | format(), [list_opt()]) :: :ok
+  def print(records_or_format, opts)
+  def print(records, _opts) when is_list(records), do: records |> format() |> IO.puts()
+  def print(fmt, opts) when is_atom(fmt), do: opts |> list() |> format(fmt) |> IO.puts()
 
-  def print(records, fmt) do
-    IO.puts(format(records, fmt))
-  end
-
-  @spec print(list(Record.t()) | format()) :: :ok
-  def print(records) when is_list(records), do: print(records, @default_format)
-  def print(fmt) when is_atom(fmt), do: print(list(), fmt)
+  def print(fmt_or_opts)
+  def print(fmt) when is_atom(fmt), do: print(fmt, [])
+  def print(opts) when is_list(opts), do: print(@default_format, opts)
 
   @spec print() :: :ok
-  def print(), do: print(list(), @default_format)
+  def print(), do: print([])
 
-  @doc """
-  Add a record to the trace buffer.
-  """
-  @spec log(GenServer.name(), binary(), [log_opt()]) :: :ok
+  @doc "Add a record to the trace buffer."
+  @spec log(GenServer.server(), binary(), [log_opt()]) :: :ok
   def log(name, binary, opts) do
     GenServer.cast(name, {:log, binary, opts})
   end
@@ -103,37 +91,43 @@ defmodule Grizzly.Trace do
   @spec log(binary(), [log_opt()]) :: :ok
   def log(binary, opts \\ []) when is_binary(binary), do: log(__MODULE__, binary, opts)
 
-  @doc """
-  Reset the trace buffer.
-  """
-  @spec clear(GenServer.name()) :: :ok
-  def clear(name \\ __MODULE__) do
-    GenServer.call(name, :clear)
+  @doc "Reset the trace buffer."
+  @spec clear(GenServer.server()) :: :ok
+  def clear(name \\ __MODULE__), do: GenServer.call(name, :clear)
+
+  @doc "List all records in the trace buffer."
+  @spec list(GenServer.server(), [list_opt()]) :: [Record.t()]
+  def list(name, opts) do
+    node_id_filter = Keyword.get(opts, :node_id, nil)
+    records = GenServer.call(name, :list)
+
+    if node_id_filter do
+      Enum.filter(records, &(&1.src == node_id_filter || &1.dest == node_id_filter))
+    else
+      records
+    end
   end
 
-  @doc """
-  List all records in the trace buffer.
-  """
-  @spec list(GenServer.name()) :: [Record.t()]
-  def list(name \\ __MODULE__) do
-    GenServer.call(name, :list)
-  end
+  @doc "See `list/2`."
+  @spec list(GenServer.server() | [list_opt()]) :: [Record.t()]
+  def list(opts) when is_list(opts), do: list(__MODULE__, opts)
+  def list(name), do: list(name, [])
 
-  @doc """
-  Change the max size of the trace buffer from the default of #{@default_size}.
-  """
-  @spec resize(GenServer.name(), pos_integer()) :: :ok
-  def resize(name \\ __MODULE__, size) do
-    GenServer.call(name, {:resize, size})
-  end
+  @doc "See `list/2`."
+  @spec list() :: [Record.t()]
+  def list(), do: list(__MODULE__, [])
 
-  @doc """
-  Enable or disable logging of keepalive frames.
-  """
-  @spec record_keepalives(GenServer.name(), boolean()) :: :ok
-  def record_keepalives(name \\ __MODULE__, enabled? \\ true) do
-    GenServer.call(name, {:record_keepalives, enabled?})
-  end
+  @doc "Change the max size of the trace buffer from the default of #{@default_size}."
+  @spec resize(GenServer.server(), pos_integer()) :: :ok
+  def resize(name \\ __MODULE__, size), do: GenServer.call(name, {:resize, size})
+
+  @doc "Enable or disable logging of keepalive frames."
+  @spec record_keepalives(GenServer.server(), boolean()) :: :ok
+  def record_keepalives(name, enabled?), do: GenServer.call(name, {:record_keepalives, enabled?})
+
+  @doc "See `record_keepalives/2`."
+  @spec record_keepalives(boolean()) :: :ok
+  def record_keepalives(enabled? \\ true), do: record_keepalives(__MODULE__, enabled?)
 
   @impl GenServer
   def init(opts) do

--- a/lib/grizzly/transport.ex
+++ b/lib/grizzly/transport.ex
@@ -31,6 +31,7 @@ defmodule Grizzly.Transport do
   @type args() :: [
           ip_address: :inet.ip_address(),
           port: :inet.port_number(),
+          node_id: Grizzly.node_id(),
           transport: t()
         ]
 
@@ -155,9 +156,10 @@ defmodule Grizzly.Transport do
 
   @spec node_id(t()) :: {:ok, Grizzly.node_id()} | {:error, any()}
   def node_id(transport) do
-    case peername(transport) do
+    case assign(transport, :node_id) || peername(transport) do
       {:ok, {ip, _}} -> {:ok, ZIPGateway.node_id_from_ip(ip)}
       {:error, reason} -> {:error, reason}
+      node_id -> {:ok, node_id}
     end
   end
 

--- a/lib/grizzly/unsolicited_server/socket.ex
+++ b/lib/grizzly/unsolicited_server/socket.ex
@@ -34,6 +34,7 @@ defmodule Grizzly.UnsolicitedServer.Socket do
     with {:ok, accept_transport} <- Transport.accept(listening_transport),
          {:ok, transport} <- Transport.handshake(accept_transport) do
       {:ok, node_id} = Transport.node_id(transport)
+      transport = Transport.assigns(transport, :node_id, node_id)
       Logger.metadata(node_id: node_id)
 
       # Start a new listen socket to replace this one as this one is now bound

--- a/test/grizzly/trace/record_test.exs
+++ b/test/grizzly/trace/record_test.exs
@@ -9,12 +9,11 @@ defmodule Grizzly.Trace.RecordTest do
     {:ok, encapsulated_command} = SwitchBinarySet.new(target_value: :on)
     {:ok, zip_packet} = ZIPPacket.with_zwave_command(encapsulated_command, 0x01)
     binary = ZWave.to_binary(zip_packet)
-    record = Record.new(binary, src: "192.168.0.1", dest: "192.168.0.2")
+    record = Record.new(binary, src: :grizzly, dest: 1)
 
-    expected_string =
-      "#{Time.to_string(record.timestamp)} #{record.src} #{record.dest} 1   switch_binary_set <<37, 1, 255>>"
+    expected_string = "   G -> 1   1    switch_binary_set <<37, 1, 255>>"
 
-    assert expected_string == Record.to_string(record)
+    assert Record.to_string(record) =~ expected_string
   end
 
   test "decodes NodeAddDSKReport for S2 unauthenticated device without crashing" do
@@ -24,22 +23,22 @@ defmodule Grizzly.Trace.RecordTest do
       <<52, 19, 123, 0, 110, 113, 215, 70, 212, 90, 35, 31, 65, 21, 237, 23, 121, 95, 97, 122>>
 
     trace = %Grizzly.Trace.Record{
-      src: "[fd00:bbbb::1]:41230",
-      dest: "[fd00:aaaa::2]:41230",
+      src: 1,
+      dest: :grizzly,
       binary: zip_packet_binary <> command_binary,
       timestamp: ~T[21:11:41.766545]
     }
 
     expected_string =
-      "21:11:41.766545 [fd00:bbbb::1]:41230 [fd00:aaaa::2]:41230 42  node_add_dsk_report #{inspect(command_binary)}"
+      "21:11:41.766   1 -> G   42   node_add_dsk_report #{inspect(command_binary)}"
 
     assert expected_string == Record.to_string(trace)
   end
 
   test "encode NodeAddKeysSet without crashing" do
     trace = %Grizzly.Trace.Record{
-      src: "[fd00:aaaa::2]:41230",
-      dest: "[fd00:bbbb::1]:41230",
+      src: :grizzly,
+      dest: 1,
       binary: <<35, 2, 128, 80, 127, 0, 0, 52, 18, 127, 1, 1>>,
       timestamp: ~T[21:11:41.673225]
     }

--- a/test/grizzly/trace_test.exs
+++ b/test/grizzly/trace_test.exs
@@ -24,18 +24,22 @@ defmodule Grizzly.TraceTest do
     Trace.log(tracer, ZWave.to_binary(zip_packet), [])
 
     {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 2)
-    Trace.log(tracer, ZWave.to_binary(zip_packet), src: "src1", dest: "dest1")
+    Trace.log(tracer, ZWave.to_binary(zip_packet), src: :grizzly, dest: 5)
 
     {:ok, zip_packet} = ZIPPacket.with_zwave_command(cmd, 3)
-    Trace.log(tracer, ZWave.to_binary(zip_packet), src: "src2", dest: "dest2")
+    Trace.log(tracer, ZWave.to_binary(zip_packet), src: 6, dest: :grizzly)
 
     list = Trace.list(tracer)
     assert length(list) == 2
 
     assert [
-             %{binary: <<_::32, 2, _::binary>>, src: "src1", dest: "dest1"},
-             %{binary: <<_::32, 3, _::binary>>, src: "src2", dest: "dest2"}
+             %{binary: <<_::32, 2, _::binary>>, src: :grizzly, dest: 5},
+             %{binary: <<_::32, 3, _::binary>>, src: 6, dest: :grizzly}
            ] = list
+
+    list = Trace.list(tracer, node_id: 5)
+    assert length(list) == 1
+    assert [%{binary: <<_::32, 2, _::binary>>, src: :grizzly, dest: 5}] = list
   end
 
   @tag size: 1

--- a/test/grizzly/transports/dtls_test.exs
+++ b/test/grizzly/transports/dtls_test.exs
@@ -1,17 +1,20 @@
 defmodule Grizzly.Transports.DTLSTest do
   use ExUnit.Case, async: true
 
-  alias Grizzly.Transports.DTLS
+  alias Grizzly.Transport
   alias Grizzly.Transport.Response
+  alias Grizzly.Transports.DTLS
   alias Grizzly.ZWave.Command
 
   describe "parse response" do
     test "when Z/IP Packet" do
+      transport = %Transport{impl: DTLS, assigns: %{node_id: 5}}
+
       response =
         {:ssl, {:sslsocket, {:gen_udp, 123, :dtls_connection}, make_ref()},
          [0x23, 0x2, 0x80, 0x50, 0x1, 0x0, 0x0, 0x25, 0x2]}
 
-      {:ok, %Response{command: zip_packet}} = DTLS.parse_response(response, [])
+      {:ok, %Response{command: zip_packet}} = DTLS.parse_response(response, transport: transport)
 
       command = Command.param!(zip_packet, :command)
 
@@ -19,18 +22,22 @@ defmodule Grizzly.Transports.DTLSTest do
     end
 
     test "when binary response" do
+      transport = %Transport{impl: DTLS, assigns: %{node_id: 5}}
+
       response =
         {:ssl, {:sslsocket, {:gen_udp, 123, :dtls_connection}, make_ref()},
          [0x23, 0x2, 0x80, 0x50, 0x1, 0x0, 0x0, 0x25, 0x2]}
 
       expected_out = <<0x23, 0x2, 0x80, 0x50, 0x1, 0x0, 0x0, 0x25, 0x2>>
-      assert {:ok, expected_out} == DTLS.parse_response(response, raw: true)
+      assert {:ok, expected_out} == DTLS.parse_response(response, raw: true, transport: transport)
     end
 
     test "when socket closes" do
+      transport = %Transport{impl: DTLS, assigns: %{node_id: 5}}
+
       response = {:ssl_closed, {:sslsocket, {:gen_udp, 123, :dtls_connection}, [123]}}
 
-      assert {:ok, :connection_closed} == DTLS.parse_response(response, [])
+      assert {:ok, :connection_closed} == DTLS.parse_response(response, transport: transport)
     end
   end
 end

--- a/test/support/UDP.ex
+++ b/test/support/UDP.ex
@@ -35,7 +35,7 @@ defmodule GrizzlyTest.Transport.UDP do
   @impl Grizzly.Transport
   def send(transport, binary, _) do
     node_id = Transport.assign(transport, :node_id)
-    Grizzly.Trace.log(binary, src: "G", dest: "#{node_id}")
+    Grizzly.Trace.log(binary, src: :grizzly, dest: node_id)
 
     transport
     |> Transport.assign(:socket)
@@ -52,7 +52,7 @@ defmodule GrizzlyTest.Transport.UDP do
   def parse_response({:udp, _, ip, _port, binary}, opts) do
     transport = Keyword.fetch!(opts, :transport)
     node_id = Transport.assign(transport, :node_id)
-    Grizzly.Trace.log(binary, src: "#{node_id}", dest: "G")
+    Grizzly.Trace.log(binary, src: node_id, dest: :grizzly)
 
     if Keyword.get(opts, :raw, false) do
       {:ok, binary}


### PR DESCRIPTION
Having IPv6 addresses in traces is really annoying when all you care
about is the node id.
