### PR TITLE
Fix command name for Node Info Cached Report

### DIFF
--- a/lib/grizzly/commands/table.ex
+++ b/lib/grizzly/commands/table.ex
@@ -77,7 +77,7 @@ defmodule Grizzly.Commands.Table do
        handler: {WaitReport, complete_report: :failed_node_replace_status}},
     node_info_cached_get:
       {Commands.NodeInfoCachedGet,
-       handler: {WaitReport, complete_report: :node_info_cache_report}},
+       handler: {WaitReport, complete_report: :node_info_cached_report}},
     node_remove:
       {Commands.NodeRemove, handler: {WaitReport, complete_report: :node_remove_status}},
     failed_node_remove:

--- a/lib/grizzly/node.ex
+++ b/lib/grizzly/node.ex
@@ -25,7 +25,7 @@ defmodule Grizzly.Node do
   @doc """
   Get the information for a node by its id
 
-  The response to this command is the `NodeInfoCacheReport` command
+  The response to this command is the `NodeInfoCachedReport` command
   """
   @spec get_info(ZWave.node_id() | VirtualDevices.id(), [info_opt() | opt()]) ::
           Grizzly.send_command_response()

--- a/lib/grizzly/virtual_devices/reports.ex
+++ b/lib/grizzly/virtual_devices/reports.ex
@@ -12,7 +12,7 @@ defmodule Grizzly.VirtualDevices.Reports do
     ManufacturerSpecificDeviceSpecificReport,
     ManufacturerSpecificReport,
     NodeAddStatus,
-    NodeInfoCacheReport,
+    NodeInfoCachedReport,
     NodeRemoveStatus,
     VersionCommandClassReport,
     VersionReport
@@ -74,7 +74,7 @@ defmodule Grizzly.VirtualDevices.Reports do
     seq_number = Command.param!(node_info_get, :seq_number)
 
     {:ok, node_info_report} =
-      NodeInfoCacheReport.new(
+      NodeInfoCachedReport.new(
         seq_number: seq_number,
         status: :ok,
         age: 1,

--- a/lib/grizzly/zwave/commands/node_info_cached_report.ex
+++ b/lib/grizzly/zwave/commands/node_info_cached_report.ex
@@ -1,4 +1,4 @@
-defmodule Grizzly.ZWave.Commands.NodeInfoCacheReport do
+defmodule Grizzly.ZWave.Commands.NodeInfoCachedReport do
   @moduledoc """
   Report the cached node information
 
@@ -59,7 +59,7 @@ defmodule Grizzly.ZWave.Commands.NodeInfoCacheReport do
   def new(params) do
     # TODO validate params
     command = %Command{
-      name: :node_info_cache_report,
+      name: :node_info_cached_report,
       command_byte: 0x04,
       command_class: NetworkManagementProxy,
       params: params,

--- a/lib/grizzly/zwave/decoder.ex
+++ b/lib/grizzly/zwave/decoder.ex
@@ -92,7 +92,7 @@ defmodule Grizzly.ZWave.Decoder do
     {0x52, 0x01} => Commands.NodeListGet,
     {0x52, 0x02} => Commands.NodeListReport,
     {0x52, 0x03} => Commands.NodeInfoCachedGet,
-    {0x52, 0x04} => Commands.NodeInfoCacheReport,
+    {0x52, 0x04} => Commands.NodeInfoCachedReport,
     {0x52, 0x06} => Commands.NetworkManagementMultiChannelEndPointReport,
     {0x52, 0x07} => Commands.NetworkManagementMultiChannelCapabilityGet,
     {0x52, 0x08} => Commands.NetworkManagementMultiChannelCapabilityReport,

--- a/test/grizzly/virtual_devices/thermostat_test.exs
+++ b/test/grizzly/virtual_devices/thermostat_test.exs
@@ -22,7 +22,7 @@ defmodule Grizzly.VirtualDevices.ThermostatTest do
 
     assert {:ok, %Report{type: :command, command: command}} = Node.get_info(device_id)
 
-    assert command.name == :node_info_cache_report
+    assert command.name == :node_info_cached_report
   end
 
   test "get thermostat manufacture info" do


### PR DESCRIPTION
Command names should match module names, and module names should match
file names. Also, let's be consistent with how it's named in the spec.