### PR TITLE
Support finding all endpoints with Multi Channel Endpoint Find

### DIFF
--- a/lib/grizzly/zwave/commands/multi_channel_endpoint_find.ex
+++ b/lib/grizzly/zwave/commands/multi_channel_endpoint_find.ex
@@ -13,12 +13,13 @@ defmodule Grizzly.ZWave.Commands.MultiChannelEndpointFind do
 
   @behaviour Grizzly.ZWave.Command
 
-  alias Grizzly.ZWave.{Command, DeviceClasses}
+  alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.CommandClasses.MultiChannel
+  alias Grizzly.ZWave.DeviceClasses, as: DC
 
   @type param ::
-          {:generic_device_class, DeviceClasses.generic_device_class()}
-          | {:specific_device_class, DeviceClasses.specific_device_class()}
+          {:generic_device_class, DC.generic_device_class() | :all}
+          | {:specific_device_class, DC.specific_device_class() | :all}
 
   @impl Grizzly.ZWave.Command
   @spec new([param()]) :: {:ok, Command.t()}
@@ -36,33 +37,42 @@ defmodule Grizzly.ZWave.Commands.MultiChannelEndpointFind do
 
   @impl Grizzly.ZWave.Command
   def encode_params(command) do
-    generic_device_class = Command.param!(command, :generic_device_class)
-    generic_device_class_byte = DeviceClasses.generic_device_class_to_byte(generic_device_class)
+    generic_class = Command.param(command, :generic_device_class, :all)
+    generic_class_byte = encode_generic_class(generic_class)
 
-    specific_device_class_byte =
-      DeviceClasses.specific_device_class_to_byte(
-        generic_device_class,
-        Command.param!(command, :specific_device_class)
-      )
+    specific_class = Command.param(command, :specific_device_class, :all)
+    specific_class_byte = encode_specific_class(generic_class, specific_class)
 
-    <<generic_device_class_byte, specific_device_class_byte>>
+    <<generic_class_byte, specific_class_byte>>
   end
 
   @impl Grizzly.ZWave.Command
-  def decode_params(<<generic_device_class_byte, specific_device_class_byte>>) do
-    {:ok, generic_device_class} =
-      DeviceClasses.generic_device_class_from_byte(generic_device_class_byte)
-
-    {:ok, specific_device_class} =
-      DeviceClasses.specific_device_class_from_byte(
-        generic_device_class,
-        specific_device_class_byte
-      )
+  def decode_params(<<generic_class_byte, specific_class_byte>>) do
+    generic_class = decode_generic_class(generic_class_byte)
+    specific_class = decode_specific_class(generic_class, specific_class_byte)
 
     {:ok,
      [
-       generic_device_class: generic_device_class,
-       specific_device_class: specific_device_class
+       generic_device_class: generic_class,
+       specific_device_class: specific_class
      ]}
   end
+
+  @spec encode_generic_class(atom() | 0..255) :: 0..255
+  defp encode_generic_class(:all), do: 0xFF
+  defp encode_generic_class(g) when is_atom(g), do: DC.generic_device_class_to_byte(g)
+  defp encode_generic_class(g) when g in 0..255, do: g
+
+  @spec decode_generic_class(0..255) :: atom()
+  defp decode_generic_class(0xFF), do: :all
+  defp decode_generic_class(g), do: elem(DC.generic_device_class_from_byte(g), 1)
+
+  @spec encode_specific_class(atom(), atom() | 0..255) :: 0..255
+  defp encode_specific_class(_g, :all), do: 0xFF
+  defp encode_specific_class(g, s) when is_atom(s), do: DC.specific_device_class_to_byte(g, s)
+  defp encode_specific_class(_g, s) when s in 0..255, do: s
+
+  @spec decode_specific_class(atom(), 0..255) :: atom()
+  defp decode_specific_class(_g, 0xFF), do: :all
+  defp decode_specific_class(g, s), do: elem(DC.specific_device_class_from_byte(g, s), 1)
 end

--- a/test/grizzly/zwave/commands/multi_channel_endpoint_find_test.exs
+++ b/test/grizzly/zwave/commands/multi_channel_endpoint_find_test.exs
@@ -21,6 +21,19 @@ defmodule Grizzly.ZWave.Commands.MultiChannelEndpointFindTest do
     {:ok, command} = MultiChannelEndpointFind.new(params)
     expected_binary = <<0x10, 0x04>>
     assert expected_binary == MultiChannelEndpointFind.encode_params(command)
+
+    params = [
+      generic_device_class: :all,
+      specific_device_class: :all
+    ]
+
+    {:ok, command} = MultiChannelEndpointFind.new(params)
+    expected_binary = <<0xFF, 0xFF>>
+    assert expected_binary == MultiChannelEndpointFind.encode_params(command)
+
+    {:ok, command} = MultiChannelEndpointFind.new([])
+    expected_binary = <<0xFF, 0xFF>>
+    assert expected_binary == MultiChannelEndpointFind.encode_params(command)
   end
 
   test "decodes params correctly" do


### PR DESCRIPTION
The special case device classes of `:all` and `:all` will return all
endpoints regardless of device class.
