### PR TITLE
Use atoms for scale in Sensor Multilevel Get

### DIFF
--- a/lib/grizzly/zwave/commands/sensor_multilevel_get.ex
+++ b/lib/grizzly/zwave/commands/sensor_multilevel_get.ex
@@ -40,7 +40,8 @@ defmodule Grizzly.ZWave.Commands.SensorMultilevelGet do
       sensor_type ->
         scale = Command.param!(command, :scale)
         sensor_type_byte = SensorMultilevel.encode_sensor_type(sensor_type)
-        <<sensor_type_byte, 0x00::3, scale::2, 0x00::3>>
+        scale_byte = SensorMultilevel.encode_sensor_scale(sensor_type, scale)
+        <<sensor_type_byte, 0x00::3, scale_byte::2, 0x00::3>>
     end
   end
 
@@ -54,7 +55,11 @@ defmodule Grizzly.ZWave.Commands.SensorMultilevelGet do
   def decode_params(<<sensor_type_byte, _::3, scale::2, _::3>>) do
     case SensorMultilevel.decode_sensor_type(sensor_type_byte) do
       {:ok, sensor_type} ->
-        {:ok, [sensor_type: sensor_type, scale: scale]}
+        {:ok,
+         [
+           sensor_type: sensor_type,
+           scale: SensorMultilevel.decode_sensor_scale(sensor_type, scale)
+         ]}
 
       :error ->
         {:error,

--- a/test/grizzly/zwave/commands/sensor_multilevel_get_test.exs
+++ b/test/grizzly/zwave/commands/sensor_multilevel_get_test.exs
@@ -9,7 +9,7 @@ defmodule Grizzly.ZWave.Commands.SensorMultilevelGetTest do
   end
 
   test "creates the v5 command and validates params" do
-    params = [sensor_type: :temperature, scale: 2]
+    params = [sensor_type: :temperature, scale: :f]
     {:ok, _command} = SensorMultilevelGet.new(params)
   end
 
@@ -21,9 +21,9 @@ defmodule Grizzly.ZWave.Commands.SensorMultilevelGetTest do
   end
 
   test "encodes v5 params correctly" do
-    params = [sensor_type: :temperature, scale: 2]
+    params = [sensor_type: :temperature, scale: :f]
     {:ok, command} = SensorMultilevelGet.new(params)
-    expected_binary = <<0x01, 0x00::3, 0x02::2, 0x00::3>>
+    expected_binary = <<0x01, 0x00::3, 0x01::2, 0x00::3>>
     assert expected_binary == SensorMultilevelGet.encode_params(command)
   end
 
@@ -33,9 +33,14 @@ defmodule Grizzly.ZWave.Commands.SensorMultilevelGetTest do
   end
 
   test "decodes v5 params correctly" do
+    binary_params = <<0x01, 0x00::3, 0x01::2, 0x00::3>>
+    {:ok, params} = SensorMultilevelGet.decode_params(binary_params)
+    assert Keyword.get(params, :sensor_type) == :temperature
+    assert Keyword.get(params, :scale) == :f
+
     binary_params = <<0x01, 0x00::3, 0x02::2, 0x00::3>>
     {:ok, params} = SensorMultilevelGet.decode_params(binary_params)
     assert Keyword.get(params, :sensor_type) == :temperature
-    assert Keyword.get(params, :scale) == 2
+    assert Keyword.get(params, :scale) == :unknown
   end
 end


### PR DESCRIPTION
Aligns with the changes to Sensor Multilevel Report in #995.
