### PR TITLE
Allow more time for the default_set (zwave reset) command to complete

### DIFF
--- a/lib/grizzly/network.ex
+++ b/lib/grizzly/network.ex
@@ -99,7 +99,9 @@ defmodule Grizzly.Network do
     seq_number = SeqNumber.get_and_inc()
     node_id = node_id_from_opts(opts)
 
-    case Grizzly.send_command(node_id, :default_set, [seq_number: seq_number], timeout: 10_000) do
+    # Changed timeout from 10s because doing a Z-Wave reset can take a few seconds longer than 10s.
+    # 60s is more than enough time.
+    case Grizzly.send_command(node_id, :default_set, [seq_number: seq_number], timeout: 60_000) do
       {:ok, %Report{type: :command, status: :complete}} = response ->
         _ = Associations.delete_all(Keyword.get(opts, :associations_server, Grizzly.Associations))
         response


### PR DESCRIPTION
The timeout was set at 10s which could cause timeouts. It is now set to 60s.

 [SRH-1792]

[SRH-1792]: https://smartrent.atlassian.net/browse/SRH-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ