### PR TITLE
Rename ThermostatModeSetReport to ThermostatModeReport

### DIFF
--- a/lib/grizzly/zwave/commands.ex
+++ b/lib/grizzly/zwave/commands.ex
@@ -985,9 +985,9 @@ defmodule Grizzly.ZWave.Commands do
   end
 
   command_class :thermostat_mode, 0x40 do
-    command :thermostat_mode_set, 0x01, Cmds.ThermostatModeSetReport
+    command :thermostat_mode_set, 0x01, Cmds.ThermostatModeSet
     command :thermostat_mode_get, 0x02, Cmds.Generic, params: []
-    command :thermostat_mode_report, 0x03, Cmds.ThermostatModeSetReport
+    command :thermostat_mode_report, 0x03, Cmds.ThermostatModeReport
     command :thermostat_mode_supported_get, 0x04, Cmds.Generic, params: []
     command :thermostat_mode_supported_report, 0x05
   end

--- a/lib/grizzly/zwave/commands/thermostat_mode_report.ex
+++ b/lib/grizzly/zwave/commands/thermostat_mode_report.ex
@@ -1,9 +1,9 @@
-defmodule Grizzly.ZWave.Commands.ThermostatModeSetReport do
+defmodule Grizzly.ZWave.Commands.ThermostatModeReport do
   @moduledoc """
-  This module implements command THERMOSTAT_MODE_SET of the
+  This module implements command THERMOSTAT_MODE_REPORT of the
   COMMAND_CLASS_THERMOSTAT_MODE command class.
 
-  This command is used to set the mode from the thermostat device.
+  This command is used to report the mode from the thermostat device.
 
   Params:
 

--- a/lib/grizzly/zwave/commands/thermostat_mode_set.ex
+++ b/lib/grizzly/zwave/commands/thermostat_mode_set.ex
@@ -1,0 +1,55 @@
+defmodule Grizzly.ZWave.Commands.ThermostatModeSet do
+  @moduledoc """
+  This module implements command THERMOSTAT_MODE_SET of the
+  COMMAND_CLASS_THERMOSTAT_MODE command class.
+
+  This command is used to set the mode from the thermostat device.
+
+  Params:
+
+    * `:mode` - the mode of the thermostat, see ThermostatMode (required)
+
+  """
+
+  @behaviour Grizzly.ZWave.Command
+
+  alias Grizzly.ZWave.Command
+  alias Grizzly.ZWave.CommandClasses.ThermostatMode
+
+  @type param :: {:mode, ThermostatMode.mode()}
+
+  @impl Grizzly.ZWave.Command
+  def encode_params(_spec, command) do
+    mode = Command.param!(command, :mode)
+
+    if mode == :manufacturer_specific do
+      mfr_data = Command.param!(command, :manufacturer_data)
+
+      if byte_size(mfr_data) > 7 do
+        raise ArgumentError, "ThermostatModeSet manufacturer_data must be <= 7 bytes"
+      end
+
+      mfr_data_len = byte_size(mfr_data)
+
+      <<mfr_data_len::3, ThermostatMode.encode_mode(:manufacturer_specific)::5,
+        mfr_data::binary-size(mfr_data_len)>>
+    else
+      mode_byte = ThermostatMode.encode_mode(Command.param!(command, :mode))
+      <<0x00::3, mode_byte::5>>
+    end
+  end
+
+  @impl Grizzly.ZWave.Command
+  def decode_params(
+        _spec,
+        <<mfr_data_len::3, mode_byte::5, mfr_data::binary-size(mfr_data_len), _garbage::binary>>
+      ) do
+    with {:ok, mode} <- ThermostatMode.decode_mode(mode_byte) do
+      if mode == :manufacturer_specific do
+        {:ok, [mode: mode, manufacturer_data: mfr_data]}
+      else
+        {:ok, [mode: mode]}
+      end
+    end
+  end
+end

--- a/test/grizzly/zwave/commands/thermostat_mode_report_test.exs
+++ b/test/grizzly/zwave/commands/thermostat_mode_report_test.exs
@@ -1,8 +1,8 @@
-defmodule Grizzly.ZWave.Commands.ThermostatModeSetReportTest do
+defmodule Grizzly.ZWave.Commands.ThermostatModeReportTest do
   use ExUnit.Case, async: true
 
   alias Grizzly.ZWave.Commands
-  alias Grizzly.ZWave.Commands.ThermostatModeSetReport
+  alias Grizzly.ZWave.Commands.ThermostatModeReport
 
   test "creates the command and validates params" do
     params = [mode: :heat]
@@ -13,31 +13,31 @@ defmodule Grizzly.ZWave.Commands.ThermostatModeSetReportTest do
     params = [mode: :heat]
     {:ok, command} = Commands.create(:thermostat_mode_set, params)
     expected_binary = <<0x00::3, 0x01::5>>
-    assert expected_binary == ThermostatModeSetReport.encode_params(nil, command)
+    assert expected_binary == ThermostatModeReport.encode_params(nil, command)
 
     assert_raise KeyError, fn ->
       params = [mode: :manufacturer_specific]
       {:ok, cmd} = Commands.create(:thermostat_mode_set, params)
-      ThermostatModeSetReport.encode_params(nil, cmd)
+      ThermostatModeReport.encode_params(nil, cmd)
     end
 
     assert_raise ArgumentError, fn ->
       params = [mode: :manufacturer_specific, manufacturer_data: "12345678"]
       {:ok, cmd} = Commands.create(:thermostat_mode_set, params)
-      ThermostatModeSetReport.encode_params(nil, cmd)
+      ThermostatModeReport.encode_params(nil, cmd)
     end
 
     params = [mode: :manufacturer_specific, manufacturer_data: "1234567"]
     {:ok, cmd} = Commands.create(:thermostat_mode_set, params)
-    assert <<0xFF, "1234567">> = ThermostatModeSetReport.encode_params(nil, cmd)
+    assert <<0xFF, "1234567">> = ThermostatModeReport.encode_params(nil, cmd)
   end
 
   test "decodes params correctly" do
     binary_params = <<0x00::3, 0x02::5>>
-    {:ok, params} = ThermostatModeSetReport.decode_params(nil, binary_params)
+    {:ok, params} = ThermostatModeReport.decode_params(nil, binary_params)
     assert Keyword.get(params, :mode) == :cool
 
-    assert {:ok, params} = ThermostatModeSetReport.decode_params(nil, <<0xFF, "1234567">>)
+    assert {:ok, params} = ThermostatModeReport.decode_params(nil, <<0xFF, "1234567">>)
     assert params == [mode: :manufacturer_specific, manufacturer_data: "1234567"]
   end
 end


### PR DESCRIPTION
To align with the Z-Wave specs (2.2.112.4. Thermostat Mode Report Command)