### PR TITLE
Fix crash on decoding a thermostat mode report

### DIFF
--- a/lib/grizzly/zwave/commands/thermostat_mode_set_report.ex
+++ b/lib/grizzly/zwave/commands/thermostat_mode_set_report.ex
@@ -40,7 +40,10 @@ defmodule Grizzly.ZWave.Commands.ThermostatModeSetReport do
   end
 
   @impl Grizzly.ZWave.Command
-  def decode_params(_spec, <<mfr_data_len::3, mode_byte::5, mfr_data::binary-size(mfr_data_len)>>) do
+  def decode_params(
+        _spec,
+        <<mfr_data_len::3, mode_byte::5, mfr_data::binary-size(mfr_data_len), _garbage::binary>>
+      ) do
     with {:ok, mode} <- ThermostatMode.decode_mode(mode_byte) do
       if mode == :manufacturer_specific do
         {:ok, [mode: mode, manufacturer_data: mfr_data]}


### PR DESCRIPTION
From the Sensi Lite smart thermostat sending an extra byte

Ignore any extra bytes

[SRH-2118]

[SRH-2118]: https://smartrent.atlassian.net/browse/SRH-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ