### PR TITLE
Improve error handling during firmware updates

### DIFF
--- a/lib/grizzly/background_rssi_monitor.ex
+++ b/lib/grizzly/background_rssi_monitor.ex
@@ -114,7 +114,7 @@ defmodule Grizzly.BackgroundRSSIMonitor do
         set_or_clear_alarm(state)
         {:ok, state}
 
-      {:error, :including} ->
+      {:error, reason} when reason in [:including, :firmware_updating] ->
         {:error, state}
 
       {:error, reason} ->

--- a/lib/grizzly/firmware_updates.ex
+++ b/lib/grizzly/firmware_updates.ex
@@ -55,6 +55,8 @@ defmodule Grizzly.FirmwareUpdates do
           | {:max_fragment_size, non_neg_integer}
           | {:activation_may_be_delayed?, boolean}
           | {:transmission_delay, pos_integer()}
+          | {:progress_timeout, timeout()}
+          | {:max_fragment_retries, non_neg_integer()}
 
   @type image_path :: String.t()
 

--- a/lib/grizzly/firmware_updates.ex
+++ b/lib/grizzly/firmware_updates.ex
@@ -92,6 +92,13 @@ defmodule Grizzly.FirmwareUpdates do
   end
 
   @doc """
+  Returns the progress of the current firmware update, if any, as a tuple containing
+  the last requested fragment index and the total number of fragments.
+  """
+  @spec progress() :: {non_neg_integer(), pos_integer()} | nil
+  defdelegate progress(), to: FirmwareUpdateRunner
+
+  @doc """
   Stop the current firmware update runner, if any.
   """
   @spec stop_firmware_update() :: :ok

--- a/lib/grizzly/firmware_updates/firmware_update_runner/firmware_update.ex
+++ b/lib/grizzly/firmware_updates/firmware_update_runner/firmware_update.ex
@@ -31,6 +31,11 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate do
           firmware_target: byte,
           activation_may_be_delayed?: boolean,
           current_command_ref: reference(),
+          current_command: Command.t() | nil,
+          current_command_attempts: non_neg_integer(),
+          progress_timer: reference() | nil,
+          # How long to wait with no progress before aborting
+          progress_timeout: non_neg_integer(),
           state: state,
           last_batch_size: non_neg_integer(),
           # Number of fragments still to be sent as a burst
@@ -48,6 +53,11 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate do
             conn: nil,
             # Ref to the currently executing command - so it can be stopped if needed
             current_command_ref: nil,
+            current_command: nil,
+            current_command_attempts: 0,
+            last_progress: nil,
+            progress_timer: nil,
+            progress_timeout: :timer.minutes(2),
             device_id: 1,
             image: nil,
             manufacturer_id: nil,
@@ -72,8 +82,17 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate do
   @spec current_command_ref(t()) :: reference()
   def current_command_ref(firmware_update), do: firmware_update.current_command_ref
 
-  def update_command_ref(firmware_update, new_command_ref),
-    do: %__MODULE__{firmware_update | current_command_ref: new_command_ref}
+  def update_command_ref(firmware_update, new_command_ref, command),
+    do: %__MODULE__{
+      firmware_update
+      | current_command_ref: new_command_ref,
+        current_command: command,
+        current_command_attempts:
+          if(command == firmware_update.current_command,
+            do: firmware_update.current_command_attempts + 1,
+            else: 1
+          )
+    }
 
   @spec in_progress?(t()) :: boolean()
   def in_progress?(firmware_update),
@@ -242,10 +261,7 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate do
          firmware_update,
          true = _last?
        ) do
-    %__MODULE__{
-      firmware_update
-      | fragments_wanted: 0
-    }
+    %__MODULE__{firmware_update | fragments_wanted: 0}
   end
 
   defp firmware_fragment_uploaded(
@@ -330,5 +346,21 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate do
          image: image
        }) do
     Image.data(image, fragment_index)
+  end
+
+  def clear_progress_timer(%__MODULE__{progress_timer: progress_timer} = firmware_update) do
+    _ =
+      if is_reference(progress_timer) do
+        Process.cancel_timer(progress_timer)
+      end
+
+    %{firmware_update | progress_timer: nil}
+  end
+
+  def reset_progress_timer(%__MODULE__{} = firmware_update) do
+    firmware_update = clear_progress_timer(firmware_update)
+
+    timer_ref = Process.send_after(self(), :progress_timeout, firmware_update.progress_timeout)
+    %__MODULE__{firmware_update | progress_timer: timer_ref}
   end
 end

--- a/lib/grizzly/firmware_updates/firmware_update_runner/firmware_update.ex
+++ b/lib/grizzly/firmware_updates/firmware_update_runner/firmware_update.ex
@@ -36,6 +36,7 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate do
           progress_timer: reference() | nil,
           # How long to wait with no progress before aborting
           progress_timeout: non_neg_integer(),
+          max_fragment_retries: non_neg_integer(),
           state: state,
           last_batch_size: non_neg_integer(),
           # Number of fragments still to be sent as a burst
@@ -58,6 +59,7 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.FirmwareUpdate do
             last_progress: nil,
             progress_timer: nil,
             progress_timeout: :timer.minutes(2),
+            max_fragment_retries: 10,
             device_id: 1,
             image: nil,
             manufacturer_id: nil,


### PR DESCRIPTION
It's been observed that sometimes Z/IP Gateway doesn't end up sending
an ack or nack response to a packet when an S2 nonce exchange fails.
This can happen in environments with a lot of background noise. When
this happened, Grizzly would immediately abort the firmware update
without retrying anything, oftentimes prematurely. This could happen
even if the target device had resumed the update by sending a new
Firmware Update Metadata Get command.

Additionally, Grizzly would ignore nack responses and wait for the next
Firmware Update Metadata Get from the target device to resume sending
fragments. This could cause the firmware update to stall due to
transient noise events (such as a nearby wakeup beam).

In both cases, we will now retry the last transmitted command up to 10
times in an attempt to progress the firmware update.

Additionally, a firmware update will only be aborted due to transmission
errors after 2 minutes of failing make any progress. This timeout is
based on the recommendation for end devices in the spec (see 3.2.17.6,
requirement CC:007A.03.05.12.002).
