### PR TITLE
Fix OTW update runner issues when Z/IP Gateway is not available

### DIFF
--- a/lib/grizzly/firmware_updates/otw_update_runner.ex
+++ b/lib/grizzly/firmware_updates/otw_update_runner.ex
@@ -346,7 +346,7 @@ defmodule Grizzly.FirmwareUpdates.OTWUpdateRunner do
 
       {:error, _reason} ->
         {:keep_state, %{data | errors: data.errors + 1},
-         [next_event_action(:zgw_version_check, :timer.seconds(5))]}
+         [next_event_action(:zgw_version_check, :timer.seconds(1))]}
     end
   end
 
@@ -580,8 +580,9 @@ defmodule Grizzly.FirmwareUpdates.OTWUpdateRunner do
   @spec version_from_zipgateway() ::
           {:ok, Version.version()} | {:error, Grizzly.send_command_error()}
   defp version_from_zipgateway() do
-    case Grizzly.send_command(1, :version_zwave_software_get) do
+    case Grizzly.send_command(1, :version_zwave_software_get, [], timeout: 1000) do
       {:ok, %{command: %Command{} = cmd}} -> {:ok, Command.param!(cmd, :host_interface_version)}
+      {:ok, %{type: :timeout}} -> {:error, :timeout}
       {:error, reason} -> {:error, reason}
     end
   end


### PR DESCRIPTION
When Z/IP Gateway is not available (such as when a previous OTW update
was interrupted and the Z-Wave module needs to be recovered), a case
clause error was being raised because commands that time out in that way
return `{:ok, %Grizzly.Report{type: :timeout}}`.

This also reduces the timeout on the Version Z-Wave Software Get and the
delay between retries since if things are working normally, it should come
back nearly instantly. It's really only when the Z-Wave module is in a bad
state (or Z/IP Gateway isn't running) that this command should fail at all.
