### PR TITLE
CIOT: Account for missing YMM notification type(s)

### DIFF
--- a/lib/grizzly/zwave/notifications.ex
+++ b/lib/grizzly/zwave/notifications.ex
@@ -512,7 +512,8 @@ defmodule Grizzly.ZWave.Notifications do
              :credential_unlock_operation,
              :valid_credential_denied_user_disabled,
              :valid_credential_denied_user_schedule_not_active,
-             :messaging_user_code_entered_via_keypad
+             :messaging_user_code_entered_via_keypad,
+             :non_access_credential_used
            ] do
     case decode_credential_usage_data(params_binary) do
       {:ok, data} ->

--- a/test/grizzly/zwave/notifications_test.exs
+++ b/test/grizzly/zwave/notifications_test.exs
@@ -1,5 +1,36 @@
 defmodule Grizzly.ZWave.NotificationsTest do
   use ExUnit.Case, async: true
 
+  alias Grizzly.ZWave.Notifications
+
   doctest Grizzly.ZWave.Notifications
+
+  describe "decode_event_params/3 for access_control credential usage events" do
+    test "credential_unlock_operation" do
+      assert Notifications.decode_event_params(
+               :access_control,
+               :credential_unlock_operation,
+               <<0, 33, 1, 1, 0, 4>>
+             ) ==
+               {:ok, [user_id: 33, credentials_used: [%{type: :pin_code, slot_id: 4}]]}
+    end
+
+    test "credential_lock_operation" do
+      assert Notifications.decode_event_params(
+               :access_control,
+               :credential_lock_operation,
+               <<0, 33, 1, 1, 0, 4>>
+             ) ==
+               {:ok, [user_id: 33, credentials_used: [%{type: :pin_code, slot_id: 4}]]}
+    end
+
+    test "non_access_credential_used" do
+      assert Notifications.decode_event_params(
+               :access_control,
+               :non_access_credential_used,
+               <<0, 33, 1, 1, 0, 4>>
+             ) ==
+               {:ok, [user_id: 33, credentials_used: [%{type: :pin_code, slot_id: 4}]]}
+    end
+  end
 end


### PR DESCRIPTION
Somewhat related to
- https://github.com/smartrent/control.smartrent.com/pull/17649
    - It's especially worth checking out the markdown table of all the supported YMM notifications.
- https://github.com/smartrent/grizzly/pull/1204
    - Released in Grizzly 9.0.0, which was included in hub firmware 1.38.0.