### PR TITLE
Properly handle multi channel association commands

### DIFF
--- a/lib/grizzly.ex
+++ b/lib/grizzly.ex
@@ -134,6 +134,7 @@ defmodule Grizzly do
           | {:status_updates?, boolean()}
           | {:mode, connection_mode()}
           | {:more_info, boolean()}
+          | {:destination, ZWave.endpoint_id()}
 
   @type command :: atom()
 

--- a/lib/grizzly/associations.ex
+++ b/lib/grizzly/associations.ex
@@ -28,7 +28,7 @@ defmodule Grizzly.Associations do
 
     @type t() :: %__MODULE__{
             grouping_id: byte(),
-            node_ids: [ZWave.node_id()]
+            node_ids: [ZWave.node_id() | {ZWave.node_id(), ZWave.endpoint_id()}]
           }
 
     defstruct grouping_id: nil, node_ids: []

--- a/lib/grizzly/network.ex
+++ b/lib/grizzly/network.ex
@@ -327,7 +327,15 @@ defmodule Grizzly.Network do
 
     with true <- Keyword.get(opts, :notify, true),
          %Associations.Association{node_ids: nodes} <- Associations.get(server, 1) do
-      Enum.each(nodes, &Grizzly.send_command(&1, :device_reset_locally_notification))
+      Enum.each(nodes, fn
+        {node_id, endpoint} ->
+          Grizzly.send_command(node_id, :device_reset_locally_notification, [],
+            destination: endpoint
+          )
+
+        node_id ->
+          Grizzly.send_command(node_id, :device_reset_locally_notification)
+      end)
     else
       _ -> :ok
     end

--- a/lib/grizzly/zwave.ex
+++ b/lib/grizzly/zwave.ex
@@ -8,6 +8,7 @@ defmodule Grizzly.ZWave do
   @type seq_number :: non_neg_integer()
 
   @type node_id :: non_neg_integer()
+  @type endpoint_id :: 0..127
 
   @spec from_binary(binary()) :: {:ok, Command.t()} | {:error, DecodeError.t()}
   def from_binary(binary) do

--- a/test/grizzly/associations_test.exs
+++ b/test/grizzly/associations_test.exs
@@ -33,8 +33,10 @@ defmodule Grizzly.AssociationsTest do
   end
 
   test "get all associations", %{server: server} do
-    :ok = Associations.save(server, 1, [1, 2])
-    assert [%Association{node_ids: [1, 2], grouping_id: 1}] == Associations.get_all(server)
+    :ok = Associations.save(server, 1, [1, 2, {3, 1}])
+
+    assert [%Association{node_ids: [1, 2, {3, 1}], grouping_id: 1}] ==
+             Associations.get_all(server)
   end
 
   @tag max_per_group: 2

--- a/test/grizzly/unsolicited_server/response_handler_test.exs
+++ b/test/grizzly/unsolicited_server/response_handler_test.exs
@@ -182,14 +182,20 @@ defmodule Grizzly.UnsolicitedServer.ResponseHandlerTest do
     end
 
     test "set", %{multi_channel_server: server} do
-      {:ok, mcas} = MultiChannelAssociationSet.new(grouping_identifier: 1, nodes: [1, 2, 3, 4])
+      {:ok, mcas} =
+        MultiChannelAssociationSet.new(
+          grouping_identifier: 1,
+          nodes: [1, 2, 3, 4],
+          node_endpoints: [%{node: 5, endpoint: 6, bit_address: 0}]
+        )
 
       assert [:ack] =
                ResponseHandler.handle_response(make_response(mcas), associations_server: server)
     end
 
     test "remove", %{multi_channel_server: server} do
-      {:ok, mcar} = MultiChannelAssociationRemove.new(grouping_identifier: 1, nodes: [])
+      {:ok, mcar} =
+        MultiChannelAssociationRemove.new(grouping_identifier: 1, nodes: [], node_endpoints: [])
 
       assert [:ack] =
                ResponseHandler.handle_response(make_response(mcar), associations_server: server)


### PR DESCRIPTION
We weren't properly handling Multi Channel Association Set for endpoint
associations. This fixes a couple of certification test cases.
