### PR TITLE
chore: fixed Elixir 1.20 warnings for bin pattern matching `size(pinned)` and unused `require Logger` statements

### DIFF
--- a/lib/grizzly.ex
+++ b/lib/grizzly.ex
@@ -53,8 +53,6 @@ defmodule Grizzly do
   alias Grizzly.ZWave.Commands.RssiReport
   alias Grizzly.ZWave.CommandSpec
 
-  require Logger
-
   import Grizzly.VersionReports, only: [is_extra_command: 1]
 
   @typedoc """

--- a/lib/grizzly/firmware_updates/firmware_update_runner/image.ex
+++ b/lib/grizzly/firmware_updates/firmware_update_runner/image.ex
@@ -1,8 +1,6 @@
 defmodule Grizzly.FirmwareUpdates.FirmwareUpdateRunner.Image do
   @moduledoc false
 
-  require Logger
-
   @type t :: %__MODULE__{path: String.t(), fragments: [binary]}
 
   defstruct path: nil,

--- a/lib/grizzly/inclusions/zwave_adapter.ex
+++ b/lib/grizzly/inclusions/zwave_adapter.ex
@@ -11,8 +11,6 @@ defmodule Grizzly.Inclusions.ZWaveAdapter do
   alias Grizzly.ZWave.DSK
   alias Grizzly.ZWave.Security
 
-  require Logger
-
   @inclusion_timeout :timer.seconds(530)
 
   @type state :: %{

--- a/lib/grizzly/options.ex
+++ b/lib/grizzly/options.ex
@@ -8,8 +8,6 @@ defmodule Grizzly.Options do
   alias Grizzly.Trace
   alias Grizzly.ZIPGateway.Config
 
-  require Logger
-
   @typedoc """
   Options for configuring Z-Wave module firmware upgrades.
 

--- a/lib/grizzly/requests/handlers/wait_report.ex
+++ b/lib/grizzly/requests/handlers/wait_report.ex
@@ -8,8 +8,6 @@ defmodule Grizzly.Requests.Handlers.WaitReport do
   alias Grizzly.ZWave.Command
   alias Grizzly.ZWave.Commands
 
-  require Logger
-
   @type state :: %{complete_report: atom(), get_command: Command.t()}
 
   @type opt :: {:complete_report, atom(), get_command: Command.t()}

--- a/lib/grizzly/storage/populate.ex
+++ b/lib/grizzly/storage/populate.ex
@@ -10,8 +10,6 @@ defmodule Grizzly.Storage.Populate do
   alias Grizzly.ZIPGateway.Database, as: ZIPGatewayDb
   alias Grizzly.ZWave.DSK
 
-  require Logger
-
   @spec start_link(any()) :: GenServer.on_start()
   def start_link(opts) do
     database = Keyword.get(opts, :database, Grizzly.options().database_file)

--- a/lib/grizzly/supervisor.ex
+++ b/lib/grizzly/supervisor.ex
@@ -46,8 +46,6 @@ defmodule Grizzly.Supervisor do
   alias Grizzly.Trace
   alias Grizzly.ZIPGateway.ReadyChecker
 
-  require Logger
-
   @typedoc """
   The RF region code you want the Z-Wave controller to operate at.
 

--- a/lib/grizzly/transports/DTLS.ex
+++ b/lib/grizzly/transports/DTLS.ex
@@ -9,8 +9,6 @@ defmodule Grizzly.Transports.DTLS do
   alias Grizzly.Transport
   alias Grizzly.ZWave
 
-  require Logger
-
   @impl Grizzly.Transport
   def open(args, ifaddr \\ {0xFD00, 0xAAAA, 0, 0, 0, 0, 0, 0x0002}) do
     ip_address = Keyword.fetch!(args, :ip_address)

--- a/lib/grizzly/zwave/command_classes.ex
+++ b/lib/grizzly/zwave/command_classes.ex
@@ -5,8 +5,6 @@ defmodule Grizzly.ZWave.CommandClasses do
 
   import Grizzly.ZWave.GeneratedMappings, only: [command_class_mappings: 0]
 
-  require Logger
-
   @type command_class_list :: [
           non_secure_supported: list(atom()),
           non_secure_controlled: list(atom()),

--- a/lib/grizzly/zwave/commands/configuration_bulk_report.ex
+++ b/lib/grizzly/zwave/commands/configuration_bulk_report.ex
@@ -56,7 +56,7 @@ defmodule Grizzly.ZWave.Commands.ConfigurationBulkReport do
           size::3, values_bin::binary>>
       ) do
     values =
-      for(<<value::signed-integer-size(size)-unit(8) <- values_bin>>, do: value)
+      for(<<value::signed-integer-size(^size)-unit(8) <- values_bin>>, do: value)
       |> Enum.take(count)
 
     {:ok,

--- a/lib/grizzly/zwave/commands/configuration_bulk_set.ex
+++ b/lib/grizzly/zwave/commands/configuration_bulk_set.ex
@@ -50,7 +50,7 @@ defmodule Grizzly.ZWave.Commands.ConfigurationBulkSet do
         <<offset::16, _count, default_bit::1, handshake_bit::1, _reserved::3, size::3,
           values_bin::binary>>
       ) do
-    values = for <<value::signed-integer-size(size)-unit(8) <- values_bin>>, do: value
+    values = for <<value::signed-integer-size(^size)-unit(8) <- values_bin>>, do: value
 
     {:ok,
      [

--- a/lib/grizzly/zwave/commands/configuration_properties_report.ex
+++ b/lib/grizzly/zwave/commands/configuration_properties_report.ex
@@ -198,11 +198,11 @@ defmodule Grizzly.ZWave.Commands.ConfigurationPropertiesReport do
   defp value_spec(size, format, value_bin) do
     case format do
       :signed_integer ->
-        <<value::signed-size(size)-unit(8)>> = value_bin
+        <<value::signed-size(^size)-unit(8)>> = value_bin
         value
 
       _other ->
-        <<value::integer-size(size)-unit(8)>> = value_bin
+        <<value::integer-size(^size)-unit(8)>> = value_bin
         value
     end
   end

--- a/lib/grizzly/zwave/commands/configuration_set.ex
+++ b/lib/grizzly/zwave/commands/configuration_set.ex
@@ -60,7 +60,7 @@ defmodule Grizzly.ZWave.Commands.ConfigurationSet do
   end
 
   def decode_params(_spec, <<param_number, _::5, size::3, value::binary>>) do
-    <<value_int::signed-integer-size(size)-unit(8)>> = value
+    <<value_int::signed-integer-size(^size)-unit(8)>> = value
     {:ok, [param_number: param_number, value: value_int, size: size]}
   end
 

--- a/lib/grizzly/zwave/commands/meter_report.ex
+++ b/lib/grizzly/zwave/commands/meter_report.ex
@@ -166,10 +166,10 @@ defmodule Grizzly.ZWave.Commands.MeterReport do
       {0, <<scale2::8>>} ->
         {:ok, {:unknown, scale2}}
 
-      {_, <<previous_value::size(size)-unit(8)>>} ->
+      {_, <<previous_value::size(^size)-unit(8)>>} ->
         {:ok, {Encoding.decode_zwave_float(previous_value, precision), 0}}
 
-      {_, <<previous_value::size(size)-unit(8), scale2::8>>} ->
+      {_, <<previous_value::size(^size)-unit(8), scale2::8>>} ->
         {:ok, {Encoding.decode_zwave_float(previous_value, precision), scale2}}
 
       _ ->

--- a/lib/grizzly/zwave/commands/window_covering_set.ex
+++ b/lib/grizzly/zwave/commands/window_covering_set.ex
@@ -31,7 +31,7 @@ defmodule Grizzly.ZWave.Commands.WindowCoveringSet do
   @impl Grizzly.ZWave.Command
   def decode_params(_spec, <<0x00::4, parameters_count::4, rest::binary>>) do
     parameters_size = parameters_count * 2
-    <<parameters_binary::binary-size(parameters_size), duration>> = rest
+    <<parameters_binary::binary-size(^parameters_size), duration>> = rest
 
     try do
       parameters = parameters_from_binary(parameters_binary)

--- a/lib/grizzly/zwave/commands/zip_packet.ex
+++ b/lib/grizzly/zwave/commands/zip_packet.ex
@@ -251,7 +251,7 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket do
       # Subtract one because the field includes itself thus leading to
       # pulling out the command class byte along with the header extension
       header_extension_length = header_extension_length - 1
-      <<_, extensions_bin::binary-size(header_extension_length), _command::binary>> = packet_body
+      <<_, extensions_bin::binary-size(^header_extension_length), _command::binary>> = packet_body
 
       HeaderExtensions.from_binary(extensions_bin)
     else
@@ -265,7 +265,7 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket do
     # Subtract one because the field includes itself thus leading to
     # pulling out the command class byte along with the header extension
     header_extension_length = header_extension_length - 1
-    <<_extensions::binary-size(header_extension_length), command_binary::binary>> = rest
+    <<_extensions::binary-size(^header_extension_length), command_binary::binary>> = rest
 
     if command_binary == "" do
       {:ok, nil}

--- a/lib/grizzly/zwave/commands/zip_packet/header_extensions.ex
+++ b/lib/grizzly/zwave/commands/zip_packet/header_extensions.ex
@@ -64,7 +64,7 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions do
     do: {[:installation_and_maintenance_get | extensions], rest}
 
   defp parse_extension(<<0x03, length, rest::binary>> = report, extensions) do
-    <<_::binary-size(length), rest::binary>> = rest
+    <<_::binary-size(^length), rest::binary>> = rest
 
     {[
        {:installation_and_maintenance_report,

--- a/lib/grizzly/zwave/commands/zip_packet/header_extensions/installation_and_maintenance_report.ex
+++ b/lib/grizzly/zwave/commands/zip_packet/header_extensions/installation_and_maintenance_report.ex
@@ -6,7 +6,7 @@ defmodule Grizzly.ZWave.Commands.ZIPPacket.HeaderExtensions.InstallationAndMaint
   alias Grizzly.ZWave.Encoding
 
   def from_binary(<<0x03, length, rest::binary>>) do
-    <<imes_bin::binary-size(length), _rest::binary>> = rest
+    <<imes_bin::binary-size(^length), _rest::binary>> = rest
 
     imes_bin
     |> Encoding.reduce_binary(&ime_from_binary/2)

--- a/lib/grizzly/zwave/encoding.ex
+++ b/lib/grizzly/zwave/encoding.ex
@@ -518,7 +518,7 @@ defmodule Grizzly.ZWave.Encoding do
     # bit.
     bits = ceil(:math.log2(abs(int_value))) + 1
 
-    <<msb::1, _rest::size(bits - 1)>> = <<int_value::signed-size(bits)>>
+    <<msb::1, _rest::size(^bits - 1)>> = <<int_value::signed-size(bits)>>
 
     if msb == 1 && int_value > 0 do
       bits + 1

--- a/lib/grizzly/zwave/node_id.ex
+++ b/lib/grizzly/zwave/node_id.ex
@@ -122,7 +122,7 @@ defmodule Grizzly.ZWave.NodeId do
         do_parse(node_id_bin)
 
       del_size ->
-        <<node_id_8, _delimiter::size(del_size)-unit(8), node_id_16::binary>> = node_id_bin
+        <<node_id_8, _delimiter::size(^del_size)-unit(8), node_id_16::binary>> = node_id_bin
         do_parse(<<node_id_8, node_id_16::binary>>)
     end
   end

--- a/lib/grizzly/zwave/param_spec.ex
+++ b/lib/grizzly/zwave/param_spec.ex
@@ -148,7 +148,7 @@ defmodule Grizzly.ZWave.ParamSpec do
   def take_bits(%__MODULE__{type: type, size: size}, bitstring, _other_params)
       when type in [:binary, :dsk] and is_integer(size) and rem(size, 8) == 0 and
              bit_size(bitstring) >= size do
-    <<value::bitstring-size(size), rest::bitstring>> = bitstring
+    <<value::bitstring-size(^size), rest::bitstring>> = bitstring
     {:ok, {size, value, rest}}
   end
 
@@ -187,7 +187,7 @@ defmodule Grizzly.ZWave.ParamSpec do
 
   def take_bits(%__MODULE__{size: size}, bitstring, _other_params)
       when is_integer(size) and bit_size(bitstring) >= size do
-    <<value::bitstring-size(size), rest::bitstring>> = bitstring
+    <<value::bitstring-size(^size), rest::bitstring>> = bitstring
     {:ok, {size, value, rest}}
   end
 
@@ -235,7 +235,7 @@ defmodule Grizzly.ZWave.ParamSpec do
     # Only truncate to size if the size is less than 8 bytes. Multi-byte bitmasks
     # are always byte-aligned.
     if size < 8 do
-      <<_truncated::size(8 - size), right_sized_bitmask::bitstring-size(size)>> = full_bitmask
+      <<_truncated::size(8 - ^size), right_sized_bitmask::bitstring-size(^size)>> = full_bitmask
       right_sized_bitmask
     else
       full_bitmask
@@ -499,7 +499,7 @@ defmodule Grizzly.ZWave.ParamSpec do
   def decode_value(%__MODULE__{type: :binary, size: size} = param_spec, binary, _other_params)
       when is_integer(size) do
     case binary do
-      <<v::bitstring-size(size)>> ->
+      <<v::bitstring-size(^size)>> ->
         {:ok, v}
 
       _ ->

--- a/test/support/dtls.ex
+++ b/test/support/dtls.ex
@@ -8,8 +8,6 @@ defmodule GrizzlyTest.Transport.DTLS do
   alias Grizzly.Transport
   alias Grizzly.Transports.DTLS
 
-  require Logger
-
   @handshake_timeout Application.compile_env(:grizzly, :dtls_handshake_timeout, 10_000)
 
   @impl Grizzly.Transport


### PR DESCRIPTION
None of these were resulting in crash though since non pinned val inside `::size/1` bin pattern match still works, plus removed unused `require Logger` statements that surfaced with Elixir 1.20, here's a brief summary, this [was found on](https://github.com/smartrent/grizzly/actions/runs/30860737805/job/91841928925):



```
    warning: unused require Logger
    │
 11 │   require Logger
    │   ~
    │
    └─ lib/grizzly/requests/handlers/wait_report.ex:11:3

  ...

     warning: the variable "header_extension_length" is accessed inside size(...) of a bitstring but it was defined outside of the match. You must precede it with the pin operator
     │
 268 │     <<_extensions::binary-size(header_extension_length), command_binary::binary>> = rest
     │                                ~
     │
     └─ lib/grizzly/zwave/commands/zip_packet.ex:268:32: Grizzly.ZWave.Commands.ZIPPacket.parse_command/2
```

There are other type of warnings caught by the type checker will send in another PR though