### PR TITLE
Support alarm reports for Alarm CC v1

### DIFF
--- a/lib/grizzly/zwave/notifications.ex
+++ b/lib/grizzly/zwave/notifications.ex
@@ -387,6 +387,7 @@ defmodule Grizzly.ZWave.Notifications do
   def type_from_byte(byte) do
     case Map.fetch(@type_from_byte, byte) do
       {:ok, type} -> {:ok, type}
+      # There is no decoding for Alarm CC V1 - the byte is the type
       :error -> {:error, :invalid_type_byte}
     end
   end
@@ -399,6 +400,7 @@ defmodule Grizzly.ZWave.Notifications do
     with v when not is_nil(v) <- get_in(@event_from_byte, [type, byte]) do
       {:ok, v}
     else
+      # Alarm reports might not provide a defined event (e.g.  event byte is 0)
       _ -> {:error, :invalid_event_byte}
     end
   end

--- a/test/grizzly/zwave/commands/alarm_report_test.exs
+++ b/test/grizzly/zwave/commands/alarm_report_test.exs
@@ -162,6 +162,19 @@ defmodule Grizzly.ZWave.Commands.AlarmReportTest do
              ]
     end
 
+    test "v2 with undefined zwave_event and zwave_type" do
+      binary = <<0x10, 0x25, 0x00, 0x00, 0xB9, 0x9B, 0x04, 0x63, 0x03, 0xFB, 0x01>>
+
+      {:ok, params} = AlarmReport.decode_params(binary)
+
+      assert Keyword.fetch!(params, :type) == 0x10
+      assert Keyword.fetch!(params, :level) == 0x25
+      assert Keyword.fetch!(params, :zwave_status) == :disabled
+      assert Keyword.fetch!(params, :zensor_net_node_id) == 0x00
+      assert Keyword.fetch!(params, :zwave_type) == 0xB9
+      assert Keyword.fetch!(params, :zwave_event) == 0x9B
+    end
+
     test "v8 with sequence number" do
       binary =
         <<0x10, 0x25, 0x00, 0x00, 0x06, 0x06, 0x01::1, 0x00::2, 0x04::5, 0x63, 0x03, 0xFB, 0x01,


### PR DESCRIPTION
Allow for alarm types and events to be undecodable

[SRH-1583]

[SRH-1583]: https://smartrent.atlassian.net/browse/SRH-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ