### PR TITLE
Fix flaky WaitReport handler test

### DIFF
--- a/test/support/server/handler.ex
+++ b/test/support/server/handler.ex
@@ -576,7 +576,8 @@ defmodule GrizzlyTest.Server.Handler do
       [first, second] = state.commands_received
 
       cc = second |> Command.param!(:command) |> Command.param!(:command_class)
-      {:ok, reply} = VersionCommandClassReport.new(command_class: cc, version: 2)
+      v = if(cc == :alarm, do: 1, else: 2)
+      {:ok, reply} = VersionCommandClassReport.new(command_class: cc, version: v)
 
       {:ok, out_packet} = ZIPPacket.with_zwave_command(reply, Grizzly.SeqNumber.get_and_inc())
       :ok = Socket.send(socket, ZWave.to_binary(out_packet))
@@ -584,7 +585,8 @@ defmodule GrizzlyTest.Server.Handler do
       Process.sleep(100)
 
       cc = first |> Command.param!(:command) |> Command.param!(:command_class)
-      {:ok, reply} = VersionCommandClassReport.new(command_class: cc, version: 1)
+      v = if(cc == :alarm, do: 1, else: 2)
+      {:ok, reply} = VersionCommandClassReport.new(command_class: cc, version: v)
 
       {:ok, out_packet} = ZIPPacket.with_zwave_command(reply, Grizzly.SeqNumber.get_and_inc())
       :ok = Socket.send(socket, ZWave.to_binary(out_packet))


### PR DESCRIPTION
The test tries to send two commands out of order, but sometimes due to
the two async processes not being coordinated, the commands sometimes
end up going out in order. However, the mock Z/IP Gateway server always
sends the responses out of order, so we just need to make sure that the
data is matched up correctly.
