### PR TITLE
Handle alarm v1 support flag not 0 in alarm_type_supported_report

### DIFF
--- a/lib/grizzly/zwave/commands/alarm_type_supported_report.ex
+++ b/lib/grizzly/zwave/commands/alarm_type_supported_report.ex
@@ -39,7 +39,9 @@ defmodule Grizzly.ZWave.Commands.AlarmTypeSupportedReport do
 
   @impl Grizzly.ZWave.Command
   @spec decode_params(binary()) :: {:ok, [param()]} | {:error, DecodeError.t()}
-  def decode_params(<<0x00::3, number_of_masks::5, bitmasks::binary-size(number_of_masks)>>) do
+  def decode_params(
+        <<_v1_support::3, number_of_masks::5, bitmasks::binary-size(number_of_masks)>>
+      ) do
     with {:ok, types} <- decode_alarm_types(bitmasks) do
       {:ok, [types: types]}
     else

--- a/test/grizzly/zwave/commands/alarm_type_supported_report_test.exs
+++ b/test/grizzly/zwave/commands/alarm_type_supported_report_test.exs
@@ -22,4 +22,12 @@ defmodule Grizzly.ZWave.Commands.AlarmTypeSupportedReportTest do
     assert Enum.sort([:smoke_alarm, :home_security, :siren, :gas_alarm]) ==
              Enum.sort(Keyword.get(params, :types))
   end
+
+  test "decodes params correctly with alarm v1 support" do
+    binary_params = <<0x01::3, 0x03::5, 0b10000010, 0b01000000, 0b00000100>>
+    {:ok, params} = AlarmTypeSupportedReport.decode_params(binary_params)
+
+    assert Enum.sort([:smoke_alarm, :home_security, :siren, :gas_alarm]) ==
+             Enum.sort(Keyword.get(params, :types))
+  end
 end


### PR DESCRIPTION
Decoding of :alarm_type_supported_type_report fails for devices also implementing v1 of alarm types

The alarm_v1 flag can be 0 or 1. The current implementation  expects only 0.

```
0 = the device implements only Notification CC V2 (or newer) Notification Type(s).

1 = the device implements Notification CC V2 Notification Types as well as proprietary Alarm CC V1 Alarm Types and Alarm Levels.
```