### PR TITLE
Ignore extended CCs when parsing command class lists

### DIFF
--- a/lib/grizzly/zwave/command_classes.ex
+++ b/lib/grizzly/zwave/command_classes.ex
@@ -78,56 +78,77 @@ defmodule Grizzly.ZWave.CommandClasses do
   """
   @spec command_class_list_from_binary(binary()) :: [command_class_list()]
   def command_class_list_from_binary(binary) do
-    binary_list = :erlang.binary_to_list(binary)
-
-    {_, command_classes} =
-      Enum.reduce(
-        binary_list,
-        {:non_secure_supported,
-         [
-           non_secure_supported: [],
-           non_secure_controlled: [],
-           secure_supported: [],
-           secure_controlled: []
-         ]},
-        fn
-          0xEF, {:non_secure_supported, command_classes} ->
-            {:non_secure_controlled, command_classes}
-
-          0xF1, {_, command_classes} ->
-            {:secure_supported, command_classes}
-
-          0x00, {_, command_classes} ->
-            {:secure_supported, command_classes}
-
-          0xEF, {:secure_supported, command_classes} ->
-            {:secure_controlled, command_classes}
-
-          command_class_byte, {security, command_classes}
-          when command_class_byte not in [0xF1, 0xEF, 0x00] ->
-            case from_byte(command_class_byte) do
-              {:ok, command_class} ->
-                {security,
-                 Keyword.update(command_classes, security, [], &(&1 ++ [command_class]))}
-
-              {:error, :unsupported_command_class} ->
-                # Skip unsupported command classes
-                {security, command_classes}
-            end
-        end
-      )
-
-    command_classes
+    binary
+    |> :erlang.binary_to_list()
+    |> group_extended_command_classes()
+    |> parse_and_categorize_command_classes()
   end
 
-  def maybe_concat_command_classes(binary, _, <<>>), do: binary
+  defp group_extended_command_classes(command_class_id_list) do
+    command_class_id_list
+    |> Enum.reduce({nil, []}, fn
+      # Extended command classes start with 0xF1..0xFF
+      byte, {nil, acc} when byte in 0xF1..0xFF ->
+        {byte, acc}
 
-  def maybe_concat_command_classes(binary, :non_secure_controlled, ccs_bin),
+      # Second byte of an extended command class
+      byte, {prev_byte, acc} when prev_byte in 0xF1..0xFF ->
+        {nil, [prev_byte * 2 ** 8 + byte | acc]}
+
+      # All other command classes
+      byte, {nil, acc} ->
+        {nil, [byte | acc]}
+    end)
+    |> elem(1)
+    |> Enum.reverse()
+  end
+
+  defp parse_and_categorize_command_classes(command_class_id_list) do
+    command_class_id_list
+    |> Enum.reduce(
+      {:non_secure_supported,
+       [
+         non_secure_supported: [],
+         non_secure_controlled: [],
+         secure_supported: [],
+         secure_controlled: []
+       ]},
+      fn
+        0xEF, {:non_secure_supported, command_classes} ->
+          {:non_secure_controlled, command_classes}
+
+        0xF100, {_, command_classes} ->
+          {:secure_supported, command_classes}
+
+        0xEF, {:secure_supported, command_classes} ->
+          {:secure_controlled, command_classes}
+
+        # Skip extended command classes
+        command_class_id, acc when command_class_id > 0xFF ->
+          acc
+
+        command_class_id, {security, command_classes} ->
+          case from_byte(command_class_id) do
+            {:ok, command_class} ->
+              {security, Keyword.update(command_classes, security, [], &(&1 ++ [command_class]))}
+
+            {:error, :unsupported_command_class} ->
+              # Skip unsupported command classes
+              {security, command_classes}
+          end
+      end
+    )
+    |> elem(1)
+  end
+
+  defp maybe_concat_command_classes(binary, _, <<>>), do: binary
+
+  defp maybe_concat_command_classes(binary, :non_secure_controlled, ccs_bin),
     do: binary <> <<0xEF, ccs_bin::binary>>
 
-  def maybe_concat_command_classes(binary, :secure_supported, ccs_bin),
+  defp maybe_concat_command_classes(binary, :secure_supported, ccs_bin),
     do: binary <> <<0xF1, 0x00, ccs_bin::binary>>
 
-  def maybe_concat_command_classes(binary, :secure_controlled, ccs_bin),
+  defp maybe_concat_command_classes(binary, :secure_controlled, ccs_bin),
     do: binary <> <<0xEF, ccs_bin::binary>>
 end

--- a/test/grizzly/zwave/command_classes_test.exs
+++ b/test/grizzly/zwave/command_classes_test.exs
@@ -36,6 +36,16 @@ defmodule Grizzly.ZWave.CommandClassesTest do
 
       binary = <<0x20, 0x32, 0xEF, 0xCC>>
       assert expected_command_classes == CommandClasses.command_class_list_from_binary(binary)
+
+      expected_command_classes = [
+        non_secure_supported: [:basic, :meter],
+        non_secure_controlled: [],
+        secure_supported: [],
+        secure_controlled: []
+      ]
+
+      binary = <<0x20, 0x32, 0xEF, 0xCC, 0xFA, 0x01, 0xF8, 0x90>>
+      assert expected_command_classes == CommandClasses.command_class_list_from_binary(binary)
     end
   end
 end


### PR DESCRIPTION
Ref: SRH-1571
