### PR TITLE
Continue inclusion started by an inclusion controller

### DIFF
--- a/lib/grizzly/inclusions.ex
+++ b/lib/grizzly/inclusions.ex
@@ -168,7 +168,7 @@ defmodule Grizzly.Inclusions do
 
   alias Grizzly.Inclusions.StatusServer
   alias Grizzly.InclusionServer
-  alias Grizzly.ZWave.{DSK, Security}
+  alias Grizzly.ZWave.{Command, DSK, Security}
 
   @typedoc """
   Status of the inclusion server
@@ -305,5 +305,13 @@ defmodule Grizzly.Inclusions do
   @spec inclusion_running?() :: boolean()
   def inclusion_running?() do
     StatusServer.get() != :idle
+  end
+
+  @doc """
+  Continues security bootstrapping for a node added by an inclusion controller.
+  """
+  @spec continue_inclusion(Command.t()) :: :ok
+  def continue_inclusion(command) do
+    InclusionServer.continue_inclusion(command)
   end
 end

--- a/lib/grizzly/supervisor.ex
+++ b/lib/grizzly/supervisor.ex
@@ -220,6 +220,7 @@ defmodule Grizzly.Supervisor do
          port: port,
          num_acceptors: 10,
          handler_module: Grizzly.UnsolicitedServer.ConnectionHandler,
+         handler_options: [inclusion_handler: options.inclusion_handler],
          transport_module: Grizzly.UnsolicitedServer.DTLSTransport,
          transport_options: [ifaddr: ip],
          supervisor_options: [name: Grizzly.UnsolicitedServer]


### PR DESCRIPTION
When an inclusion controller adds a new node, Z/IP Gateway will inform
us via the unsolicited destination. The rest of the inclusion process
remains the same.

In order for this to work, the `:inclusion_handler` option must be set
when starting `Grizzly.Supervisor`. Additionally, Z/IP Gateway must be
modified so that it doesn't compare port numbers for network management
commands. Perhaps one day, we'll do some refactoring to make it work the
"right way" (i.e. sending the inclusion commands back via the
unsolicited server connection).

SRH-1572