### PR TITLE
Add util to get NWI home id from DSK

### DIFF
--- a/lib/grizzly/zwave/dsk.ex
+++ b/lib/grizzly/zwave/dsk.ex
@@ -221,6 +221,19 @@ defmodule Grizzly.ZWave.DSK do
     }
   end
 
+  @doc """
+  Extracts the NWI Home ID (the Home ID used by a SmartStart device when it is
+  not yet included in a network) from the DSK.
+
+  The NWI Home ID is calculated by taking bytes 9-12 of the DSK. Given this value,
+  the two most significant bits are then set and the least significant bit is cleared.
+  """
+  @spec nwi_home_id(t()) :: non_neg_integer()
+  def nwi_home_id(%__MODULE__{raw: <<_::8-bytes, _::2, dsk_bits::29, _::1, _::binary>>}) do
+    <<nwi_home_id::32>> = <<1::1, 1::1, dsk_bits::29, 0::1>>
+    nwi_home_id
+  end
+
   defimpl String.Chars do
     @moduledoc false
     defdelegate to_string(v), to: Grizzly.ZWave.DSK

--- a/test/grizzly/zwave/dsk_test.exs
+++ b/test/grizzly/zwave/dsk_test.exs
@@ -94,4 +94,12 @@ defmodule Grizzly.ZWave.DSKTest do
   test "inspecting a DSK" do
     assert inspect(@dsk_struct) == "#DSK<" <> @dsk_string <> ">"
   end
+
+  test "nwi_home_id/1" do
+    dsk = DSK.parse!("65319-38004-24661-25491-29723-39413-61677-10659")
+    assert 0xF41B99F4 == DSK.nwi_home_id(dsk)
+
+    dsk = DSK.parse!("11111-48612-46962-61307-25830-37127-62771-03285")
+    assert 0xE4E69106 == DSK.nwi_home_id(dsk)
+  end
 end


### PR DESCRIPTION
The NWI Home ID is the Home ID used by a SmartStart node when it is not
yet included in a network. It is defined as bytes 9-12 of the DSK with
the two most significant bits set and the least significant bit cleared.
