### PR TITLE
Fix firmware update timeouts are conflated with nack responses from devices

### DIFF
--- a/lib/grizzly/firmware_updates/firmware_update_runner.ex
+++ b/lib/grizzly/firmware_updates/firmware_update_runner.ex
@@ -177,7 +177,7 @@ defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner do
   # Async responses to commands sent
   def handle_info({:grizzly, :report, report}, firmware_update) do
     case report.type do
-      type when type in [:nack_response, :timeout] ->
+      :nack_response ->
         firmware_update = handle_nack_response(firmware_update)
 
         {:noreply, firmware_update}


### PR DESCRIPTION
They need to be handled separately and differently as documented in the code