### PR TITLE
Rename humidity control setpoint types

### DIFF
--- a/lib/grizzly/zwave/command_classes/humidity_control_setpoint.ex
+++ b/lib/grizzly/zwave/command_classes/humidity_control_setpoint.ex
@@ -7,7 +7,7 @@ defmodule Grizzly.ZWave.CommandClasses.HumidityControlSetpoint do
 
   require Logger
 
-  @type type :: :humidifier | :dehumidifier | :auto
+  @type type :: :humidify | :dehumidify | :auto
   @type scale :: :percentage | :absolute
 
   @impl Grizzly.ZWave.CommandClass
@@ -16,14 +16,14 @@ defmodule Grizzly.ZWave.CommandClasses.HumidityControlSetpoint do
   @impl Grizzly.ZWave.CommandClass
   def name(), do: :humidity_control_setpoint
 
-  @spec encode_type(:auto | :dehumidifier | :humidifier) :: 1 | 2 | 3
-  def encode_type(:humidifier), do: 0x01
-  def encode_type(:dehumidifier), do: 0x02
+  @spec encode_type(type()) :: 1 | 2 | 3
+  def encode_type(:humidify), do: 0x01
+  def encode_type(:dehumidify), do: 0x02
   def encode_type(:auto), do: 0x03
 
-  @spec decode_type(byte()) :: :auto | :dehumidifier | :humidifier | :unknown
-  def decode_type(0x01), do: :humidifier
-  def decode_type(0x02), do: :dehumidifier
+  @spec decode_type(byte()) :: type() | :unknown
+  def decode_type(0x01), do: :humidify
+  def decode_type(0x02), do: :dehumidify
   def decode_type(0x03), do: :auto
 
   def decode_type(v) do
@@ -31,11 +31,11 @@ defmodule Grizzly.ZWave.CommandClasses.HumidityControlSetpoint do
     :unknown
   end
 
-  @spec encode_scale(:absolute | :percentage) :: 0 | 1
+  @spec encode_scale(scale()) :: 0 | 1
   def encode_scale(:percentage), do: 0x00
   def encode_scale(:absolute), do: 0x01
 
-  @spec decode_scale(byte()) :: :absolute | :percentage | :unknown
+  @spec decode_scale(byte()) :: scale() | :unknown
   def decode_scale(0x00), do: :percentage
   def decode_scale(0x01), do: :absolute
 

--- a/test/grizzly/zwave/commands/humidity_control_setpoint_capabilities_get_test.exs
+++ b/test/grizzly/zwave/commands/humidity_control_setpoint_capabilities_get_test.exs
@@ -4,7 +4,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointCapabilitiesGetTest do
   alias Grizzly.ZWave.Commands.HumidityControlSetpointCapabilitiesGet
 
   test "encode/1 correctly encodes command" do
-    {:ok, command} = HumidityControlSetpointCapabilitiesGet.new(setpoint_type: :humidifier)
+    {:ok, command} = HumidityControlSetpointCapabilitiesGet.new(setpoint_type: :humidify)
     assert <<1>> == HumidityControlSetpointCapabilitiesGet.encode_params(command)
 
     {:ok, command} = HumidityControlSetpointCapabilitiesGet.new(setpoint_type: :auto)
@@ -12,7 +12,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointCapabilitiesGetTest do
   end
 
   test "decode/1 correctly decodes command" do
-    assert {:ok, [setpoint_type: :humidifier]} ==
+    assert {:ok, [setpoint_type: :humidify]} ==
              HumidityControlSetpointCapabilitiesGet.decode_params(<<1>>)
 
     assert {:ok, [setpoint_type: :auto]} ==

--- a/test/grizzly/zwave/commands/humidity_control_setpoint_capabilities_report_test.exs
+++ b/test/grizzly/zwave/commands/humidity_control_setpoint_capabilities_report_test.exs
@@ -6,7 +6,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointCapabilitiesReportTest d
   test "encodes params correctly" do
     {:ok, command} =
       HumidityControlSetpointCapabilitiesReport.new(
-        setpoint_type: :humidifier,
+        setpoint_type: :humidify,
         min_value: 1.1,
         min_scale: :percentage,
         max_value: 10,
@@ -21,7 +21,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointCapabilitiesReportTest d
     binary = <<0x01, 0b00100001, 11, 0b00001001, 10>>
 
     assert {:ok, params} = HumidityControlSetpointCapabilitiesReport.decode_params(binary)
-    assert params[:setpoint_type] == :humidifier
+    assert params[:setpoint_type] == :humidify
     assert params[:min_value] == 1.1
     assert params[:min_scale] == :percentage
     assert params[:max_value] == 10

--- a/test/grizzly/zwave/commands/humidity_control_setpoint_get_test.exs
+++ b/test/grizzly/zwave/commands/humidity_control_setpoint_get_test.exs
@@ -4,7 +4,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointGetTest do
   alias Grizzly.ZWave.Commands.HumidityControlSetpointGet
 
   test "encode/1 correctly encodes command" do
-    {:ok, command} = HumidityControlSetpointGet.new(setpoint_type: :humidifier)
+    {:ok, command} = HumidityControlSetpointGet.new(setpoint_type: :humidify)
     assert <<1>> == HumidityControlSetpointGet.encode_params(command)
 
     {:ok, command} = HumidityControlSetpointGet.new(setpoint_type: :auto)
@@ -12,7 +12,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointGetTest do
   end
 
   test "decode/1 correctly decodes command" do
-    assert {:ok, [setpoint_type: :humidifier]} ==
+    assert {:ok, [setpoint_type: :humidify]} ==
              HumidityControlSetpointGet.decode_params(<<1>>)
 
     assert {:ok, [setpoint_type: :auto]} ==

--- a/test/grizzly/zwave/commands/humidity_control_setpoint_report_test.exs
+++ b/test/grizzly/zwave/commands/humidity_control_setpoint_report_test.exs
@@ -6,7 +6,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointReportTest do
   test "encodes params correctly" do
     {:ok, command} =
       HumidityControlSetpointReport.new(
-        setpoint_type: :humidifier,
+        setpoint_type: :humidify,
         value: 1.1,
         scale: :absolute
       )
@@ -19,7 +19,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointReportTest do
     binary = <<0x01, 0b00101001, 11>>
 
     assert {:ok, params} = HumidityControlSetpointReport.decode_params(binary)
-    assert params[:setpoint_type] == :humidifier
+    assert params[:setpoint_type] == :humidify
     assert params[:value] == 1.1
     assert params[:scale] == :absolute
   end

--- a/test/grizzly/zwave/commands/humidity_control_setpoint_scale_supported_get_test.exs
+++ b/test/grizzly/zwave/commands/humidity_control_setpoint_scale_supported_get_test.exs
@@ -4,7 +4,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointScaleSupportedGetTest do
   alias Grizzly.ZWave.Commands.HumidityControlSetpointScaleSupportedGet
 
   test "encode/1 correctly encodes command" do
-    {:ok, command} = HumidityControlSetpointScaleSupportedGet.new(setpoint_type: :humidifier)
+    {:ok, command} = HumidityControlSetpointScaleSupportedGet.new(setpoint_type: :humidify)
     assert <<1>> == HumidityControlSetpointScaleSupportedGet.encode_params(command)
 
     {:ok, command} = HumidityControlSetpointScaleSupportedGet.new(setpoint_type: :auto)
@@ -12,7 +12,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointScaleSupportedGetTest do
   end
 
   test "decode/1 correctly decodes command" do
-    assert {:ok, [setpoint_type: :humidifier]} ==
+    assert {:ok, [setpoint_type: :humidify]} ==
              HumidityControlSetpointScaleSupportedGet.decode_params(<<1>>)
 
     assert {:ok, [setpoint_type: :auto]} ==

--- a/test/grizzly/zwave/commands/humidity_control_setpoint_set_test.exs
+++ b/test/grizzly/zwave/commands/humidity_control_setpoint_set_test.exs
@@ -6,7 +6,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointSetTest do
   test "encodes params correctly" do
     {:ok, command} =
       HumidityControlSetpointSet.new(
-        setpoint_type: :humidifier,
+        setpoint_type: :humidify,
         value: 1.1,
         scale: :absolute
       )
@@ -19,7 +19,7 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointSetTest do
     binary = <<0x01, 0b00101001, 11>>
 
     assert {:ok, params} = HumidityControlSetpointSet.decode_params(binary)
-    assert params[:setpoint_type] == :humidifier
+    assert params[:setpoint_type] == :humidify
     assert params[:value] == 1.1
     assert params[:scale] == :absolute
   end

--- a/test/grizzly/zwave/commands/humidity_control_setpoint_supported_report_test.exs
+++ b/test/grizzly/zwave/commands/humidity_control_setpoint_supported_report_test.exs
@@ -5,13 +5,13 @@ defmodule Grizzly.ZWave.Commands.HumidityControlSetpointSupportedReportTest do
 
   test "encodes params correctly" do
     {:ok, command} =
-      HumidityControlSetpointSupportedReport.new(setpoint_types: [:humidifier, :auto])
+      HumidityControlSetpointSupportedReport.new(setpoint_types: [:humidify, :auto])
 
     assert <<0b1010>> == HumidityControlSetpointSupportedReport.encode_params(command)
   end
 
   test "decodes params correctly" do
     assert {:ok, params} = HumidityControlSetpointSupportedReport.decode_params(<<0b1010>>)
-    assert params[:setpoint_types] == [:humidifier, :auto]
+    assert params[:setpoint_types] == [:humidify, :auto]
   end
 end


### PR DESCRIPTION
Renamed `:humidifier` and `:dehumidifier` to `:humidify` and
`:dehumidify` to align with the humidity control mode names.
