### PR TITLE
Use seconds or :default to give the duration when setting a switch

### DIFF
--- a/lib/grizzly/zwave/command_classes/switch_support.ex
+++ b/lib/grizzly/zwave/command_classes/switch_support.ex
@@ -1,0 +1,43 @@
+defmodule Grizzly.ZWave.CommandClasses.SwitchSupport do
+  @moduledoc """
+  Support for Switch Binary and Switch Multilevel Command Classes
+  """
+
+  alias Grizzly.ZWave.DecodeError
+
+  # Duration in seconds, or the manufacturer's default
+  @type duration :: :default | 0..7620
+
+  # Duration encoding
+  #   * 0 -> instantly
+  #   * 1..127 -> seconds
+  #   * 128..254 -> minutes + 127
+  #   * 255 -> factory default (option v2)
+  @doc """
+  Encode a duration into a byte according to the Z-Wave specs
+  """
+  @spec duration_to_byte(duration()) :: byte()
+  def duration_to_byte(:default), do: 255
+  def duration_to_byte(seconds) when seconds in 0..127, do: seconds
+
+  def duration_to_byte(seconds) when seconds in 128..7620 do
+    minutes = div(seconds, 60)
+    127 + minutes
+  end
+
+  # Force duration values within supported bounds
+  def duration_to_byte(seconds) when seconds > 7620, do: 254
+  def duration_to_byte(seconds) when seconds < 0, do: 0
+
+  @doc """
+  Decode a duration from a byte according to the Z-Wave specs
+  """
+  @spec duration_from_byte(byte()) ::
+          {:error, DecodeError.t()} | {:ok, duration()}
+  def duration_from_byte(255), do: {:ok, :default}
+  def duration_from_byte(byte) when byte in 0..127, do: {:ok, byte}
+  def duration_from_byte(byte) when byte in 128..254, do: {:ok, (byte - 127) * 60}
+
+  def duration_from_byte(byte),
+    do: {:error, %DecodeError{value: byte, param: :duration, command: :switch_multilevel_report}}
+end

--- a/test/grizzly/zwave/commands/switch_binary_report_test.exs
+++ b/test/grizzly/zwave/commands/switch_binary_report_test.exs
@@ -23,6 +23,23 @@ defmodule Grizzly.ZWave.Commands.SwitchBinaryReportTest do
       assert <<0x25, 0x03, 0xFE>> == ZWave.to_binary(report)
     end
 
+    test "encodes duration param correctly" do
+      params = [current_value: :on, target_value: :off, duration: 10]
+      {:ok, command} = SwitchBinaryReport.new(params)
+      expected_binary = <<0xFF, 0x00, 0x0A>>
+      assert expected_binary == SwitchBinaryReport.encode_params(command)
+
+      params = [current_value: :on, target_value: :off, duration: :default]
+      {:ok, command} = SwitchBinaryReport.new(params)
+      expected_binary = <<0xFF, 0x00, 0xFF>>
+      assert expected_binary == SwitchBinaryReport.encode_params(command)
+
+      params = [current_value: :on, target_value: :off, duration: 180]
+      {:ok, command} = SwitchBinaryReport.new(params)
+      expected_binary = <<0xFF, 0x00, 0x82>>
+      assert expected_binary == SwitchBinaryReport.encode_params(command)
+    end
+
     test "decodes correctly on" do
       binary = <<0x25, 0x03, 0xFF>>
       expected_report = SwitchBinaryReport.new(target_value: :on)

--- a/test/grizzly/zwave/commands/switch_multilevel_report_test.exs
+++ b/test/grizzly/zwave/commands/switch_multilevel_report_test.exs
@@ -20,6 +20,16 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelReportTest do
     {:ok, command} = SwitchMultilevelReport.new(params)
     expected_binary = <<0x63, 0x0A>>
     assert expected_binary == SwitchMultilevelReport.encode_params(command)
+
+    params = [value: 99, duration: :default]
+    {:ok, command} = SwitchMultilevelReport.new(params)
+    expected_binary = <<0x63, 0xFF>>
+    assert expected_binary == SwitchMultilevelReport.encode_params(command)
+
+    params = [value: 99, duration: 180]
+    {:ok, command} = SwitchMultilevelReport.new(params)
+    expected_binary = <<0x63, 0x82>>
+    assert expected_binary == SwitchMultilevelReport.encode_params(command)
   end
 
   test "decodes v1 params correctly" do
@@ -33,6 +43,16 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelReportTest do
     {:ok, params} = SwitchMultilevelReport.decode_params(binary_params)
     assert Keyword.get(params, :value) == 0x32
     assert Keyword.get(params, :duration) == 0x0A
+
+    binary_params = <<0x32, 0xFF>>
+    {:ok, params} = SwitchMultilevelReport.decode_params(binary_params)
+    assert Keyword.get(params, :value) == 0x32
+    assert Keyword.get(params, :duration) == :default
+
+    binary_params = <<0x32, 0x81>>
+    {:ok, params} = SwitchMultilevelReport.decode_params(binary_params)
+    assert Keyword.get(params, :value) == 0x32
+    assert Keyword.get(params, :duration) == 120
   end
 
   test "decodes v4 params correctly" do

--- a/test/grizzly/zwave/commands/switch_multilevel_set_test.exs
+++ b/test/grizzly/zwave/commands/switch_multilevel_set_test.exs
@@ -20,6 +20,16 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelSetTest do
     {:ok, command} = SwitchMultilevelSet.new(params)
     expected_binary = <<0x63, 0x0A>>
     assert expected_binary == SwitchMultilevelSet.encode_params(command)
+
+    params = [target_value: 99, duration: :default]
+    {:ok, command} = SwitchMultilevelSet.new(params)
+    expected_binary = <<0x63, 0xFF>>
+    assert expected_binary == SwitchMultilevelSet.encode_params(command)
+
+    params = [target_value: 99, duration: 180]
+    {:ok, command} = SwitchMultilevelSet.new(params)
+    expected_binary = <<0x63, 0x82>>
+    assert expected_binary == SwitchMultilevelSet.encode_params(command)
   end
 
   test "encodes v2 params correctly - accept level 100" do
@@ -40,5 +50,15 @@ defmodule Grizzly.ZWave.Commands.SwitchMultilevelSetTest do
     {:ok, params} = SwitchMultilevelSet.decode_params(binary_params)
     assert Keyword.get(params, :target_value) == 0x32
     assert Keyword.get(params, :duration) == 0x0A
+
+    binary_params = <<0x32, 0xFF>>
+    {:ok, params} = SwitchMultilevelSet.decode_params(binary_params)
+    assert Keyword.get(params, :target_value) == 0x32
+    assert Keyword.get(params, :duration) == :default
+
+    binary_params = <<0x32, 0x81>>
+    {:ok, params} = SwitchMultilevelSet.decode_params(binary_params)
+    assert Keyword.get(params, :target_value) == 0x32
+    assert Keyword.get(params, :duration) == 120
   end
 end


### PR DESCRIPTION
Whether a binary or multilevel switch,
instead of passing the duration pre-encoded.

Required for certification

[SRH-1797]

[SRH-1797]: https://smartrent.atlassian.net/browse/SRH-1797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ