### PR TITLE
ENG: Update `Trace`/`Trace.Record` output

### DIFF
--- a/lib/grizzly/trace.ex
+++ b/lib/grizzly/trace.ex
@@ -35,6 +35,8 @@ defmodule Grizzly.Trace do
 
   @type list_opt() :: {:node_id, Grizzly.node_id()}
 
+  @type print_opt() :: list_opt() | {:decode, boolean()}
+
   @default_size 300
   @default_format :text
 
@@ -55,11 +57,11 @@ defmodule Grizzly.Trace do
   * `:raw` - Each record is on a new line and is formatted as
     `timestamp source -> destination: binary`.
   """
-  @spec format([Record.t()], format()) :: binary()
-  def format(records, format \\ @default_format)
+  @spec format([Record.t()], format(), keyword()) :: binary()
+  def format(records, format \\ @default_format, opts \\ [])
 
-  def format(records, fmt) when fmt in [:text, :raw],
-    do: Enum.map_join(records, "\n", &Record.to_string(&1, fmt))
+  def format(records, fmt, opts) when fmt in [:text, :raw],
+    do: Enum.map_join(records, "\n", &Record.to_string(&1, fmt, opts))
 
   @doc "Dump trace records into a file using Erlang External Term Format."
   @spec dump(binary()) :: :ok | {:error, atom()}
@@ -71,17 +73,19 @@ defmodule Grizzly.Trace do
   @doc """
   Write trace records to standard out. See `format/2` for the available formats.
   """
-  @spec print(list(Record.t()) | format(), [list_opt()]) :: :ok
+  @spec print(list(Record.t()) | format(), [print_opt()]) :: :ok
   def print(records_or_format, opts)
 
-  def print(records, _opts) when is_list(records) do
+  def print(records, opts) when is_list(records) do
     print_header()
-    records |> format() |> IO.puts()
+    {format_opts, _list_opts} = Keyword.split(opts, [:decode])
+    records |> format(@default_format, format_opts) |> IO.puts()
   end
 
   def print(fmt, opts) when is_atom(fmt) do
     print_header()
-    opts |> list() |> format(fmt) |> IO.puts()
+    {format_opts, list_opts} = Keyword.split(opts, [:decode])
+    list_opts |> list() |> format(fmt, format_opts) |> IO.puts()
   end
 
   def print(fmt_or_opts)

--- a/lib/grizzly/trace.ex
+++ b/lib/grizzly/trace.ex
@@ -131,7 +131,7 @@ defmodule Grizzly.Trace do
   @spec resize(GenServer.server(), pos_integer()) :: :ok
   def resize(name \\ __MODULE__, size), do: GenServer.call(name, {:resize, size})
 
-  defp print_header do
+  defp print_header() do
     # Values based on those in `Grizzly.Trace.Record`
     timestamp = String.pad_trailing("TIMESTAMP", 12)
     src = String.pad_leading("SRC", 3)

--- a/lib/grizzly/trace.ex
+++ b/lib/grizzly/trace.ex
@@ -58,10 +58,12 @@ defmodule Grizzly.Trace do
     `timestamp source -> destination: binary`.
   """
   @spec format([Record.t()], format(), keyword()) :: binary()
-  def format(records, format \\ @default_format, opts \\ [])
-
   def format(records, fmt, opts) when fmt in [:text, :raw],
     do: Enum.map_join(records, "\n", &Record.to_string(&1, fmt, opts))
+
+  def format(records, opts) when is_list(opts), do: format(records, @default_format, opts)
+  def format(records, fmt) when is_atom(fmt), do: format(records, fmt, [])
+  def format(records), do: format(records, @default_format, [])
 
   @doc "Dump trace records into a file using Erlang External Term Format."
   @spec dump(binary()) :: :ok | {:error, atom()}
@@ -79,7 +81,7 @@ defmodule Grizzly.Trace do
   def print(records, opts) when is_list(records) do
     print_header()
     {format_opts, _list_opts} = Keyword.split(opts, [:decode])
-    records |> format(@default_format, format_opts) |> IO.puts()
+    records |> format(format_opts) |> IO.puts()
   end
 
   def print(fmt, opts) when is_atom(fmt) do

--- a/lib/grizzly/trace.ex
+++ b/lib/grizzly/trace.ex
@@ -22,6 +22,8 @@ defmodule Grizzly.Trace do
 
   alias Grizzly.Trace.Record
 
+  require Logger
+
   @type trace_opt :: {:name, atom()} | {:size, pos_integer()} | {:record_keepalives, boolean()}
 
   @type src() :: Grizzly.node_id() | :grizzly
@@ -71,8 +73,16 @@ defmodule Grizzly.Trace do
   """
   @spec print(list(Record.t()) | format(), [list_opt()]) :: :ok
   def print(records_or_format, opts)
-  def print(records, _opts) when is_list(records), do: records |> format() |> IO.puts()
-  def print(fmt, opts) when is_atom(fmt), do: opts |> list() |> format(fmt) |> IO.puts()
+
+  def print(records, _opts) when is_list(records) do
+    print_header()
+    records |> format() |> IO.puts()
+  end
+
+  def print(fmt, opts) when is_atom(fmt) do
+    print_header()
+    opts |> list() |> format(fmt) |> IO.puts()
+  end
 
   def print(fmt_or_opts)
   def print(fmt) when is_atom(fmt), do: print(fmt, [])
@@ -117,6 +127,20 @@ defmodule Grizzly.Trace do
   @spec resize(GenServer.server(), pos_integer()) :: :ok
   def resize(name \\ __MODULE__, size), do: GenServer.call(name, {:resize, size})
 
+  defp print_header do
+    # Values based on those in `Grizzly.Trace.Record`
+    timestamp = String.pad_trailing("TIMESTAMP", 12)
+    src = String.pad_leading("SRC", 3)
+    dest = String.pad_trailing("DST", 3)
+    seq = String.pad_trailing("SEQ", 4)
+    command = "COMMAND"
+
+    header = "#{timestamp} #{src} -> #{dest} #{seq} #{command}"
+
+    IO.puts(header)
+    IO.puts(String.duplicate("-", String.length(header) + 20))
+  end
+
   @doc "Enable or disable logging of keepalive frames."
   @spec record_keepalives(GenServer.server(), boolean()) :: :ok
   def record_keepalives(name, enabled?), do: GenServer.call(name, {:record_keepalives, enabled?})
@@ -152,6 +176,15 @@ defmodule Grizzly.Trace do
       end)
 
     {:noreply, state}
+  rescue
+    err ->
+      Logger.error("""
+      [Grizzly.Trace] Failed to log event:
+
+      #{Exception.format(:error, err, __STACKTRACE__)}
+      """)
+
+      {:noreply, state}
   end
 
   @impl GenServer

--- a/lib/grizzly/trace/record.ex
+++ b/lib/grizzly/trace/record.ex
@@ -37,19 +37,20 @@ defmodule Grizzly.Trace.Record do
   @doc """
   Turn a record into the string format
   """
-  @spec to_string(t(), Trace.format()) :: String.t()
-  def to_string(record, format \\ :text)
+  @spec to_string(t(), Trace.format(), keyword()) :: String.t()
+  def to_string(record, format \\ :text, opts \\ [])
 
-  def to_string(record, :text) do
+  def to_string(record, :text, opts) do
     %__MODULE__{timestamp: ts, src: src, dest: dest, binary: binary} = record
     ts = Time.truncate(ts, :millisecond)
 
     prefix = "#{Time.to_string(ts)} #{src_to_string(src)} -> #{dest_to_string(dest)}"
+    decode? = Keyword.get(opts, :decode, false)
 
     try do
       case ZWave.from_binary(binary) do
         {:ok, zip_packet} ->
-          "#{prefix} #{command_info_str(zip_packet, binary)}"
+          "#{prefix} #{command_info_str(zip_packet, binary, decode?)}"
 
         {:error, _} ->
           "#{prefix} #{inspect(binary, limit: 500)}"
@@ -61,7 +62,7 @@ defmodule Grizzly.Trace.Record do
     end
   end
 
-  def to_string(record, :raw) do
+  def to_string(record, :raw, _opts) do
     %__MODULE__{timestamp: ts, src: src, dest: dest, binary: binary} = record
 
     time = ts |> Time.truncate(:millisecond) |> Time.to_string()
@@ -91,7 +92,7 @@ defmodule Grizzly.Trace.Record do
   defp dest_to_string(:grizzly), do: dest_to_string("G")
   defp dest_to_string(dest), do: dest |> Kernel.to_string() |> String.pad_trailing(3)
 
-  defp command_info_str(%Command{name: :keep_alive} = cmd, _binary) do
+  defp command_info_str(%Command{name: :keep_alive} = cmd, _binary, _decode?) do
     case Command.param!(cmd, :ack_flag) do
       :ack_request ->
         "    keep_alive (ack req)"
@@ -101,7 +102,7 @@ defmodule Grizzly.Trace.Record do
     end
   end
 
-  defp command_info_str(zip_packet, binary) do
+  defp command_info_str(zip_packet, binary, decode?) do
     seq_number = Command.param!(zip_packet, :seq_number)
     flag = Command.param!(zip_packet, :flag)
 
@@ -119,7 +120,7 @@ defmodule Grizzly.Trace.Record do
         "    no_operation"
 
       true ->
-        command_info_with_encapsulated_command(seq_number, zip_packet, binary)
+        command_info_with_encapsulated_command(seq_number, zip_packet, binary, decode?)
     end
   end
 
@@ -127,7 +128,7 @@ defmodule Grizzly.Trace.Record do
     "#{seq_number_to_str(seq_number)} #{flag}"
   end
 
-  defp command_info_with_encapsulated_command(seq_number, zip_packet, binary) do
+  defp command_info_with_encapsulated_command(seq_number, zip_packet, binary, decode?) do
     command = Command.param!(zip_packet, :command)
     command_binary = ZIPPacket.unwrap(binary)
 
@@ -135,10 +136,14 @@ defmodule Grizzly.Trace.Record do
          encap_bin = Command.param!(command, :encapsulated_command),
          {:ok, inner_command} <-
            Grizzly.ZWave.from_binary(encap_bin) do
-      "#{seq_number_to_str(seq_number)} supervision_get(#{inner_command.name}) #{inspect(encap_bin, limit: 500)}"
+      detail = if decode?, do: inspect(inner_command.params), else: inspect(encap_bin, limit: 500)
+      "#{seq_number_to_str(seq_number)} supervision_get(#{inner_command.name}) #{detail}"
     else
       _ ->
-        "#{seq_number_to_str(seq_number)} #{command.name} #{inspect(command_binary, limit: 500)}"
+        detail =
+          if decode?, do: inspect(command.params), else: inspect(command_binary, limit: 500)
+
+        "#{seq_number_to_str(seq_number)} #{command.name} #{detail}"
     end
   rescue
     err ->

--- a/lib/grizzly/trace/record.ex
+++ b/lib/grizzly/trace/record.ex
@@ -75,6 +75,16 @@ defmodule Grizzly.Trace.Record do
   def remote_node(%__MODULE__{src: :grizzly, dest: dest}), do: dest
   def remote_node(%__MODULE__{src: src, dest: :grizzly}), do: src
 
+  def remote_node(%__MODULE__{src: src} = record) do
+    Logger.warning("""
+    [Grizzly.Trace] Remote node has invalid destination:
+
+    #{inspect(record[:dest])}
+    """)
+
+    src
+  end
+
   defp src_to_string(:grizzly), do: src_to_string("G")
   defp src_to_string(src), do: src |> Kernel.to_string() |> String.pad_leading(3)
 


### PR DESCRIPTION
Before:
```
> Grizzly.Trace.print
03:11:15.501   1 -> G   148  s2_resynchronization_event <<103, 9, 9, 0, 0, 0>>
03:11:15.503   G -> 1   148  ack_response
06:57:55.892   G -> 1   5    failed_node_list_get <<82, 11, 5>>
06:57:55.894   1 -> G   5    ack_response
```

After:
```
> Grizzly.Trace.print
TIMESTAMP    SRC -> DST SEQ  COMMAND
-----------------------------------------------
03:11:15.501   1 -> G   148  s2_resynchronization_event <<103, 9, 9, 0, 0, 0>>
03:11:15.503   G -> 1   148  ack_response
06:57:55.892   G -> 1   5    failed_node_list_get <<82, 11, 5>>
06:57:55.894   1 -> G   5    ack_response
```

Or:
```
> Grizzly.Trace.print(decode: true)
TIMESTAMP    SRC -> DST SEQ  COMMAND
-----------------------------------------------
03:11:15.501   1 -> G   148  s2_resynchronization_event [node_id: 9, reason: 0]
03:11:15.503   G -> 1   148  ack_response
06:57:55.892   G -> 1   5    failed_node_list_get [seq_number: 5]
06:57:55.894   1 -> G   5    ack_response
```

Also might hopefully fix a bug Ben noticed where `Grizzly.Trace.print` would seemingly fill the buffer up and cause no new events to be added somehow. 🤞 